### PR TITLE
Add ColorAuthority for format-specific CMS precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## 0.2.5
+
+### zenpixels — additions
+
+- **`ColorAuthority`** enum (`Icc` | `Cicp`) — declares which color metadata
+  field the CMS should trust for building transforms. Set by the codec during
+  decode based on the format's specification (e.g., AVIF: ICC wins when present;
+  PNG 3rd Ed: cICP wins when present; JPEG/WebP/TIFF: ICC only). Default is
+  `Icc`. Both `icc` and `cicp` fields remain populated regardless of authority
+  for metadata roundtripping during cross-format transcode. Re-exported at
+  crate root.
+- **`color_authority` field** on `ColorContext` and `ColorOrigin`. Constructors
+  set it automatically: `from_icc()` → `Icc`, `from_cicp()` → `Cicp`,
+  `from_icc_and_cicp()` → `Cicp`. Override with `with_color_authority()`.
+
+### zenpixels — behavior change
+
+- **`ColorContext::as_profile_source()`** now respects `color_authority` instead
+  of hardcoding CICP preference. When authority is `Icc`, returns the ICC
+  profile; when `Cicp`, returns CICP. Falls back to the other field when the
+  authoritative one is absent. Previously always returned CICP when present,
+  which was wrong for AVIF (where ICC takes precedence per MIAF spec).
+
+### zenpixels-convert — additions
+
+- **`ColorManagement::build_transform_from_cicp()`** — builds a CMS transform
+  directly from CICP codes, avoiding the ICC serialize→deserialize round-trip.
+  `MoxCms` implementation uses `ColorProfile::new_from_cicp()`. Shared
+  transform-building logic extracted to `build_transform_inner()`.
+- **`ConvertError::HdrTransferRequiresToneMapping`** — returned by
+  `finalize_for_output()` when a PQ/HLG source targets an SDR output. Prevents
+  silent highlight clipping. Callers must tone map first (e.g., via
+  `ultrahdr_core::color::tonemap::tonemap_image_to_srgb8()`), then retry with
+  SDR metadata.
+
+### zenpixels-convert — behavior change
+
+- **`finalize_for_output()` respects `ColorAuthority`** on the `ColorOrigin`.
+  When authority is `Icc`, builds the CMS source from ICC bytes. When `Cicp`,
+  uses `build_transform_from_cicp()`. Falls back to the non-authoritative field
+  when the authoritative one is missing (handles codec bugs gracefully).
+- **`SameAsOrigin` no longer invokes the CMS.** It means "keep the color space"
+  — only pixel format changes (depth, layout) are applied via `RowConverter`.
+  Previously it wastefully built a same-profile-to-same-profile CMS transform.
+- **PQ/HLG → SDR is now rejected.** `finalize_for_output()` returns
+  `HdrTransferRequiresToneMapping` instead of silently clipping. HDR → HDR
+  (SameAsOrigin, Named PQ/HLG) is allowed.
+
 ## 0.2.3
 
 ### zenpixels-convert — additions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,20 +826,7 @@ dependencies = [
 
 [[package]]
 name = "zenpixels"
-version = "0.2.3"
-dependencies = [
- "bytemuck",
- "imgref",
- "rgb",
- "serde",
- "whereat",
-]
-
-[[package]]
-name = "zenpixels"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94439a80006e7c0667781a60ebb73145db6e6792e546f187933bcc472b36dece"
+version = "0.2.5"
 dependencies = [
  "bytemuck",
  "imgref",
@@ -850,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "zenpixels-convert"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "archmage",
  "bytemuck",
@@ -862,7 +849,7 @@ dependencies = [
  "rgb",
  "whereat",
  "zenbench",
- "zenpixels 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenpixels",
  "zenpixels-convert",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 members = ["zenpixels", "zenpixels-convert"]
 resolver = "2"
 
+[workspace.dependencies]
+zenpixels = { path = "zenpixels", version = "0.2.5", default-features = false }
+
 [workspace.package]
 version = "0.2.2"
 edition = "2024"

--- a/zenpixels-convert/Cargo.toml
+++ b/zenpixels-convert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zenpixels-convert"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 rust-version = "1.89"
 license.workspace = true
@@ -35,7 +35,7 @@ cms-moxcms = ["std", "dep:moxcms"]
 serde = ["zenpixels/serde"]
 
 [dependencies]
-zenpixels = { path = "../zenpixels", version = "0.2.3", default-features = false }
+zenpixels = { workspace = true, default-features = false }
 linear-srgb = { version = "0.6.7", default-features = false, features = ["transfer"] }
 bytemuck = { version = "1.21", default-features = false, features = ["extern_crate_alloc", "derive"] }
 rgb = { version = "0.8", default-features = false, features = ["bytemuck"], optional = true }
@@ -45,8 +45,8 @@ whereat = { version = "0.1.5", default-features = false }
 moxcms = { version = "0.8.1", optional = true, features = ["options"] }
 
 [dev-dependencies]
-zenpixels = { path = "../zenpixels", version = "0.2.3", features = ["planar", "imgref"] }
-zenpixels-convert = { path = "", features = ["pipeline", "imgref", "cms-moxcms"] , version = "0.2.4" }
+zenpixels = { workspace = true, features = ["planar", "imgref"] }
+zenpixels-convert = { path = "", features = ["pipeline", "imgref", "cms-moxcms"] , version = "0.2.5" }
 zenbench = { version = "0.1.2"}
 half = "2"
 palette = "0.7"

--- a/zenpixels-convert/TONEMAP_EXAMPLE_DESIGN.md
+++ b/zenpixels-convert/TONEMAP_EXAMPLE_DESIGN.md
@@ -1,0 +1,212 @@
+# Tone Mapping Example Design
+
+How to handle `HdrRequiresToneMapping` by converting any HDR content to sRGB
+using `ultrahdr-core`'s tone mapping before `finalize_for_output()`.
+
+## The problem
+
+`finalize_for_output()` rejects HDR (PQ/HLG) sources targeting SDR outputs:
+
+```rust
+let result = finalize_for_output(&buffer, &origin, OutputProfile::Icc(srgb), Rgb8, &cms);
+// → Err(HdrRequiresToneMapping)
+```
+
+The caller must tone map first, then retry with SDR metadata.
+
+## ultrahdr-core API surface
+
+### One-shot (simplest)
+
+```rust
+// Takes RawImage, returns RGBA8 sRGB bytes
+ultrahdr_core::color::tonemap::tonemap_image_to_srgb8(
+    img: &RawImage,
+    target_gamut: ColorGamut,  // ColorGamut::Bt709 for sRGB
+) -> Result<Vec<u8>>
+```
+
+Handles PQ, HLG, sRGB, and linear transfers. Does gamut conversion + tone curve + sRGB OETF + quantize in one pass. Output is always RGBA8 sRGB.
+
+Pixel format support: `Rgba8`, `Rgb8`, `Rgba32F`, `Rgba1010102`, `P010`.
+
+### Per-pixel (for custom pipelines)
+
+```rust
+// PQ linear RGB → SDR linear RGB (BT.709 gamut, 0-1 range)
+tonemap_pq_to_sdr(pq_rgb: [f32; 3], config: &ToneMapConfig) -> [f32; 3]
+
+// HLG linear RGB → SDR linear RGB
+tonemap_hlg_to_sdr(hlg_rgb: [f32; 3], config: &ToneMapConfig) -> [f32; 3]
+```
+
+### Streaming (for zenpipe integration)
+
+```rust
+StreamingTonemapper::new(width, height, config) -> Result<Self>
+  .push_rows(data: &[f32], stride, num_rows) -> Result<Vec<TonemapOutput>>
+  .finish() -> Result<Vec<TonemapOutput>>
+```
+
+`TonemapOutput` contains linear f32 rows. Caller applies sRGB OETF via
+`StreamingTonemapper::linear_to_srgb8_rgba()` or `linear_to_srgb8_rgb()`.
+
+### BT.2408 (broadcast standard)
+
+```rust
+Bt2408Tonemapper::new(content_max_nits: f32, display_max_nits: f32) -> Self
+  .tonemap_rgb(rgb: [f32; 3]) -> [f32; 3]
+  .tonemap_luminance(nits: f32) -> f32
+```
+
+Uses ITU-R BT.2408 reference EETF. Takes scene-linear nits, outputs display-linear nits.
+
+## Bridge: PixelBuffer ↔ RawImage
+
+The key challenge. `PixelBuffer` uses `PixelDescriptor` (format + transfer + primaries).
+`RawImage` uses `PixelFormat` + `ColorGamut` + `ColorTransfer` enums.
+
+### Cicp → ultrahdr-core mapping
+
+```rust
+fn cicp_to_gamut(cicp: &Cicp) -> Option<ColorGamut> {
+    match cicp.color_primaries {
+        1  => Some(ColorGamut::Bt709),
+        9  => Some(ColorGamut::Bt2100),
+        12 => Some(ColorGamut::P3),
+        _  => None,
+    }
+}
+
+fn cicp_to_transfer(cicp: &Cicp) -> Option<ColorTransfer> {
+    match cicp.transfer_characteristics {
+        1 | 6 | 13 => Some(ColorTransfer::Srgb),
+        8          => Some(ColorTransfer::Linear),
+        16         => Some(ColorTransfer::Pq),
+        18         => Some(ColorTransfer::Hlg),
+        _          => None,
+    }
+}
+```
+
+### PixelBuffer → RawImage
+
+```rust
+fn pixel_buffer_to_raw_image(
+    buffer: &PixelBuffer,
+    cicp: &Cicp,
+) -> Result<RawImage, &'static str> {
+    let format = match buffer.descriptor().format {
+        PixelFormat::Rgba8  => ultrahdr_core::PixelFormat::Rgba8,
+        PixelFormat::Rgb8   => ultrahdr_core::PixelFormat::Rgb8,
+        PixelFormat::RgbaF32 => ultrahdr_core::PixelFormat::Rgba32F,
+        _ => return Err("unsupported pixel format for tone mapping"),
+    };
+    let gamut = cicp_to_gamut(cicp).ok_or("unsupported gamut")?;
+    let transfer = cicp_to_transfer(cicp).ok_or("unsupported transfer")?;
+
+    let slice = buffer.as_slice();
+    let data = slice.contiguous_bytes().into_owned();
+    let stride = buffer.width() * buffer.descriptor().bytes_per_pixel() as u32;
+
+    RawImage::from_data(buffer.width(), buffer.height(), format, data)
+        .map(|mut img| { img.gamut = gamut; img.transfer = transfer; img.stride = stride; img })
+        .map_err(|_| "invalid image dimensions")
+}
+```
+
+### SDR output → PixelBuffer + ColorOrigin
+
+After `tonemap_image_to_srgb8()`, the output is RGBA8 sRGB:
+
+```rust
+let sdr_bytes = tonemap_image_to_srgb8(&raw_image, ColorGamut::Bt709)?;
+let sdr_buffer = PixelBuffer::from_vec(
+    sdr_bytes, width, height, PixelDescriptor::RGBA8_SRGB,
+)?;
+let sdr_origin = ColorOrigin::from_cicp(Cicp::SRGB);
+```
+
+## Complete workflow
+
+```rust
+fn convert_any_to_srgb(
+    buffer: &PixelBuffer,
+    origin: &ColorOrigin,
+    cms: &impl ColorManagement,
+) -> Result<EncodeReady, ConvertError> {
+    // Try direct conversion first
+    match finalize_for_output(buffer, origin, OutputProfile::Named(Cicp::SRGB), Rgb8, cms) {
+        Ok(ready) => return Ok(ready),
+        Err(e) if *e.error() == ConvertError::HdrRequiresToneMapping => {
+            // Fall through to tone mapping
+        }
+        Err(e) => return Err(e),
+    }
+
+    // HDR path: tone map first
+    let cicp = origin.cicp.ok_or(ConvertError::CmsError("HDR without CICP".into()))?;
+    let raw = pixel_buffer_to_raw_image(buffer, &cicp)?;
+    let sdr_bytes = tonemap_image_to_srgb8(&raw, ColorGamut::Bt709)?;
+    let sdr_buffer = PixelBuffer::from_vec(
+        sdr_bytes, buffer.width(), buffer.height(), PixelDescriptor::RGBA8_SRGB,
+    )?;
+    let sdr_origin = ColorOrigin::from_cicp(Cicp::SRGB);
+
+    // Now it's SDR → finalize succeeds
+    finalize_for_output(&sdr_buffer, &sdr_origin, OutputProfile::Named(Cicp::SRGB), Rgb8, cms)
+}
+```
+
+## Test plan
+
+### Integration test: `tests/tonemap_integration.rs`
+
+Feature-gated behind `tonemap` (pulls `ultrahdr-core` with `transfer` feature).
+
+| # | Test | Input | Expected |
+|---|------|-------|----------|
+| 1 | `pq_bt2020_to_srgb8` | Synthetic PQ RGBA32F gradient | sRGB RGBA8, values in 0-255, not clipped to 0/255 |
+| 2 | `hlg_bt2020_to_srgb8` | Synthetic HLG RGBA32F | sRGB RGBA8, midtones preserved |
+| 3 | `pq_p3_to_srgb8` | PQ Display P3 | sRGB RGBA8, gamut mapped |
+| 4 | `sdr_passthrough` | sRGB RGBA8 | Unchanged (no tone mapping) |
+| 5 | `convert_any_pq` | PQ RGBA32F | `convert_any_to_srgb` succeeds |
+| 6 | `convert_any_sdr` | sRGB RGB8 | `convert_any_to_srgb` succeeds (direct path) |
+| 7 | `convert_any_p3_sdr` | Display P3 sRGB-TRC RGB8 | CMS path (gamut only, no tone map) |
+| 8 | `streaming_pq_tonemap` | PQ f32 rows | StreamingTonemapper produces valid sRGB8 |
+
+### Synthetic test data
+
+No real HDR images needed. Generate gradient ramps:
+
+```rust
+fn pq_gradient(width: u32, height: u32) -> Vec<f32> {
+    // Linear-light values 0..10000 nits, encoded as PQ
+    // PQ OETF: signal = ((c1 + c2 * Y^m1) / (1 + c3 * Y^m1))^m2
+    // where Y = nits / 10000
+}
+```
+
+Values should span 0-1000 nits (typical HDR content) so tone mapping
+produces visible midtone detail (not just clipped white).
+
+## Where this lives
+
+- Bridge functions (`cicp_to_gamut`, `pixel_buffer_to_raw_image`): `zenpixels-convert/src/hdr.rs` (already exists, has `HdrMetadata`)
+- `convert_any_to_srgb` helper: `zenpixels-convert/src/output.rs` or a new `src/tonemap.rs`
+- Tests: `zenpixels-convert/tests/tonemap_integration.rs`
+- Feature: `tonemap` = `["dep:ultrahdr-core", "ultrahdr-core/transfer"]`
+
+## Dependency
+
+```toml
+[dependencies]
+ultrahdr-core = { version = "0.4.1", optional = true, default-features = false, features = ["transfer"] }
+
+[features]
+tonemap = ["dep:ultrahdr-core"]
+```
+
+The `transfer` feature on ultrahdr-core enables the tone mapping and streaming
+tonemap modules (`color::tonemap`, `color::streaming_tonemap`). Without it,
+only gain map math and metadata are available.

--- a/zenpixels-convert/src/cms.rs
+++ b/zenpixels-convert/src/cms.rs
@@ -304,6 +304,27 @@ pub trait ColorManagement {
         self.build_transform(src_icc, dst_icc)
     }
 
+    /// Build a format-aware row-level transform from CICP codes to an ICC profile.
+    ///
+    /// Like [`build_transform_for_format`](Self::build_transform_for_format),
+    /// but the source profile is constructed from CICP code points instead of
+    /// parsed from ICC bytes. Avoids the ICC serialize→deserialize round-trip
+    /// when [`ColorAuthority::Cicp`](crate::ColorAuthority) indicates that CICP
+    /// is the authoritative color description.
+    ///
+    /// The default implementation synthesizes an ICC profile from the CICP codes
+    /// and delegates to [`build_transform_for_format`](Self::build_transform_for_format).
+    /// Backends that can construct source profiles directly from CICP (e.g.,
+    /// `ColorProfile::new_from_cicp()` in moxcms) should override this for
+    /// better performance.
+    fn build_transform_from_cicp(
+        &self,
+        src_cicp: crate::Cicp,
+        dst_icc: &[u8],
+        src_format: PixelFormat,
+        dst_format: PixelFormat,
+    ) -> Result<Box<dyn RowTransform>, Self::Error>;
+
     /// Identify whether an ICC profile matches a known CICP combination.
     ///
     /// Two-tier matching:

--- a/zenpixels-convert/src/cms_moxcms.rs
+++ b/zenpixels-convert/src/cms_moxcms.rs
@@ -213,6 +213,50 @@ impl RowTransform for MoxRowTransform {
 // ColorManagement implementation
 // ---------------------------------------------------------------------------
 
+/// Build a [`RowTransform`] from two already-parsed [`ColorProfile`]s.
+///
+/// Shared implementation for both ICC-to-ICC and CICP-to-ICC paths.
+/// Always uses `PreferIcc` / `RelativeColorimetric` — CICP-in-ICC tags
+/// are never trusted for TRC (see moxcms issue #154).
+fn build_transform_inner(
+    src_profile: &ColorProfile,
+    dst_profile: &ColorProfile,
+    src_format: PixelFormat,
+    dst_format: PixelFormat,
+) -> Result<Box<dyn RowTransform>, MoxCmsError> {
+    let src_layout = pixel_format_to_layout(src_format).unwrap_or(Layout::Rgb);
+    let dst_layout = pixel_format_to_layout(dst_format).unwrap_or(Layout::Rgb);
+    let opts = transform_opts(ColorPriority::PreferIcc, RenderingIntent::default());
+
+    let depth = src_format.channel_type();
+
+    let inner = match depth {
+        ChannelType::U8 => {
+            let xform = src_profile
+                .create_transform_8bit(src_layout, dst_profile, dst_layout, opts)
+                .map_err(|e| MoxCmsError(format!("failed to create u8 transform: {e}")))?;
+            MoxTransformInner::U8(xform)
+        }
+        ChannelType::U16 => {
+            let xform = src_profile
+                .create_transform_16bit(src_layout, dst_profile, dst_layout, opts)
+                .map_err(|e| MoxCmsError(format!("failed to create u16 transform: {e}")))?;
+            MoxTransformInner::U16(xform)
+        }
+        // F16 and F32 both use the f32 transform path (F16 data must be
+        // converted to f32 before CMS — IEEE 754 half-floats are not
+        // integer-encoded u16 values).
+        ChannelType::F16 | ChannelType::F32 | _ => {
+            let xform = src_profile
+                .create_transform_f32(src_layout, dst_profile, dst_layout, opts)
+                .map_err(|e| MoxCmsError(format!("failed to create f32 transform: {e}")))?;
+            MoxTransformInner::F32(xform)
+        }
+    };
+
+    Ok(Box::new(MoxRowTransform { inner }))
+}
+
 impl ColorManagement for MoxCms {
     type Error = MoxCmsError;
 
@@ -221,7 +265,6 @@ impl ColorManagement for MoxCms {
         src_icc: &[u8],
         dst_icc: &[u8],
     ) -> Result<Box<dyn RowTransform>, Self::Error> {
-        // Default: u8 RGB, which covers the common JPEG/PNG/WebP case.
         self.build_transform_for_format(src_icc, dst_icc, PixelFormat::Rgb8, PixelFormat::Rgb8)
     }
 
@@ -237,42 +280,31 @@ impl ColorManagement for MoxCms {
         let dst_profile = ColorProfile::new_from_slice(dst_icc)
             .map_err(|e| MoxCmsError(format!("failed to parse destination ICC profile: {e}")))?;
 
-        let src_layout = pixel_format_to_layout(src_format).unwrap_or(Layout::Rgb);
-        let dst_layout = pixel_format_to_layout(dst_format).unwrap_or(Layout::Rgb);
-        // CICP transfer is for applications, not CMMs (ICC Votable Proposal).
-        // Matches the v2 path fix — see moxcms issue #154.
-        let opts = transform_opts(ColorPriority::PreferIcc, RenderingIntent::default());
+        build_transform_inner(&src_profile, &dst_profile, src_format, dst_format)
+    }
 
-        // Pick the narrower of the two channel types to avoid unnecessary
-        // precision loss, but always use the source depth when both differ
-        // (the CMS handles the depth conversion internally).
-        let depth = src_format.channel_type();
+    fn build_transform_from_cicp(
+        &self,
+        src_cicp: Cicp,
+        dst_icc: &[u8],
+        src_format: PixelFormat,
+        dst_format: PixelFormat,
+    ) -> Result<Box<dyn RowTransform>, Self::Error> {
+        let src_profile = ColorProfile::new_from_cicp(moxcms::CicpProfile {
+            color_primaries: moxcms::CicpColorPrimaries::try_from(src_cicp.color_primaries)
+                .unwrap_or(moxcms::CicpColorPrimaries::Bt709),
+            transfer_characteristics: moxcms::TransferCharacteristics::try_from(
+                src_cicp.transfer_characteristics,
+            )
+            .unwrap_or(moxcms::TransferCharacteristics::Srgb),
+            matrix_coefficients: moxcms::MatrixCoefficients::try_from(src_cicp.matrix_coefficients)
+                .unwrap_or(moxcms::MatrixCoefficients::Identity),
+            full_range: src_cicp.full_range,
+        });
+        let dst_profile = ColorProfile::new_from_slice(dst_icc)
+            .map_err(|e| MoxCmsError(format!("failed to parse destination ICC profile: {e}")))?;
 
-        let inner = match depth {
-            ChannelType::U8 => {
-                let xform = src_profile
-                    .create_transform_8bit(src_layout, &dst_profile, dst_layout, opts)
-                    .map_err(|e| MoxCmsError(format!("failed to create u8 transform: {e}")))?;
-                MoxTransformInner::U8(xform)
-            }
-            ChannelType::U16 => {
-                let xform = src_profile
-                    .create_transform_16bit(src_layout, &dst_profile, dst_layout, opts)
-                    .map_err(|e| MoxCmsError(format!("failed to create u16 transform: {e}")))?;
-                MoxTransformInner::U16(xform)
-            }
-            // F16 and F32 both use the f32 transform path (F16 data must be
-            // converted to f32 before CMS — IEEE 754 half-floats are not
-            // integer-encoded u16 values).
-            ChannelType::F16 | ChannelType::F32 | _ => {
-                let xform = src_profile
-                    .create_transform_f32(src_layout, &dst_profile, dst_layout, opts)
-                    .map_err(|e| MoxCmsError(format!("failed to create f32 transform: {e}")))?;
-                MoxTransformInner::F32(xform)
-            }
-        };
-
-        Ok(Box::new(MoxRowTransform { inner }))
+        build_transform_inner(&src_profile, &dst_profile, src_format, dst_format)
     }
 
     fn identify_profile(&self, icc: &[u8]) -> Option<Cicp> {

--- a/zenpixels-convert/src/error.rs
+++ b/zenpixels-convert/src/error.rs
@@ -36,6 +36,11 @@ pub enum ConvertError {
     AllocationFailed,
     /// CMS transform could not be built (invalid ICC profile, unsupported color space, etc.).
     CmsError(alloc::string::String),
+    /// HDR source requires tone mapping before conversion to an SDR target.
+    ///
+    /// A colorimetric CMS transform from PQ/HLG to an SDR profile will clip
+    /// highlights. Tone map the pixels first, then retry with SDR metadata.
+    HdrTransferRequiresToneMapping,
 }
 
 impl fmt::Display for ConvertError {
@@ -78,6 +83,10 @@ impl fmt::Display for ConvertError {
             }
             Self::AllocationFailed => write!(f, "buffer allocation failed"),
             Self::CmsError(msg) => write!(f, "CMS transform failed: {msg}"),
+            Self::HdrTransferRequiresToneMapping => write!(
+                f,
+                "HDR source (PQ/HLG) requires tone mapping before conversion to SDR target"
+            ),
         }
     }
 }

--- a/zenpixels-convert/src/output.rs
+++ b/zenpixels-convert/src/output.rs
@@ -86,8 +86,8 @@ use crate::cms::ColorManagement;
 use crate::error::ConvertError;
 use crate::hdr::HdrMetadata;
 use crate::{
-    Cicp, ColorOrigin, ColorPrimaries, PixelBuffer, PixelDescriptor, PixelFormat, PixelSlice,
-    TransferFunction,
+    Cicp, ColorAuthority, ColorOrigin, ColorPrimaries, PixelBuffer, PixelDescriptor, PixelFormat,
+    PixelSlice, TransferFunction,
 };
 use whereat::{At, ResultAtExt};
 
@@ -183,6 +183,11 @@ pub fn finalize_for_output<C: ColorManagement>(
     let source_desc = buffer.descriptor();
     let target_desc = pixel_format.descriptor();
 
+    // Reject HDR→SDR without tone mapping.
+    if origin_has_hdr_transfer(origin) && !target_has_hdr_transfer(&target) {
+        return Err(whereat::at!(ConvertError::HdrTransferRequiresToneMapping));
+    }
+
     // Determine output metadata based on target profile.
     let (metadata, needs_cms_transform) = match &target {
         OutputProfile::SameAsOrigin => {
@@ -191,8 +196,9 @@ pub fn finalize_for_output<C: ColorManagement>(
                 cicp: origin.cicp,
                 hdr: None,
             };
-            // If origin has ICC, we may need a CMS transform.
-            (metadata, origin.icc.is_some())
+            // SameAsOrigin = keep the source color space. No CMS conversion.
+            // Pixel format changes (depth, layout) are handled by RowConverter.
+            (metadata, false)
         }
         OutputProfile::Named(cicp) => {
             let metadata = OutputMetadata {
@@ -212,15 +218,11 @@ pub fn finalize_for_output<C: ColorManagement>(
         }
     };
 
-    // If source has an ICC profile and we need CMS, use it.
+    // Apply CMS transform if needed, respecting color_authority.
     if needs_cms_transform
-        && let Some(src_icc) = buffer.color_context().and_then(|c| c.icc.as_ref())
-        && let Some(dst_icc) = &metadata.icc
+        && let Some(transform) =
+            build_cms_transform(origin, &metadata, &source_desc, pixel_format, cms)?
     {
-        let transform = cms
-            .build_transform_for_format(src_icc, dst_icc, source_desc.format, pixel_format)
-            .map_err(|e| whereat::at!(ConvertError::CmsError(alloc::format!("{e:?}"))))?;
-
         let src_slice = buffer.as_slice();
         let mut out = PixelBuffer::try_new(buffer.width(), buffer.height(), target_desc)
             .map_err(|_| whereat::at!(ConvertError::AllocationFailed))?;
@@ -283,6 +285,81 @@ pub fn finalize_for_output<C: ColorManagement>(
         pixels: out,
         metadata,
     })
+}
+
+/// Build a CMS transform from the origin's authoritative color metadata.
+///
+/// Respects [`ColorAuthority`]: when `Icc`, builds from ICC bytes; when `Cicp`,
+/// builds from CICP codes via [`build_transform_from_cicp`](ColorManagement::build_transform_from_cicp).
+///
+/// Falls back to the non-authoritative field when the authoritative one is
+/// missing (e.g., `Icc` authority but no ICC → tries CICP). This handles
+/// codec bugs (wrong authority) and incomplete metadata gracefully.
+///
+/// Returns `Ok(None)` when no source profile can be determined.
+fn build_cms_transform<C: ColorManagement>(
+    origin: &ColorOrigin,
+    metadata: &OutputMetadata,
+    source_desc: &PixelDescriptor,
+    dst_format: PixelFormat,
+    cms: &C,
+) -> Result<Option<alloc::boxed::Box<dyn crate::cms::RowTransform>>, At<ConvertError>> {
+    let src_format = source_desc.format;
+    let Some(ref dst_icc) = metadata.icc else {
+        return Ok(None);
+    };
+
+    // Try the authoritative source first, then fall back to the other field.
+    match origin.color_authority {
+        ColorAuthority::Icc => {
+            if let Some(ref src_icc) = origin.icc {
+                let transform = cms
+                    .build_transform_for_format(src_icc, dst_icc, src_format, dst_format)
+                    .map_err(|e| whereat::at!(ConvertError::CmsError(alloc::format!("{e:?}"))))?;
+                return Ok(Some(transform));
+            }
+            // Fallback: ICC authority but no ICC — try CICP if available.
+            if let Some(cicp) = origin.cicp {
+                let transform = cms
+                    .build_transform_from_cicp(cicp, dst_icc, src_format, dst_format)
+                    .map_err(|e| whereat::at!(ConvertError::CmsError(alloc::format!("{e:?}"))))?;
+                return Ok(Some(transform));
+            }
+            Ok(None)
+        }
+        ColorAuthority::Cicp => {
+            if let Some(cicp) = origin.cicp {
+                let transform = cms
+                    .build_transform_from_cicp(cicp, dst_icc, src_format, dst_format)
+                    .map_err(|e| whereat::at!(ConvertError::CmsError(alloc::format!("{e:?}"))))?;
+                return Ok(Some(transform));
+            }
+            // Fallback: CICP authority but no CICP — try ICC if available.
+            if let Some(ref src_icc) = origin.icc {
+                let transform = cms
+                    .build_transform_for_format(src_icc, dst_icc, src_format, dst_format)
+                    .map_err(|e| whereat::at!(ConvertError::CmsError(alloc::format!("{e:?}"))))?;
+                return Ok(Some(transform));
+            }
+            Ok(None)
+        }
+    }
+}
+
+/// Check if the origin describes HDR content (PQ or HLG transfer).
+fn origin_has_hdr_transfer(origin: &ColorOrigin) -> bool {
+    origin
+        .cicp
+        .is_some_and(|c| matches!(c.transfer_characteristics, 16 | 18))
+}
+
+/// Check if the output target is HDR-capable (PQ or HLG).
+fn target_has_hdr_transfer(target: &OutputProfile) -> bool {
+    match target {
+        OutputProfile::SameAsOrigin => true, // same as source — if source is HDR, output is too
+        OutputProfile::Named(cicp) => matches!(cicp.transfer_characteristics, 16 | 18),
+        OutputProfile::Icc(_) => false, // can't determine from ICC bytes alone — assume SDR
+    }
 }
 
 /// Resolve the target transfer function.

--- a/zenpixels-convert/tests/output_finalize.rs
+++ b/zenpixels-convert/tests/output_finalize.rs
@@ -3,11 +3,12 @@
 //! This is a critical function with zero prior test coverage.
 
 use alloc::sync::Arc;
+use core::sync::atomic::{AtomicU32, Ordering};
 
 use zenpixels_convert::cms::{ColorManagement, RowTransform};
 use zenpixels_convert::{
-    Cicp, ColorOrigin, PixelBuffer, PixelDescriptor, PixelFormat, finalize_for_output,
-    output::OutputProfile,
+    Cicp, ColorAuthority, ColorOrigin, PixelBuffer, PixelDescriptor, PixelFormat,
+    finalize_for_output, output::OutputProfile,
 };
 
 extern crate alloc;
@@ -28,6 +29,16 @@ impl ColorManagement for NoopCms {
         _dst_icc: &[u8],
     ) -> Result<Box<dyn RowTransform>, Self::Error> {
         Err("no-op CMS: ICC transforms not supported")
+    }
+
+    fn build_transform_from_cicp(
+        &self,
+        _src_cicp: Cicp,
+        _dst_icc: &[u8],
+        _src_format: PixelFormat,
+        _dst_format: PixelFormat,
+    ) -> Result<Box<dyn RowTransform>, Self::Error> {
+        Err("no-op CMS: CICP transforms not supported")
     }
 
     fn identify_profile(&self, _icc: &[u8]) -> Option<Cicp> {
@@ -55,6 +66,79 @@ impl ColorManagement for IdentityCms {
         _src_icc: &[u8],
         _dst_icc: &[u8],
     ) -> Result<Box<dyn RowTransform>, Self::Error> {
+        Ok(Box::new(IdentityTransform))
+    }
+
+    fn build_transform_from_cicp(
+        &self,
+        _src_cicp: Cicp,
+        _dst_icc: &[u8],
+        _src_format: PixelFormat,
+        _dst_format: PixelFormat,
+    ) -> Result<Box<dyn RowTransform>, Self::Error> {
+        Ok(Box::new(IdentityTransform))
+    }
+
+    fn identify_profile(&self, _icc: &[u8]) -> Option<Cicp> {
+        None
+    }
+}
+
+/// A CMS that tracks which method was called (ICC vs CICP).
+struct TrackingCms {
+    icc_calls: AtomicU32,
+    cicp_calls: AtomicU32,
+}
+
+impl TrackingCms {
+    fn new() -> Self {
+        Self {
+            icc_calls: AtomicU32::new(0),
+            cicp_calls: AtomicU32::new(0),
+        }
+    }
+    fn icc_calls(&self) -> u32 {
+        self.icc_calls.load(Ordering::Relaxed)
+    }
+    fn cicp_calls(&self) -> u32 {
+        self.cicp_calls.load(Ordering::Relaxed)
+    }
+    fn total_calls(&self) -> u32 {
+        self.icc_calls() + self.cicp_calls()
+    }
+}
+
+impl ColorManagement for TrackingCms {
+    type Error = &'static str;
+
+    fn build_transform(
+        &self,
+        _src_icc: &[u8],
+        _dst_icc: &[u8],
+    ) -> Result<Box<dyn RowTransform>, Self::Error> {
+        self.icc_calls.fetch_add(1, Ordering::Relaxed);
+        Ok(Box::new(IdentityTransform))
+    }
+
+    fn build_transform_for_format(
+        &self,
+        _src_icc: &[u8],
+        _dst_icc: &[u8],
+        _src_format: PixelFormat,
+        _dst_format: PixelFormat,
+    ) -> Result<Box<dyn RowTransform>, Self::Error> {
+        self.icc_calls.fetch_add(1, Ordering::Relaxed);
+        Ok(Box::new(IdentityTransform))
+    }
+
+    fn build_transform_from_cicp(
+        &self,
+        _src_cicp: Cicp,
+        _dst_icc: &[u8],
+        _src_format: PixelFormat,
+        _dst_format: PixelFormat,
+    ) -> Result<Box<dyn RowTransform>, Self::Error> {
+        self.cicp_calls.fetch_add(1, Ordering::Relaxed);
         Ok(Box::new(IdentityTransform))
     }
 
@@ -339,4 +423,568 @@ fn multi_row_conversion_is_correct() {
             assert_eq!(row[off + 3], 255, "row {y} pixel {x} A");
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// ColorAuthority decision table tests (12 rows)
+// ---------------------------------------------------------------------------
+
+fn fake_icc() -> Arc<[u8]> {
+    Arc::from(vec![0xFFu8; 32].into_boxed_slice())
+}
+
+fn p3_cicp() -> Cicp {
+    Cicp::DISPLAY_P3
+}
+
+fn srgb_cicp() -> Cicp {
+    Cicp::SRGB
+}
+
+/// Row 1: Icc authority, no cicp, no icc, SameAsOrigin → no transform
+#[test]
+fn authority_row01_icc_none_none_same() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::assumed();
+    let cms = TrackingCms::new();
+    let ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::SameAsOrigin,
+        PixelFormat::Rgb8,
+        &cms,
+    )
+    .unwrap();
+    assert_eq!(cms.total_calls(), 0);
+    assert!(ready.metadata().icc.is_none());
+    assert!(ready.metadata().cicp.is_none());
+}
+
+/// Row 2: Icc authority, no cicp, sRGB icc, SameAsOrigin → no transform
+#[test]
+fn authority_row02_icc_none_srgb_same() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::from_icc(fake_icc().to_vec());
+    let cms = TrackingCms::new();
+    let ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::SameAsOrigin,
+        PixelFormat::Rgb8,
+        &cms,
+    )
+    .unwrap();
+    assert_eq!(cms.total_calls(), 0, "SameAsOrigin should not invoke CMS");
+    assert!(ready.metadata().icc.is_some());
+}
+
+/// Row 3: Icc authority, no cicp, P3 icc, Icc(srgb) → CMS from ICC bytes
+#[test]
+fn authority_row03_icc_none_p3icc_to_srgb() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::from_icc(fake_icc().to_vec());
+    let cms = TrackingCms::new();
+    let _ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::Icc(fake_icc()),
+        PixelFormat::Rgb8,
+        &cms,
+    )
+    .unwrap();
+    assert_eq!(cms.icc_calls(), 1, "should use ICC transform");
+    assert_eq!(cms.cicp_calls(), 0, "should not use CICP");
+}
+
+/// Row 4: Icc authority, P3 cicp, no icc, Icc(srgb) → fallback CMS from CICP
+#[test]
+fn authority_row04_icc_p3cicp_noicc_fallback() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    // Icc authority but no ICC, only CICP — simulates codec bug (wrong authority)
+    let origin = ColorOrigin::from_cicp(p3_cicp()).with_color_authority(ColorAuthority::Icc);
+    let cms = TrackingCms::new();
+    let _ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::Icc(fake_icc()),
+        PixelFormat::Rgb8,
+        &cms,
+    )
+    .unwrap();
+    assert_eq!(cms.cicp_calls(), 1, "should fall back to CICP transform");
+    assert_eq!(cms.icc_calls(), 0, "should not use ICC (none available)");
+}
+
+/// Row 5: Icc authority, sRGB cicp, sRGB icc, SameAsOrigin → no transform
+#[test]
+fn authority_row05_icc_srgb_srgb_same() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::from_icc_and_cicp(fake_icc().to_vec(), srgb_cicp())
+        .with_color_authority(ColorAuthority::Icc);
+    let cms = TrackingCms::new();
+    let ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::SameAsOrigin,
+        PixelFormat::Rgb8,
+        &cms,
+    )
+    .unwrap();
+    assert_eq!(cms.total_calls(), 0, "SameAsOrigin should not invoke CMS");
+    assert!(ready.metadata().icc.is_some());
+    assert_eq!(ready.metadata().cicp, Some(srgb_cicp()));
+}
+
+/// Row 6: Icc authority, P3 cicp, P3 icc, Icc(srgb) → CMS from ICC (ignore CICP)
+#[test]
+fn authority_row06_icc_p3cicp_p3icc_to_srgb() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::from_icc_and_cicp(fake_icc().to_vec(), p3_cicp())
+        .with_color_authority(ColorAuthority::Icc);
+    let cms = TrackingCms::new();
+    let _ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::Icc(fake_icc()),
+        PixelFormat::Rgb8,
+        &cms,
+    )
+    .unwrap();
+    assert_eq!(cms.icc_calls(), 1, "should use ICC (authoritative)");
+    assert_eq!(cms.cicp_calls(), 0, "should not use CICP");
+}
+
+/// Row 7: Cicp authority, no cicp, no icc, SameAsOrigin → no transform
+#[test]
+fn authority_row07_cicp_none_none_same() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::assumed().with_color_authority(ColorAuthority::Cicp);
+    let cms = TrackingCms::new();
+    let ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::SameAsOrigin,
+        PixelFormat::Rgb8,
+        &cms,
+    )
+    .unwrap();
+    assert_eq!(cms.total_calls(), 0);
+    assert!(ready.metadata().icc.is_none());
+}
+
+/// Row 8: Cicp authority, sRGB cicp, any icc, SameAsOrigin → no transform
+#[test]
+fn authority_row08_cicp_srgb_anyicc_same() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::from_icc_and_cicp(fake_icc().to_vec(), srgb_cicp())
+        .with_color_authority(ColorAuthority::Cicp);
+    let cms = TrackingCms::new();
+    let ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::SameAsOrigin,
+        PixelFormat::Rgb8,
+        &cms,
+    )
+    .unwrap();
+    assert_eq!(cms.total_calls(), 0, "SameAsOrigin should not invoke CMS");
+    assert_eq!(ready.metadata().cicp, Some(srgb_cicp()));
+}
+
+/// Row 9: Cicp authority, P3 cicp, no icc, Icc(srgb) → CMS from CICP
+#[test]
+fn authority_row09_cicp_p3_noicc_to_srgb() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::from_cicp(p3_cicp());
+    let cms = TrackingCms::new();
+    let _ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::Icc(fake_icc()),
+        PixelFormat::Rgb8,
+        &cms,
+    )
+    .unwrap();
+    assert_eq!(cms.cicp_calls(), 1, "should use CICP transform");
+    assert_eq!(cms.icc_calls(), 0, "should not use ICC (none available)");
+}
+
+/// Row 10: Cicp authority, P3 cicp, P3 icc, Icc(srgb) → CMS from CICP (ignore ICC)
+#[test]
+fn authority_row10_cicp_p3_p3icc_to_srgb() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::from_icc_and_cicp(fake_icc().to_vec(), p3_cicp());
+    let cms = TrackingCms::new();
+    let _ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::Icc(fake_icc()),
+        PixelFormat::Rgb8,
+        &cms,
+    )
+    .unwrap();
+    assert_eq!(cms.cicp_calls(), 1, "should use CICP (authoritative)");
+    assert_eq!(cms.icc_calls(), 0, "should not use ICC");
+}
+
+/// Row 11: Cicp authority, no cicp, P3 icc, Icc(srgb) → fallback CMS from ICC
+#[test]
+fn authority_row11_cicp_nocicp_p3icc_fallback() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin =
+        ColorOrigin::from_icc(fake_icc().to_vec()).with_color_authority(ColorAuthority::Cicp);
+    let cms = TrackingCms::new();
+    let _ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::Icc(fake_icc()),
+        PixelFormat::Rgb8,
+        &cms,
+    )
+    .unwrap();
+    assert_eq!(cms.icc_calls(), 1, "should fall back to ICC transform");
+    assert_eq!(cms.cicp_calls(), 0, "should not use CICP (none available)");
+}
+
+/// Row 12: Icc authority, P3 cicp, P3 icc, SameAsOrigin → no transform
+#[test]
+fn authority_row12_icc_p3_p3icc_same() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::from_icc_and_cicp(fake_icc().to_vec(), p3_cicp())
+        .with_color_authority(ColorAuthority::Icc);
+    let cms = TrackingCms::new();
+    let ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::SameAsOrigin,
+        PixelFormat::Rgb8,
+        &cms,
+    )
+    .unwrap();
+    assert_eq!(cms.total_calls(), 0, "SameAsOrigin should not invoke CMS");
+    assert!(ready.metadata().icc.is_some());
+    assert_eq!(ready.metadata().cicp, Some(p3_cicp()));
+}
+
+// ---------------------------------------------------------------------------
+// Additional coverage: both-missing, error paths, Named target
+// ---------------------------------------------------------------------------
+
+/// A CMS that always fails — exercises error mapping paths.
+struct FailingCms;
+
+impl ColorManagement for FailingCms {
+    type Error = &'static str;
+
+    fn build_transform(
+        &self,
+        _src_icc: &[u8],
+        _dst_icc: &[u8],
+    ) -> Result<Box<dyn RowTransform>, Self::Error> {
+        Err("deliberate ICC failure")
+    }
+
+    fn build_transform_for_format(
+        &self,
+        _src_icc: &[u8],
+        _dst_icc: &[u8],
+        _src_format: PixelFormat,
+        _dst_format: PixelFormat,
+    ) -> Result<Box<dyn RowTransform>, Self::Error> {
+        Err("deliberate ICC failure")
+    }
+
+    fn build_transform_from_cicp(
+        &self,
+        _src_cicp: Cicp,
+        _dst_icc: &[u8],
+        _src_format: PixelFormat,
+        _dst_format: PixelFormat,
+    ) -> Result<Box<dyn RowTransform>, Self::Error> {
+        Err("deliberate CICP failure")
+    }
+
+    fn identify_profile(&self, _icc: &[u8]) -> Option<Cicp> {
+        None
+    }
+}
+
+/// Icc authority, no icc, no cicp, Icc(target) → no source, falls through
+#[test]
+fn authority_icc_neither_field_to_icc_target() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::assumed(); // Icc, no icc, no cicp
+    let cms = TrackingCms::new();
+    let ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::Icc(fake_icc()),
+        PixelFormat::Rgb8,
+        &cms,
+    )
+    .unwrap();
+    assert_eq!(cms.total_calls(), 0, "no source profile → no CMS call");
+    // Falls through to RowConverter, pixels preserved
+    let slice = ready.pixels();
+    let row = slice.row(0);
+    assert_eq!(&row[..3], &[128, 128, 128]);
+}
+
+/// Cicp authority, no icc, no cicp, Icc(target) → no source, falls through
+#[test]
+fn authority_cicp_neither_field_to_icc_target() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::assumed().with_color_authority(ColorAuthority::Cicp);
+    let cms = TrackingCms::new();
+    let _ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::Icc(fake_icc()),
+        PixelFormat::Rgb8,
+        &cms,
+    )
+    .unwrap();
+    assert_eq!(cms.total_calls(), 0, "no source profile → no CMS call");
+}
+
+/// CMS ICC transform error is propagated
+#[test]
+fn authority_icc_transform_error_propagated() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::from_icc(fake_icc().to_vec());
+    let result = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::Icc(fake_icc()),
+        PixelFormat::Rgb8,
+        &FailingCms,
+    );
+    assert!(result.is_err(), "ICC transform failure should propagate");
+}
+
+/// CMS CICP transform error is propagated
+#[test]
+fn authority_cicp_transform_error_propagated() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::from_cicp(p3_cicp());
+    let result = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::Icc(fake_icc()),
+        PixelFormat::Rgb8,
+        &FailingCms,
+    );
+    assert!(result.is_err(), "CICP transform failure should propagate");
+}
+
+/// CMS CICP fallback error is propagated (Icc authority, no icc, cicp present)
+#[test]
+fn authority_icc_cicp_fallback_error_propagated() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::from_cicp(p3_cicp()).with_color_authority(ColorAuthority::Icc);
+    let result = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::Icc(fake_icc()),
+        PixelFormat::Rgb8,
+        &FailingCms,
+    );
+    assert!(result.is_err(), "CICP fallback failure should propagate");
+}
+
+/// CMS ICC fallback error is propagated (Cicp authority, no cicp, icc present)
+#[test]
+fn authority_cicp_icc_fallback_error_propagated() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin =
+        ColorOrigin::from_icc(fake_icc().to_vec()).with_color_authority(ColorAuthority::Cicp);
+    let result = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::Icc(fake_icc()),
+        PixelFormat::Rgb8,
+        &FailingCms,
+    );
+    assert!(result.is_err(), "ICC fallback failure should propagate");
+}
+
+/// Named target never invokes CMS regardless of authority/metadata
+#[test]
+fn named_target_never_uses_cms_with_icc_authority() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::from_icc_and_cicp(fake_icc().to_vec(), p3_cicp())
+        .with_color_authority(ColorAuthority::Icc);
+    let cms = TrackingCms::new();
+    let ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::Named(srgb_cicp()),
+        PixelFormat::Rgb8,
+        &cms,
+    )
+    .unwrap();
+    assert_eq!(cms.total_calls(), 0, "Named target uses matrices, not CMS");
+    assert_eq!(ready.metadata().cicp, Some(srgb_cicp()));
+    assert!(ready.metadata().icc.is_none());
+}
+
+/// Named target never invokes CMS regardless of authority/metadata (CICP authority)
+#[test]
+fn named_target_never_uses_cms_with_cicp_authority() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::from_cicp(p3_cicp());
+    let cms = TrackingCms::new();
+    let _ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::Named(srgb_cicp()),
+        PixelFormat::Rgb8,
+        &cms,
+    )
+    .unwrap();
+    assert_eq!(cms.total_calls(), 0, "Named target uses matrices, not CMS");
+}
+
+// ---------------------------------------------------------------------------
+// HDR guard tests
+// ---------------------------------------------------------------------------
+
+fn pq_cicp() -> Cicp {
+    Cicp::BT2100_PQ
+}
+
+fn hlg_cicp() -> Cicp {
+    Cicp::BT2100_HLG
+}
+
+/// HDR (PQ) origin → SDR ICC target → rejected
+#[test]
+fn hdr_pq_to_sdr_icc_rejected() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::from_cicp(pq_cicp());
+    let result = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::Icc(fake_icc()),
+        PixelFormat::Rgb8,
+        &NoopCms,
+    );
+    let err = result.err().expect("HDR PQ → SDR ICC should be rejected");
+    assert_eq!(
+        *err.error(),
+        zenpixels_convert::error::ConvertError::HdrTransferRequiresToneMapping
+    );
+}
+
+/// HDR (HLG) origin → SDR Named(sRGB) target → rejected
+#[test]
+fn hdr_hlg_to_sdr_named_rejected() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::from_cicp(hlg_cicp());
+    let result = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::Named(srgb_cicp()),
+        PixelFormat::Rgb8,
+        &NoopCms,
+    );
+    let err = result
+        .err()
+        .expect("HDR HLG → SDR Named should be rejected");
+    assert_eq!(
+        *err.error(),
+        zenpixels_convert::error::ConvertError::HdrTransferRequiresToneMapping
+    );
+}
+
+/// HDR origin → SameAsOrigin → allowed (passthrough)
+#[test]
+fn hdr_pq_same_as_origin_allowed() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::from_cicp(pq_cicp());
+    let ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::SameAsOrigin,
+        PixelFormat::Rgb8,
+        &NoopCms,
+    )
+    .unwrap();
+    assert_eq!(ready.metadata().cicp, Some(pq_cicp()));
+}
+
+/// HDR origin → HDR Named(PQ) target → allowed
+#[test]
+fn hdr_pq_to_hdr_named_allowed() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::from_cicp(pq_cicp());
+    let ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::Named(pq_cicp()),
+        PixelFormat::Rgb8,
+        &NoopCms,
+    )
+    .unwrap();
+    assert_eq!(ready.metadata().cicp, Some(pq_cicp()));
+}
+
+/// HDR (HLG) origin → HDR Named(HLG) target → allowed
+#[test]
+fn hdr_hlg_to_hdr_named_allowed() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::from_cicp(hlg_cicp());
+    let _ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::Named(hlg_cicp()),
+        PixelFormat::Rgb8,
+        &NoopCms,
+    )
+    .unwrap();
+}
+
+/// SDR origin → SDR target → no HDR guard triggered
+#[test]
+fn sdr_to_sdr_no_hdr_guard() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::from_cicp(p3_cicp()); // P3 is SDR
+    let _ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::Named(srgb_cicp()),
+        PixelFormat::Rgb8,
+        &NoopCms,
+    )
+    .unwrap();
+}
+
+/// SDR origin → ICC target → no HDR guard triggered
+#[test]
+fn sdr_to_icc_no_hdr_guard() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::from_icc(fake_icc().to_vec());
+    let _ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::Icc(fake_icc()),
+        PixelFormat::Rgb8,
+        &IdentityCms,
+    )
+    .unwrap();
+}
+
+/// No color metadata → no HDR guard triggered
+#[test]
+fn no_metadata_no_hdr_guard() {
+    let buf = make_rgb8_buffer(1, 1, [128, 128, 128]);
+    let origin = ColorOrigin::assumed();
+    let _ready = finalize_for_output(
+        &buf,
+        &origin,
+        OutputProfile::Icc(fake_icc()),
+        PixelFormat::Rgb8,
+        &NoopCms,
+    )
+    .unwrap();
 }

--- a/zenpixels/Cargo.toml
+++ b/zenpixels/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zenpixels"
-version = "0.2.3"
+version = "0.2.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/zenpixels/src/color.rs
+++ b/zenpixels/src/color.rs
@@ -96,6 +96,60 @@ impl NamedProfile {
     }
 }
 
+/// Which color metadata a CMS should prefer when building transforms.
+///
+/// When both ICC and CICP are present, this determines which one the CMS
+/// uses. When only one is present, it is used regardless of this flag —
+/// the authority controls precedence, not exclusivity.
+///
+/// **Codec contract:** codecs should set this to match the data they
+/// actually provide. Setting `Icc` without populating `icc_profile` (or
+/// `Cicp` without `cicp`) is a codec bug. Implementations *may* fall back
+/// to the other field when the authoritative one is absent, but are not
+/// required to — they may also treat the mismatch as an error or assume
+/// sRGB.
+///
+/// [`ColorContext::as_profile_source`] implements a lenient resolution:
+/// preferred field → other field → `None`. Stricter consumers can inspect
+/// the authority and the fields directly.
+///
+/// The codec sets this during decode based on the format's specification:
+///
+/// - **JPEG, WebP, TIFF**: `Icc` (ICC is the only color signal)
+/// - **PNG 3rd Ed**: `Cicp` when cICP chunk present, `Icc` when only iCCP
+/// - **AVIF/MIAF**: `Icc` when ICC colr box present, `Cicp` otherwise
+/// - **HEIC/HEIF**: `Cicp` when nclx colr box present, `Icc` otherwise
+/// - **JPEG XL**: `Cicp` when enum encoding (`want_icc=false`), `Icc` when embedded ICC
+///
+/// Both `icc_profile` and `cicp` may be populated regardless of this flag —
+/// the non-authoritative field is preserved for metadata roundtripping.
+///
+/// This is distinct from [`ColorProvenance`] which records *how the source
+/// described* its color (for re-encoding decisions). `ColorAuthority` says
+/// which field the CMS should *prefer* for building transforms.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
+pub enum ColorAuthority {
+    /// ICC profile bytes take precedence for CMS transforms.
+    ///
+    /// The CMS should parse `icc_profile` and use its TRC curves directly.
+    /// Any CICP tag embedded inside the ICC should NOT override the TRC
+    /// (i.e., `allow_use_cicp_transfer: false` in moxcms terms).
+    ///
+    /// Codecs should only set this when `icc_profile` is populated.
+    /// Lenient consumers may fall back to `cicp` if ICC is absent.
+    #[default]
+    Icc,
+    /// CICP codes take precedence for CMS transforms.
+    ///
+    /// The CMS should build a source profile from the `cicp` field
+    /// (e.g., `ColorProfile::new_from_cicp()` in moxcms). The ICC profile,
+    /// if present, is for backwards-compatible metadata roundtripping only.
+    ///
+    /// Codecs should only set this when `cicp` is populated.
+    /// Lenient consumers may fall back to `icc_profile` if CICP is absent.
+    Cicp,
+}
+
 /// Color space metadata for pixel data.
 ///
 /// Bundles ICC profile bytes and/or CICP parameters into a single
@@ -108,6 +162,8 @@ pub struct ColorContext {
     pub icc: Option<Arc<[u8]>>,
     /// CICP parameters (ITU-T H.273).
     pub cicp: Option<Cicp>,
+    /// Which field the CMS should treat as authoritative for transforms.
+    pub color_authority: ColorAuthority,
 }
 
 impl ColorContext {
@@ -116,6 +172,7 @@ impl ColorContext {
         Self {
             icc: Some(icc.into()),
             cicp: None,
+            color_authority: ColorAuthority::Icc,
         }
     }
 
@@ -124,6 +181,7 @@ impl ColorContext {
         Self {
             icc: None,
             cicp: Some(cicp),
+            color_authority: ColorAuthority::Cicp,
         }
     }
 
@@ -132,18 +190,32 @@ impl ColorContext {
         Self {
             icc: Some(icc.into()),
             cicp: Some(cicp),
+            color_authority: ColorAuthority::Cicp,
         }
     }
 
     /// Get a [`ColorProfileSource`] reference for CMS integration.
     ///
-    /// Returns CICP if present (takes precedence per AVIF/HEIF specs),
-    /// otherwise returns the ICC profile bytes.
+    /// Returns a source based on [`ColorAuthority`]: when authority is `Cicp`,
+    /// returns CICP if present; when authority is `Icc`, returns ICC bytes if
+    /// present. In both cases, falls back to the other field if the authoritative
+    /// one is absent, and returns `None` when neither is present.
     pub fn as_profile_source(&self) -> Option<ColorProfileSource<'_>> {
-        if let Some(cicp) = self.cicp {
-            Some(ColorProfileSource::Cicp(cicp))
-        } else {
-            self.icc.as_deref().map(ColorProfileSource::Icc)
+        match self.color_authority {
+            ColorAuthority::Cicp => {
+                if let Some(cicp) = self.cicp {
+                    return Some(ColorProfileSource::Cicp(cicp));
+                }
+                // Fallback to ICC if CICP authority but no CICP present
+                self.icc.as_deref().map(ColorProfileSource::Icc)
+            }
+            ColorAuthority::Icc => {
+                if let Some(icc) = self.icc.as_deref() {
+                    return Some(ColorProfileSource::Icc(icc));
+                }
+                // Fallback to CICP if ICC authority but no ICC present
+                self.cicp.map(ColorProfileSource::Cicp)
+            }
         }
     }
 
@@ -199,6 +271,8 @@ pub struct ColorOrigin {
     pub cicp: Option<Cicp>,
     /// How the color information was originally described.
     pub provenance: ColorProvenance,
+    /// Which field a CMS should treat as authoritative for transforms.
+    pub color_authority: ColorAuthority,
 }
 
 impl ColorOrigin {
@@ -208,6 +282,7 @@ impl ColorOrigin {
             icc: Some(icc.into()),
             cicp: None,
             provenance: ColorProvenance::Icc,
+            color_authority: ColorAuthority::Icc,
         }
     }
 
@@ -217,6 +292,7 @@ impl ColorOrigin {
             icc: None,
             cicp: Some(cicp),
             provenance: ColorProvenance::Cicp,
+            color_authority: ColorAuthority::Cicp,
         }
     }
 
@@ -226,6 +302,7 @@ impl ColorOrigin {
             icc: Some(icc.into()),
             cicp: Some(cicp),
             provenance: ColorProvenance::Cicp,
+            color_authority: ColorAuthority::Cicp,
         }
     }
 
@@ -235,6 +312,7 @@ impl ColorOrigin {
             icc: None,
             cicp: None,
             provenance: ColorProvenance::GamaChrm,
+            color_authority: ColorAuthority::Icc,
         }
     }
 
@@ -244,7 +322,14 @@ impl ColorOrigin {
             icc: None,
             cicp: None,
             provenance: ColorProvenance::Assumed,
+            color_authority: ColorAuthority::Icc,
         }
+    }
+
+    /// Override the color authority.
+    pub fn with_color_authority(mut self, authority: ColorAuthority) -> Self {
+        self.color_authority = authority;
+        self
     }
 }
 
@@ -324,8 +409,39 @@ mod tests {
     }
 
     #[test]
-    fn color_context_profile_source_prefers_cicp() {
+    fn color_context_profile_source_cicp_authority() {
+        // from_icc_and_cicp sets ColorAuthority::Cicp, so CICP wins
         let ctx = ColorContext::from_icc_and_cicp(vec![1, 2, 3], Cicp::SRGB);
+        assert_eq!(ctx.color_authority, ColorAuthority::Cicp);
+        let src = ctx.as_profile_source().unwrap();
+        assert_eq!(src, ColorProfileSource::Cicp(Cicp::SRGB));
+    }
+
+    #[test]
+    fn color_context_profile_source_icc_authority() {
+        // Manually set ICC authority on a context that has both — ICC wins
+        let mut ctx = ColorContext::from_icc_and_cicp(vec![1, 2, 3], Cicp::SRGB);
+        ctx.color_authority = ColorAuthority::Icc;
+        let src = ctx.as_profile_source().unwrap();
+        assert_eq!(src, ColorProfileSource::Icc(&[1, 2, 3]));
+    }
+
+    #[test]
+    fn color_context_profile_source_cicp_authority_fallback_to_icc() {
+        // CICP authority but no CICP present — falls back to ICC
+        let mut ctx = ColorContext::from_icc(vec![7, 8, 9]);
+        ctx.color_authority = ColorAuthority::Cicp;
+        let src = ctx.as_profile_source().unwrap();
+        assert_eq!(src, ColorProfileSource::Icc(&[7, 8, 9]));
+    }
+
+    #[test]
+    fn color_context_profile_source_icc_authority_fallback_to_cicp() {
+        // ICC authority but no ICC present — falls back to CICP
+        let ctx = ColorContext::from_cicp(Cicp::SRGB);
+        // from_cicp sets ColorAuthority::Cicp; override to Icc for fallback test
+        let mut ctx = ctx;
+        ctx.color_authority = ColorAuthority::Icc;
         let src = ctx.as_profile_source().unwrap();
         assert_eq!(src, ColorProfileSource::Cicp(Cicp::SRGB));
     }
@@ -377,6 +493,7 @@ mod tests {
         let ctx = ColorContext {
             icc: None,
             cicp: None,
+            color_authority: ColorAuthority::Icc,
         };
         assert!(ctx.as_profile_source().is_none());
     }

--- a/zenpixels/src/lib.rs
+++ b/zenpixels/src/lib.rs
@@ -69,7 +69,9 @@ pub use buffer::{Bgrx, BufferError, Pixel, PixelBuffer, PixelSlice, PixelSliceMu
 
 // Re-export color types at crate root.
 pub use cicp::Cicp;
-pub use color::{ColorContext, ColorOrigin, ColorProfileSource, ColorProvenance, NamedProfile};
+pub use color::{
+    ColorAuthority, ColorContext, ColorOrigin, ColorProfileSource, ColorProvenance, NamedProfile,
+};
 
 // Re-export HDR metadata types at crate root.
 pub use hdr::{ContentLightLevel, MasteringDisplay};


### PR DESCRIPTION
## Summary

### zenpixels
- Adds `ColorAuthority` enum (`Icc` | `Cicp`) to control which color metadata field a CMS should trust for building transforms
- Adds `color_authority` field to `ColorContext` and `ColorOrigin`
- Fixes `ColorContext::as_profile_source()` to respect authority instead of hardcoding CICP preference

### zenpixels-convert
- Adds `build_transform_from_cicp()` to the `ColorManagement` trait — builds CMS transforms directly from CICP codes, avoiding ICC serialize/deserialize round-trip
- `MoxCms` implementation uses `ColorProfile::new_from_cicp()` for direct profile construction
- Extracts shared transform-building logic into `build_transform_inner()`
- `finalize_for_output()` respects `ColorAuthority` — dispatches ICC or CICP path with fallback when the authoritative field is missing
- `SameAsOrigin` no longer invokes CMS (it means keep the color space)
- Adds `HdrTransferRequiresToneMapping` guard — rejects PQ/HLG source → SDR target to prevent silent clipping
- Tone mapping design doc for the HDR→SDR workflow using `ultrahdr-core`

## Motivation

Image formats differ on whether ICC profiles or CICP code points take precedence when both are present:

| Format | Rule |
|--------|------|
| JPEG, WebP, TIFF | `Icc` (ICC is the only color signal) |
| PNG 3rd Ed | `Cicp` when cICP chunk present, `Icc` when only iCCP |
| AVIF/MIAF | `Icc` when ICC colr box present, `Cicp` otherwise |
| HEIC/HEIF | `Cicp` when nclx colr box present, `Icc` otherwise |
| JPEG XL | `Cicp` for enum encoding, `Icc` for embedded ICC |

Previously, `as_profile_source()` hardcoded CICP preference, which is wrong for AVIF (ICC wins when present). The codec now sets the authority during decode based on its format's spec.

When `ColorAuthority::Icc`, CMS transforms always use `allow_use_cicp_transfer: false` — the ICC TRC curves are trusted, not any CICP tag embedded in the profile (moxcms issue [#155](https://github.com/awxkee/moxcms/issues/155)).

When `ColorAuthority::Cicp`, the CMS builds the source profile directly from CICP codes via `build_transform_from_cicp()`, bypassing ICC entirely.

Both fields remain populated on `SourceColor` / `ColorContext` for metadata roundtripping during cross-format transcode.

## Test plan

- [x] All existing zenpixels + zenpixels-convert tests pass
- [x] 12 authority decision table tests (TrackingCms verifies ICC vs CICP dispatch)
- [x] Fallback tests: Icc authority + no ICC → falls back to CICP (row 4), Cicp authority + no CICP → falls back to ICC (row 11)
- [x] 4 error propagation tests (FailingCms for ICC, CICP, and both fallback paths)
- [x] 2 Named target tests (CMS never invoked)
- [x] 2 both-missing tests (neither ICC nor CICP → no CMS, falls through)
- [x] 8 HDR transfer guard tests (PQ/HLG rejected to SDR, allowed to SameAsOrigin/HDR Named)
- [x] 100% coverage of reachable new code paths in `build_cms_transform` and `finalize_for_output`