### PR TITLE
feat: lower MSRV — zenpixels to 1.85, zenpixels-convert to 1.89

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,20 +146,14 @@ jobs:
           rustup toolchain install 1.85.0 --no-self-update --profile minimal
           rustup toolchain install 1.89.0 --no-self-update --profile minimal
 
-      - name: Install Rust (stable, for lockfile generation)
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      - name: Generate lockfile with stable
-        run: cargo generate-lockfile
-
       - name: Check MSRV (zenpixels @ 1.85)
-        run: cargo +1.85.0 check -p zenpixels --locked
+        run: cargo +1.85.0 check -p zenpixels
 
       - name: Check MSRV (zenpixels-convert @ 1.89)
-        run: cargo +1.89.0 check -p zenpixels-convert --locked
+        run: cargo +1.89.0 check -p zenpixels-convert
 
   # ==========================================================================
   # Feature powerset (all feature combinations compile)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,13 +141,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install MSRV toolchains
+        run: |
+          rustup toolchain install 1.85.0 --no-self-update --profile minimal
+          rustup toolchain install 1.89.0 --no-self-update --profile minimal
+
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      - name: Check MSRV
+      - name: Check MSRV (zenpixels @ 1.85, zenpixels-convert @ 1.89)
         run: cargo hack check --workspace --rust-version
 
   # ==========================================================================

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,14 +146,14 @@ jobs:
           rustup toolchain install 1.85.0 --no-self-update --profile minimal
           rustup toolchain install 1.89.0 --no-self-update --profile minimal
 
-      - name: Install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
-
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      - name: Check MSRV (zenpixels @ 1.85, zenpixels-convert @ 1.89)
-        run: cargo hack check --workspace --rust-version
+      - name: Check MSRV (zenpixels @ 1.85)
+        run: cargo +1.85.0 check -p zenpixels
+
+      - name: Check MSRV (zenpixels-convert @ 1.89)
+        run: cargo +1.89.0 check -p zenpixels-convert
 
   # ==========================================================================
   # Feature powerset (all feature combinations compile)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,14 +146,20 @@ jobs:
           rustup toolchain install 1.85.0 --no-self-update --profile minimal
           rustup toolchain install 1.89.0 --no-self-update --profile minimal
 
+      - name: Install Rust (stable, for lockfile generation)
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
+      - name: Generate lockfile with stable
+        run: cargo generate-lockfile
+
       - name: Check MSRV (zenpixels @ 1.85)
-        run: cargo +1.85.0 check -p zenpixels
+        run: cargo +1.85.0 check -p zenpixels --locked
 
       - name: Check MSRV (zenpixels-convert @ 1.89)
-        run: cargo +1.89.0 check -p zenpixels-convert
+        run: cargo +1.89.0 check -p zenpixels-convert --locked
 
   # ==========================================================================
   # Feature powerset (all feature combinations compile)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 version = "0.2.2"
 edition = "2024"
-rust-version = "1.89"
+rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/imazen/zenpixels"
 categories = ["multimedia::images"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 version = "0.2.2"
 edition = "2024"
-rust-version = "1.93"
+rust-version = "1.89"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/imazen/zenpixels"
 categories = ["multimedia::images"]

--- a/zenpixels-convert/Cargo.toml
+++ b/zenpixels-convert/Cargo.toml
@@ -35,7 +35,7 @@ cms-moxcms = ["std", "dep:moxcms"]
 serde = ["zenpixels/serde"]
 
 [dependencies]
-zenpixels = { version = "0.2.3", default-features = false }
+zenpixels = { path = "../zenpixels", version = "0.2.3", default-features = false }
 linear-srgb = { version = "0.6.7", default-features = false, features = ["transfer"] }
 bytemuck = { version = "1.21", default-features = false, features = ["extern_crate_alloc", "derive"] }
 rgb = { version = "0.8", default-features = false, features = ["bytemuck"], optional = true }
@@ -45,7 +45,7 @@ whereat = { version = "0.1.5", default-features = false }
 moxcms = { version = "0.8.1", optional = true, features = ["options"] }
 
 [dev-dependencies]
-zenpixels = { version = "0.2.3", features = ["planar", "imgref"] }
+zenpixels = { path = "../zenpixels", version = "0.2.3", features = ["planar", "imgref"] }
 zenpixels-convert = { path = "", features = ["pipeline", "imgref", "cms-moxcms"] , version = "0.2.4" }
 zenbench = { version = "0.1.2"}
 half = "2"

--- a/zenpixels-convert/Cargo.toml
+++ b/zenpixels-convert/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zenpixels-convert"
 version = "0.2.4"
 edition.workspace = true
-rust-version.workspace = true
+rust-version = "1.89"
 license.workspace = true
 readme = "../README.md"
 repository.workspace = true

--- a/zenpixels/src/buffer.rs
+++ b/zenpixels/src/buffer.rs
@@ -263,7 +263,8 @@ fn validate_slice(
     if stride_bytes < min_stride {
         return Err(BufferError::StrideTooSmall);
     }
-    if bpp > 0 && !stride_bytes.is_multiple_of(bpp) {
+    #[allow(clippy::manual_is_multiple_of)] // is_multiple_of stabilized 1.87; MSRV is 1.85
+    if bpp > 0 && stride_bytes % bpp != 0 {
         return Err(BufferError::StrideNotPixelAligned);
     }
     if rows > 0 {
@@ -273,7 +274,8 @@ fn validate_slice(
         }
     }
     let align = descriptor.min_alignment();
-    if !(data_ptr as usize).is_multiple_of(align) {
+    #[allow(clippy::manual_is_multiple_of)] // is_multiple_of stabilized 1.87; MSRV is 1.85
+    if (data_ptr as usize) % align != 0 {
         return Err(BufferError::AlignmentViolation);
     }
     Ok(())

--- a/zenpixels/src/buffer.rs
+++ b/zenpixels/src/buffer.rs
@@ -1808,7 +1808,8 @@ impl PixelBuffer {
             return None;
         }
         let pixel_size = core::mem::size_of::<P>();
-        if pixel_size == 0 || !self.stride.is_multiple_of(pixel_size) {
+        #[allow(clippy::manual_is_multiple_of)] // is_multiple_of stabilized 1.87; MSRV is 1.85
+        if pixel_size == 0 || self.stride % pixel_size != 0 {
             return None;
         }
         let total_bytes = if self.height == 0 {
@@ -1835,7 +1836,8 @@ impl PixelBuffer {
             return None;
         }
         let pixel_size = core::mem::size_of::<P>();
-        if pixel_size == 0 || !self.stride.is_multiple_of(pixel_size) {
+        #[allow(clippy::manual_is_multiple_of)] // is_multiple_of stabilized 1.87; MSRV is 1.85
+        if pixel_size == 0 || self.stride % pixel_size != 0 {
             return None;
         }
         let total_bytes = if self.height == 0 {

--- a/zenpixels/src/descriptor.rs
+++ b/zenpixels/src/descriptor.rs
@@ -949,10 +949,10 @@ impl fmt::Display for PixelDescriptor {
             self.format.channel_type(),
             self.transfer
         )?;
-        if let Some(alpha) = self.alpha
-            && alpha.has_alpha()
-        {
-            write!(f, " alpha={alpha}")?;
+        if let Some(alpha) = self.alpha {
+            if alpha.has_alpha() {
+                write!(f, " alpha={alpha}")?;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Replaces single let-chain with nested ifs so zenpixels reaches 1.85 (edition 2024 floor)
- zenpixels-convert stays at 1.89 due to archmage dependency
- CI MSRV job installs both 1.85 and 1.89 toolchains

## Test plan
- [ ] CI MSRV job passes for both crates at their declared versions
- [ ] All existing tests pass on stable