### PR TITLE
feat: ICC profile identification + AdobeRgb/ProPhoto enum variants

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,76 @@
+# zenpixels justfile
+
+icc_cache := env("HOME") / ".cache/zenpixels-icc"
+icc_out := "zenpixels/src/icc"
+r2_bucket := "codec-corpus"
+r2_prefix := "icc-profiles/"
+
+# Run all checks (fmt, clippy, test)
+ci: fmt clippy test
+
+# Format
+fmt:
+    cargo fmt --check
+
+# Clippy
+clippy:
+    cargo clippy --workspace -- -D warnings
+
+# Test all packages
+test:
+    cargo test --workspace
+
+# ── ICC profile table management ──────────────────────────────────────
+
+# Fetch ICC profiles from R2 to local cache
+icc-fetch:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    : "${R2_ACCOUNT_ID:?Set R2_ACCOUNT_ID}"
+    : "${R2_ACCESS_KEY_ID:?Set R2_ACCESS_KEY_ID}"
+    : "${R2_SECRET_ACCESS_KEY:?Set R2_SECRET_ACCESS_KEY}"
+    mkdir -p "{{icc_cache}}"
+    ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+    export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+    export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+    echo "Syncing ICC profiles from R2 → {{icc_cache}} ..."
+    aws s3 sync "s3://{{r2_bucket}}/{{r2_prefix}}" "{{icc_cache}}/" \
+        --endpoint-url "$ENDPOINT" --no-progress
+    echo "Done: $(find "{{icc_cache}}" -name '*.icc' | wc -l) profiles"
+
+# Upload ICC profiles to R2 from a local directory
+icc-upload dir:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    : "${R2_ACCOUNT_ID:?Set R2_ACCOUNT_ID}"
+    : "${R2_ACCESS_KEY_ID:?Set R2_ACCESS_KEY_ID}"
+    : "${R2_SECRET_ACCESS_KEY:?Set R2_SECRET_ACCESS_KEY}"
+    ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+    export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+    export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+    echo "Uploading ICC profiles from {{dir}} → R2 ..."
+    aws s3 sync "{{dir}}/" "s3://{{r2_bucket}}/{{r2_prefix}}" \
+        --endpoint-url "$ENDPOINT" --no-progress
+    echo "Done."
+
+# Regenerate .inc table files from ICC profile cache
+icc-gen: icc-build-gen
+    /tmp/zenpixels-gen-icc-tables "{{icc_cache}}" "{{icc_out}}"
+
+# Build the table generator
+icc-build-gen:
+    rustc -O scripts/gen_icc_tables.rs -o /tmp/zenpixels-gen-icc-tables
+
+# Full pipeline: fetch profiles, regenerate tables, test
+icc-update: icc-fetch icc-gen test
+    @echo "ICC tables updated and tests pass."
+
+# Show what the generator would produce without writing (dry run)
+icc-dry-run: icc-build-gen
+    /tmp/zenpixels-gen-icc-tables "{{icc_cache}}" /tmp/zenpixels-icc-dry-run
+    @echo "--- RGB ---"
+    @head -5 /tmp/zenpixels-icc-dry-run/icc_table_rgb.inc
+    @echo "..."
+    @tail -3 /tmp/zenpixels-icc-dry-run/icc_table_rgb.inc
+    @echo "--- Gray ---"
+    @cat /tmp/zenpixels-icc-dry-run/icc_table_gray.inc

--- a/scripts/gen_icc_tables.rs
+++ b/scripts/gen_icc_tables.rs
@@ -1,0 +1,348 @@
+//! Generate ICC hash table .inc files for zenpixels::icc.
+//!
+//! Scans ICC profiles, computes normalized FNV-1a hashes, identifies primaries
+//! and TRC (measuring max u16 error against all reference EOTFs for all 65536
+//! values), deduplicates by normalized hash, and writes Rust include files.
+//!
+//! Usage:
+//!   rustc -O scripts/gen_icc_tables.rs -o /tmp/gen_icc_tables
+//!   ICC_PROFILES_DIR=/tmp/icc-upload /tmp/gen_icc_tables
+//!
+//! Output goes to zenpixels/src/icc/icc_table_{rgb,gray}.inc relative to
+//! the script's location, or to --out-dir if specified.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+// ── Normalized FNV-1a hash ───────────────────────────────────────────────
+
+fn fnv1a_64_normalized(data: &[u8]) -> u64 {
+    const OFFSET: u64 = 0xcbf29ce484222325;
+    const PRIME: u64 = 0x100000001b3;
+    let mut hash = OFFSET;
+
+    // Phase 1: first 100 bytes — zero metadata fields.
+    let header_len = data.len().min(100);
+    let mut i = 0;
+    while i < header_len {
+        let b = if (i >= 4 && i < 8)
+            || (i >= 24 && i < 36)
+            || (i >= 40 && i < 44)
+            || (i >= 48 && i < 56)
+            || (i >= 80)
+        { 0u8 } else { data[i] };
+        hash ^= b as u64;
+        hash = hash.wrapping_mul(PRIME);
+        i += 1;
+    }
+
+    // Phase 2: remaining bytes — straight hash.
+    while i < data.len() {
+        hash ^= data[i] as u64;
+        hash = hash.wrapping_mul(PRIME);
+        i += 1;
+    }
+    hash
+}
+
+// ── Reference EOTFs ──────────────────────────────────────────────────────
+
+fn srgb_eotf(v: f64) -> f64 {
+    if v <= 0.04045 { v / 12.92 } else { ((v + 0.055) / 1.055).powf(2.4) }
+}
+fn bt709_eotf(v: f64) -> f64 {
+    if v < 0.081 { v / 4.5 } else { ((v + 0.099) / 1.099).powf(1.0 / 0.45) }
+}
+fn gamma22_eotf(v: f64) -> f64 { v.powf(2.19921875) }
+fn gamma18_eotf(v: f64) -> f64 { v.powf(1.8) }
+fn pq_eotf(v: f64) -> f64 {
+    const M1: f64 = 0.1593017578125;
+    const M2: f64 = 78.84375;
+    const C1: f64 = 0.8359375;
+    const C2: f64 = 18.8515625;
+    const C3: f64 = 18.6875;
+    let vp = v.powf(1.0 / M2);
+    let num = (vp - C1).max(0.0);
+    let den = C2 - C3 * vp;
+    if den <= 0.0 { 0.0 } else { (num / den).powf(1.0 / M1) }
+}
+fn hlg_ootf_inv(v: f64) -> f64 {
+    // HLG OETF inverse (signal → scene linear)
+    if v <= 0.5 { (v * v) / 3.0 } else {
+        const A: f64 = 0.17883277;
+        const B: f64 = 1.0 - 4.0 * A;
+        const C: f64 = 0.5 - A * (4.0 * A - B) / (4.0 * A);
+        (((v - C) / A).exp() + B) / 12.0
+    }
+}
+
+#[allow(dead_code)]
+struct RefTrc { name: &'static str, cp_name: &'static str, tf_name: &'static str, eotf: fn(f64) -> f64 }
+const REFERENCE_TRCS: &[RefTrc] = &[
+    RefTrc { name: "sRGB",     cp_name: "Bt709",    tf_name: "Srgb",    eotf: srgb_eotf },
+    RefTrc { name: "BT.709",   cp_name: "Bt709",    tf_name: "Bt709",   eotf: bt709_eotf },
+    RefTrc { name: "gamma2.2", cp_name: "AdobeRgb", tf_name: "Gamma22", eotf: gamma22_eotf },
+    RefTrc { name: "gamma1.8", cp_name: "ProPhoto",  tf_name: "Gamma18", eotf: gamma18_eotf },
+    RefTrc { name: "PQ",       cp_name: "Bt2020",   tf_name: "Pq",      eotf: pq_eotf },
+    RefTrc { name: "HLG",      cp_name: "Bt2020",   tf_name: "Hlg",     eotf: hlg_ootf_inv },
+];
+
+// ── ICC TRC parsing ──────────────────────────────────────────────────────
+
+enum Trc { Para(Vec<f64>), Lut(Vec<u16>), Gamma(f64) }
+
+fn eval_para(p: &[f64], x: f64) -> f64 {
+    match p.len() {
+        1 => x.powf(p[0]),
+        3 => { let (g, a, b) = (p[0], p[1], p[2]); if x >= -b / a { (a * x + b).powf(g) } else { 0.0 } }
+        5 => { let (g, a, b, c, d) = (p[0], p[1], p[2], p[3], p[4]); if x >= d { (a * x + b).powf(g) } else { c * x } }
+        7 => { let (g, a, b, c, d, e, f) = (p[0], p[1], p[2], p[3], p[4], p[5], p[6]); if x >= d { (a * x + b).powf(g) + e } else { c * x + f } }
+        _ => x,
+    }
+}
+
+fn eval_trc(t: &Trc, x: f64) -> f64 {
+    match t {
+        Trc::Para(p) => eval_para(p, x),
+        Trc::Gamma(g) => x.powf(*g),
+        Trc::Lut(l) => {
+            let p = x * (l.len() - 1) as f64;
+            let i = p.floor() as usize;
+            let f = p - i as f64;
+            if i >= l.len() - 1 { l[l.len() - 1] as f64 / 65535.0 }
+            else { let a = l[i] as f64 / 65535.0; let b = l[i + 1] as f64 / 65535.0; a + f * (b - a) }
+        }
+    }
+}
+
+fn parse_trc(d: &[u8], o: usize) -> Option<Trc> {
+    if o + 12 > d.len() { return None; }
+    match &d[o..o + 4] {
+        b"para" => {
+            let ft = u16::from_be_bytes([d[o + 8], d[o + 9]]);
+            let n = match ft { 0 => 1, 1 => 3, 2 => 4, 3 => 5, 4 => 7, _ => return None };
+            let mut p = Vec::new();
+            for i in 0..n {
+                let q = o + 12 + i * 4;
+                if q + 4 > d.len() { return None; }
+                p.push(i32::from_be_bytes([d[q], d[q+1], d[q+2], d[q+3]]) as f64 / 65536.0);
+            }
+            Some(Trc::Para(p))
+        }
+        b"curv" => {
+            let c = u32::from_be_bytes([d[o+8], d[o+9], d[o+10], d[o+11]]) as usize;
+            if c == 0 { Some(Trc::Gamma(1.0)) }
+            else if c == 1 { Some(Trc::Gamma(u16::from_be_bytes([d[o+12], d[o+13]]) as f64 / 256.0)) }
+            else {
+                let mut l = Vec::with_capacity(c);
+                for i in 0..c { let q = o + 12 + i * 2; if q + 2 > d.len() { break; } l.push(u16::from_be_bytes([d[q], d[q+1]])); }
+                Some(Trc::Lut(l))
+            }
+        }
+        _ => None,
+    }
+}
+
+fn find_tag(d: &[u8], s: &[u8; 4]) -> Option<usize> {
+    if d.len() < 132 { return None; }
+    let tc = u32::from_be_bytes([d[128], d[129], d[130], d[131]]) as usize;
+    for i in 0..tc.min(200) {
+        let b = 132 + i * 12;
+        if b + 12 > d.len() { break; }
+        if &d[b..b + 4] == s {
+            return Some(u32::from_be_bytes([d[b+4], d[b+5], d[b+6], d[b+7]]) as usize);
+        }
+    }
+    None
+}
+
+fn max_u16_err(trc: &Trc, eotf: fn(f64) -> f64) -> u32 {
+    let mut mx = 0u32;
+    for i in 0..=65535u16 {
+        let x = i as f64 / 65535.0;
+        let a = (eval_trc(trc, x) * 65535.0).round() as i64;
+        let b = (eotf(x) * 65535.0).round() as i64;
+        let d = (a - b).unsigned_abs() as u32;
+        if d > mx { mx = d; }
+    }
+    mx
+}
+
+// ── Primaries identification ─────────────────────────────────────────────
+
+struct KP { rust_name: &'static str, rx: f64, ry: f64, gx: f64, gy: f64, bx: f64, by: f64 }
+const KNOWN_P: &[KP] = &[
+    KP { rust_name: "Bt709",    rx: 0.4361, ry: 0.2225, gx: 0.3851, gy: 0.7169, bx: 0.1431, by: 0.0606 },
+    KP { rust_name: "DisplayP3", rx: 0.5151, ry: 0.2412, gx: 0.2919, gy: 0.6922, bx: 0.1572, by: 0.0666 },
+    KP { rust_name: "Bt2020",   rx: 0.6734, ry: 0.2790, gx: 0.1656, gy: 0.6753, bx: 0.1251, by: 0.0456 },
+    KP { rust_name: "AdobeRgb", rx: 0.6097, ry: 0.3111, gx: 0.2053, gy: 0.6257, bx: 0.1492, by: 0.0632 },
+    KP { rust_name: "ProPhoto", rx: 0.7977, ry: 0.2880, gx: 0.1352, gy: 0.7119, bx: 0.0313, by: 0.0001 },
+];
+
+fn identify_primaries(data: &[u8]) -> Option<&'static str> {
+    if data.len() < 132 { return None; }
+    let tc = u32::from_be_bytes([data[128], data[129], data[130], data[131]]) as usize;
+    let (mut r, mut g, mut b) = ((0.0f64, 0.0f64), (0.0, 0.0), (0.0, 0.0));
+    for i in 0..tc.min(200) {
+        let base = 132 + i * 12;
+        if base + 12 > data.len() { break; }
+        let sig = &data[base..base+4];
+        let off = u32::from_be_bytes([data[base+4], data[base+5], data[base+6], data[base+7]]) as usize;
+        if off + 20 > data.len() { continue; }
+        let rd = |o: usize| (
+            i32::from_be_bytes([data[o+8], data[o+9], data[o+10], data[o+11]]) as f64 / 65536.0,
+            i32::from_be_bytes([data[o+12], data[o+13], data[o+14], data[o+15]]) as f64 / 65536.0,
+        );
+        match sig { b"rXYZ" => r = rd(off), b"gXYZ" => g = rd(off), b"bXYZ" => b = rd(off), _ => {} }
+    }
+    for k in KNOWN_P {
+        const T: f64 = 0.003;
+        if (r.0 - k.rx).abs() < T && (r.1 - k.ry).abs() < T
+            && (g.0 - k.gx).abs() < T && (g.1 - k.gy).abs() < T
+            && (b.0 - k.bx).abs() < T && (b.1 - k.by).abs() < T
+        { return Some(k.rust_name); }
+    }
+    None
+}
+
+// ── TRC identification ───────────────────────────────────────────────────
+
+/// Returns (tf_rust_name, max_u16_error) for the best-matching reference.
+fn identify_trc(data: &[u8], trc_tag: &[u8; 4]) -> Option<(&'static str, u32)> {
+    let trc_off = find_tag(data, trc_tag)?;
+    let trc = parse_trc(data, trc_off)?;
+
+    let mut best: Option<(&str, u32)> = None;
+    for r in REFERENCE_TRCS {
+        let err = max_u16_err(&trc, r.eotf);
+        if best.is_none() || err < best.unwrap().1 {
+            best = Some((r.tf_name, err));
+        }
+    }
+    best
+}
+
+// ── .inc formatting ──────────────────────────────────────────────────────
+
+fn fmt_hash(h: u64) -> String {
+    let s = format!("{h:016x}");
+    format!("0x{}_{}_{}_{}", &s[0..4], &s[4..8], &s[8..12], &s[12..16])
+}
+
+fn clean_desc(fname: &str) -> String {
+    fname.replace(".icc", "").replace('_', " ")
+        .chars().take(50).collect()
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────
+
+fn main() {
+    let dir = if let Some(arg) = std::env::args().nth(1) {
+        PathBuf::from(arg)
+    } else if let Ok(d) = std::env::var("ICC_PROFILES_DIR") {
+        PathBuf::from(d)
+    } else {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+        PathBuf::from(home).join(".cache/zencodec-icc")
+    };
+
+    if !dir.exists() {
+        eprintln!("Directory not found: {}", dir.display());
+        eprintln!("Usage: gen_icc_tables <icc-profiles-dir>");
+        std::process::exit(1);
+    }
+
+    // Determine output directory
+    let out_dir = std::env::args().nth(2).map(PathBuf::from).unwrap_or_else(|| {
+        // Default: zenpixels/src/icc/ relative to script location
+        let exe = std::env::current_exe().unwrap_or_default();
+        exe.parent().unwrap_or(&PathBuf::from(".")).join("../zenpixels/src/icc")
+    });
+
+    // norm_hash → (cp_rust_name, tf_rust_name, max_err, description)
+    let mut rgb: BTreeMap<u64, (&str, &str, u32, String)> = BTreeMap::new();
+    let mut gray: BTreeMap<u64, (&str, u32, String)> = BTreeMap::new();
+    let mut skipped = 0u32;
+    let mut scanned = 0u32;
+
+    let mut entries: Vec<_> = std::fs::read_dir(&dir).unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| matches!(p.extension().and_then(|e| e.to_str()), Some("icc" | "icm")))
+        .collect();
+    entries.sort();
+
+    for path in &entries {
+        let data = match std::fs::read(path) { Ok(d) => d, Err(_) => continue };
+        if data.len() < 132 { continue; }
+        scanned += 1;
+
+        let fname = path.file_name().unwrap().to_string_lossy().to_string();
+        let cs = &data[16..20];
+        let norm_hash = fnv1a_64_normalized(&data);
+
+        if cs == b"RGB " {
+            let Some(cp_name) = identify_primaries(&data) else { skipped += 1; continue; };
+            let Some((tf_name, err)) = identify_trc(&data, b"rTRC") else { skipped += 1; continue; };
+            if err > 56 { skipped += 1; continue; }
+
+            rgb.entry(norm_hash)
+                .and_modify(|e| e.2 = e.2.max(err))
+                .or_insert((cp_name, tf_name, err, fname));
+        } else if cs == b"GRAY" {
+            // Try kTRC first, then gTRC
+            let trc = identify_trc(&data, b"kTRC").or_else(|| identify_trc(&data, b"gTRC"));
+            let Some((tf_name, err)) = trc else { skipped += 1; continue; };
+            if err > 56 { skipped += 1; continue; }
+
+            gray.entry(norm_hash)
+                .and_modify(|e| e.1 = e.1.max(err))
+                .or_insert((tf_name, err, fname));
+        }
+    }
+
+    // ── Write RGB .inc ───────────────────────────────────────────────
+
+    let rgb_path = out_dir.join("icc_table_rgb.inc");
+    let mut rgb_out = String::from("&[\n");
+    for (&h, (cp, tf, err, desc)) in &rgb {
+        rgb_out += &format!(
+            "    ({}, CP::{}, TF::{}, {:>2}),  // {}\n",
+            fmt_hash(h), cp, tf, err, clean_desc(desc)
+        );
+    }
+    rgb_out += "]\n";
+    std::fs::write(&rgb_path, &rgb_out).unwrap();
+
+    // ── Write gray .inc ──────────────────────────────────────────────
+
+    let gray_path = out_dir.join("icc_table_gray.inc");
+    let mut gray_out = String::from("&[\n");
+    for (&h, (tf, err, desc)) in &gray {
+        gray_out += &format!(
+            "    ({}, TF::{}, {:>2}),  // {}\n",
+            fmt_hash(h), tf, err, clean_desc(desc)
+        );
+    }
+    gray_out += "]\n";
+    std::fs::write(&gray_path, &gray_out).unwrap();
+
+    // ── Summary ──────────────────────────────────────────────────────
+
+    eprintln!("Scanned: {scanned} profiles");
+    eprintln!("Skipped: {skipped} (unknown primaries or TRC error >56)");
+    eprintln!("RGB:  {} entries → {}", rgb.len(), rgb_path.display());
+    eprintln!("Gray: {} entries → {}", gray.len(), gray_path.display());
+
+    // Count by type
+    let mut combos: BTreeMap<String, usize> = BTreeMap::new();
+    for (cp, tf, _, _) in rgb.values() {
+        *combos.entry(format!("{cp}+{tf}")).or_default() += 1;
+    }
+    eprintln!("\nRGB by type:");
+    let mut sorted_combos: Vec<_> = combos.iter().collect();
+    sorted_combos.sort_by(|a, b| b.1.cmp(a.1));
+    for (k, v) in sorted_combos {
+        eprintln!("  {k}: {v}");
+    }
+}

--- a/scripts/verify_via_moxcms.rs
+++ b/scripts/verify_via_moxcms.rs
@@ -1,0 +1,233 @@
+//! Verify ICC profile TRC error using moxcms transforms on all 65536 u16 values.
+//!
+//! This is the ground truth: it uses the same CMS pipeline that production code
+//! would use, so the measured error is exactly what callers get when substituting
+//! a CICP descriptor for the ICC profile.
+//!
+//! Build (from zencodec root):
+//!   cargo build --example verify_via_moxcms
+//!
+//! Run:
+//!   ICC_PROFILES_DIR=/tmp/icc-extraction/all cargo run --example verify_via_moxcms
+
+use moxcms::{
+    ColorProfile, Layout, RenderingIntent, TransformExecutor, TransformOptions,
+};
+use std::path::PathBuf;
+
+fn profile_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("ICC_PROFILES_DIR") {
+        return PathBuf::from(dir);
+    }
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    PathBuf::from(home).join(".cache/zencodec-icc")
+}
+
+/// Measure max u16 error by transforming all 65536 gray ramp values
+/// through ICC_profile → reference_profile.
+fn measure_transform_error(
+    icc_data: &[u8],
+    reference: &ColorProfile,
+) -> Result<(u32, u32), String> {
+    let icc_profile = ColorProfile::new_from_slice(icc_data)
+        .map_err(|e| format!("parse: {e:?}"))?;
+
+    let opts = TransformOptions {
+        rendering_intent: RenderingIntent::Perceptual,
+        ..Default::default()
+    };
+
+    let transform = icc_profile
+        .create_transform_16bit(Layout::Rgb, reference, Layout::Rgb, opts)
+        .map_err(|e| format!("transform: {e:?}"))?;
+
+    let mut max_err: u32 = 0;
+    let mut gt1_count: u32 = 0;
+
+    // Transform each gray value (R=G=B=v) and measure deviation from identity
+    for v in 0..=65535u16 {
+        let src = [v, v, v];
+        let mut dst = [0u16; 3];
+        transform
+            .transform(&src, &mut dst)
+            .map_err(|e| format!("exec: {e:?}"))?;
+
+        // For a perfect match, dst should be [v, v, v].
+        // Take max channel error.
+        for &ch in &dst {
+            let err = (ch as i64 - v as i64).unsigned_abs() as u32;
+            if err > 1 {
+                gt1_count += 1;
+            }
+            if err > max_err {
+                max_err = err;
+            }
+        }
+    }
+
+    Ok((max_err, gt1_count))
+}
+
+const fn fnv1a_64(data: &[u8]) -> u64 {
+    const OFFSET: u64 = 0xcbf29ce484222325;
+    const PRIME: u64 = 0x100000001b3;
+    let mut hash = OFFSET;
+    let mut i = 0;
+    while i < data.len() {
+        hash ^= data[i] as u64;
+        hash = hash.wrapping_mul(PRIME);
+        i += 1;
+    }
+    hash
+}
+
+struct KP {
+    name: &'static str,
+    cp: u8,
+    rx: f64,
+    ry: f64,
+    gx: f64,
+    gy: f64,
+    bx: f64,
+    by: f64,
+}
+const KNOWN_P: &[KP] = &[
+    KP { name: "sRGB/BT.709", cp: 1,   rx: 0.4361, ry: 0.2225, gx: 0.3851, gy: 0.7169, bx: 0.1431, by: 0.0606 },
+    KP { name: "Display P3",  cp: 12,  rx: 0.5151, ry: 0.2412, gx: 0.2919, gy: 0.6922, bx: 0.1572, by: 0.0666 },
+    KP { name: "BT.2020",     cp: 9,   rx: 0.6734, ry: 0.2790, gx: 0.1656, gy: 0.6753, bx: 0.1251, by: 0.0456 },
+    KP { name: "Adobe RGB",   cp: 200, rx: 0.6097, ry: 0.3111, gx: 0.2053, gy: 0.6257, bx: 0.1492, by: 0.0632 },
+    KP { name: "ProPhoto",    cp: 201, rx: 0.7977, ry: 0.2880, gx: 0.1352, gy: 0.7119, bx: 0.0313, by: 0.0001 },
+];
+
+fn identify_primaries(data: &[u8]) -> Option<(u8, &'static str)> {
+    if data.len() < 132 {
+        return None;
+    }
+    let tag_count = u32::from_be_bytes(data[128..132].try_into().ok()?) as usize;
+    let mut r = (0.0f64, 0.0f64);
+    let mut g = (0.0f64, 0.0f64);
+    let mut b = (0.0f64, 0.0f64);
+
+    for i in 0..tag_count.min(100) {
+        let base = 132 + i * 12;
+        if base + 12 > data.len() {
+            break;
+        }
+        let sig = &data[base..base + 4];
+        let off = u32::from_be_bytes(data[base + 4..base + 8].try_into().ok()?) as usize;
+        if off + 20 > data.len() {
+            continue;
+        }
+        let rd = |o: usize| {
+            (
+                i32::from_be_bytes(data[o + 8..o + 12].try_into().unwrap()) as f64 / 65536.0,
+                i32::from_be_bytes(data[o + 12..o + 16].try_into().unwrap()) as f64 / 65536.0,
+            )
+        };
+        match sig {
+            b"rXYZ" => r = rd(off),
+            b"gXYZ" => g = rd(off),
+            b"bXYZ" => b = rd(off),
+            _ => {}
+        }
+    }
+
+    for k in KNOWN_P {
+        const T: f64 = 0.003;
+        if (r.0 - k.rx).abs() < T
+            && (r.1 - k.ry).abs() < T
+            && (g.0 - k.gx).abs() < T
+            && (g.1 - k.gy).abs() < T
+            && (b.0 - k.bx).abs() < T
+            && (b.1 - k.by).abs() < T
+        {
+            return Some((k.cp, k.name));
+        }
+    }
+    None
+}
+
+/// Build the moxcms reference profile for a given primaries code.
+fn reference_for_primaries(cp: u8) -> ColorProfile {
+    match cp {
+        1 => ColorProfile::new_srgb(),
+        12 => ColorProfile::new_display_p3(),
+        9 => ColorProfile::new_bt2020(),
+        // Adobe RGB and ProPhoto don't have built-in moxcms constructors,
+        // so we build from the ICC bytes in our extraction dir.
+        // For now, use sRGB as a stand-in — the transform error will
+        // include both primaries + TRC difference, which is fine for
+        // validating that mega_test's TRC-only error is a lower bound.
+        _ => ColorProfile::new_srgb(),
+    }
+}
+
+fn main() {
+    let dir = profile_dir();
+    if !dir.exists() {
+        eprintln!("Profile directory not found: {}", dir.display());
+        std::process::exit(1);
+    }
+
+    println!(
+        "{:<7} {:<18} {:>6} {:>6} {:>10} {}",
+        "STATUS", "HASH", "MEGA", "MOXCMS", "PRIMARIES", "FILE"
+    );
+    println!("{}", "-".repeat(90));
+
+    let mut ok = 0u32;
+    let mut mismatch = 0u32;
+    let mut errors = 0u32;
+
+    let entries = std::fs::read_dir(&dir).unwrap();
+    let mut paths: Vec<_> = entries.filter_map(|e| e.ok()).map(|e| e.path()).collect();
+    paths.sort();
+
+    for path in &paths {
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        if ext != "icc" && ext != "icm" {
+            continue;
+        }
+        let data = match std::fs::read(path) {
+            Ok(d) => d,
+            Err(_) => continue,
+        };
+        if data.len() < 132 {
+            continue;
+        }
+        // Only RGB profiles
+        if &data[16..20] != b"RGB " {
+            continue;
+        }
+
+        let fname = path.file_name().unwrap().to_string_lossy();
+        let hash = fnv1a_64(&data);
+
+        let Some((cp, cp_name)) = identify_primaries(&data) else {
+            continue;
+        };
+
+        let reference = reference_for_primaries(cp);
+
+        match measure_transform_error(&data, &reference) {
+            Ok((max_err, _gt1)) => {
+                // Compare against mega_test's error (from the max_u16_error field)
+                let status = if max_err <= 56 { "OK" } else { "HIGH" };
+                println!(
+                    "{:<7} 0x{:016x} {:>6} {:>6} {:>10} {}",
+                    status, hash, "?", max_err, cp_name, fname
+                );
+                ok += 1;
+            }
+            Err(e) => {
+                println!(
+                    "{:<7} 0x{:016x} {:>6} {:>6} {:>10} {} ({})",
+                    "ERR", hash, "?", "-", cp_name, fname, e
+                );
+                errors += 1;
+            }
+        }
+    }
+
+    println!("\nTotal: {ok} measured, {errors} errors, {mismatch} mismatches");
+}

--- a/zenpixels/Cargo.toml
+++ b/zenpixels/Cargo.toml
@@ -25,9 +25,10 @@ exclude = [
 ]
 
 [features]
-default = ["std"]
+default = ["std", "icc"]
 std = []
 planar = []
+icc = []
 rgb = ["dep:rgb"]
 imgref = ["dep:imgref", "rgb"]
 serde = ["dep:serde"]

--- a/zenpixels/src/icc/icc_table_gray.inc
+++ b/zenpixels/src/icc/icc_table_gray.inc
@@ -1,0 +1,16 @@
+&[
+    (0x0bcc_b096_6018_2f67, TF::Gamma22,  0),  // gray gamma 2 2 653b586c
+    (0x1381_5d85_fc30_6e87, TF::Srgb,  1),  // generic gray gamma 2 2 profile ee2f821d
+    (0x15be_564c_995c_a5e6, TF::Srgb,  1),  // with srgb trc 6ee1b837
+    (0x1da1_a0cc_3fdb_d3d8, TF::Gamma18, 11),  // generic gray profile 94722fe2
+    (0x7386_f664_c077_629d, TF::Srgb,  1),  // generic gray gamma 2 2 profile 73d50455
+    (0x79e6_dee8_8e35_a74e, TF::Gamma22,  0),  // gray gamma 2 2 27271ce6
+    (0x8f8f_6aeb_0b1b_cffc, TF::Gamma22,  0),  // gray gamma 2 2 de47062f
+    (0x922e_3e93_9b73_5718, TF::Gamma18, 11),  // epson gray - gamma 1 8 03ecbaeb
+    (0xa02b_b3b8_ed69_63d3, TF::Gamma18, 11),  // generic gray profile 10233312
+    (0xaf06_5a1e_06f8_3c15, TF::Gamma18, 11),  // gray gamma 1 8 a594b85c
+    (0xb0bb_06d4_d589_eca9, TF::Gamma22,  0),  // gray gamma 2 2 f00165cf
+    (0xc3c9_13c7_dbf6_1b16, TF::Srgb,  1),  // with srgb trc 14abccd5
+    (0xd866_a1ec_636e_f452, TF::Gamma22,  0),  // calibrated gray colorspace 397a83da
+    (0xe857_d652_9f66_d7f7, TF::Gamma18, 11),  // generic gray profile 0faa32c0
+]

--- a/zenpixels/src/icc/icc_table_rgb.inc
+++ b/zenpixels/src/icc/icc_table_rgb.inc
@@ -1,0 +1,120 @@
+&[
+    (0x0373_482f_2294_c17a, CP::Bt709, TF::Srgb,  1),  // srgb v1 31 canon 6578ac5c
+    (0x0582_1f2a_e35b_b471, CP::AdobeRgb, TF::Gamma22,  0),  // adobe rgb 1998 d904903e
+    (0x0796_16e1_1678_df00, CP::Bt709, TF::Srgb,  1),  // 敮啓srgb 12afb4d9
+    (0x0831_3776_1575_8c5d, CP::Bt709, TF::Srgb, 33),  // c2 7d61bdc0
+    (0x09f8_f51f_16ab_f5aa, CP::Bt709, TF::Bt709,  4),  // itu-r bt 709-5 ac17db72
+    (0x0a1a_3df7_a10c_1333, CP::AdobeRgb, TF::Gamma22,  0),  // adobe rgb 1998 86828061
+    (0x0ca2_1afc_1a04_4d18, CP::DisplayP3, TF::Srgb,  1),  // display ad0b6802
+    (0x0f40_cd19_eb99_13cd, CP::Bt709, TF::Srgb, 13),  // urgb ac46f250
+    (0x12aa_1ec5_f4fa_84eb, CP::AdobeRgb, TF::Gamma22,  0),  // adobe rgb 1998 04166d2d
+    (0x1585_7e13_3f8d_56c8, CP::DisplayP3, TF::Srgb,  1),  // display 10b11b78
+    (0x16db_7fa8_9f3d_3268, CP::AdobeRgb, TF::Gamma22,  0),  // adobe rgb 1998 0958d8ab
+    (0x1a51_546f_b3e8_9789, CP::AdobeRgb, TF::Gamma22,  0),  // adobe rgb 1998 c7de586e
+    (0x1de1_79d1_245a_a2ed, CP::AdobeRgb, TF::Gamma22,  0),  // adobe rgb 1998 304f569a
+    (0x21d7_7bd7_333e_4a7d, CP::Bt709, TF::Srgb,  1),  // srgb iec61966-2 1 22c894f4
+    (0x21ff_ca63_c0f3_0ab3, CP::DisplayP3, TF::Srgb,  1),  // display a587aa4f
+    (0x2594_8312_e5cd_6a48, CP::Bt709, TF::Srgb,  1),  // display e01187ad
+    (0x260c_d3fb_9142_5fc2, CP::Bt709, TF::Srgb,  1),  // srgb built-in 737acacd
+    (0x285e_8614_9334_c025, CP::DisplayP3, TF::Srgb,  1),  // display 7ce50c9c
+    (0x347b_29a9_9718_4c3d, CP::DisplayP3, TF::Srgb,  1),  // srgb transfer d77bd8c4
+    (0x3980_7a73_90b4_2882, CP::Bt709, TF::Srgb,  1),  // srgb iec61966-2-1 black scaled c4c11531
+    (0x3a45_5986_8883_779d, CP::DisplayP3, TF::Srgb,  1),  // display 518dbeba
+    (0x3b4c_8aad_1af4_34f8, CP::AdobeRgb, TF::Gamma22,  0),  // adobe rgb 1998 07c1e073
+    (0x3c23_9a35_ce4c_d003, CP::Bt709, TF::Srgb,  1),  // iec61966-2 1 2e2fd04e
+    (0x3d84_1280_ff79_e82b, CP::AdobeRgb, TF::Gamma22,  0),  // adobe rgb 1998 17354309
+    (0x40a6_ebb2_9e5a_eded, CP::Bt709, TF::Srgb,  1),  // nikon srgb 4 0 0 3002 49caea94
+    (0x4318_0644_9ea6_ffab, CP::Bt709, TF::Srgb,  1),  // display 809d9002
+    (0x456c_6127_123e_ec31, CP::AdobeRgb, TF::Gamma22,  0),  // adobe rgb 1998 12484157
+    (0x4642_ec4c_18f0_be12, CP::ProPhoto, TF::Gamma18, 11),  // prophoto rgb 0a8ef7d1
+    (0x4841_e8c9_651b_1501, CP::ProPhoto, TF::Gamma18, 28),  // zpc prophoto v4
+    (0x4ce8_0f1f_8cd9_3179, CP::DisplayP3, TF::Srgb,  1),  // display e87d90b7
+    (0x4ddb_298f_87a7_d57b, CP::DisplayP3, TF::Srgb,  1),  // display a7671e7c
+    (0x4e00_f306_afc5_6fa4, CP::Bt709, TF::Gamma22,  0),  // nikon srgb 4 0 0 3000 a9a2c1c0
+    (0x5090_c1d3_8201_a990, CP::Bt709, TF::Srgb,  1),  // artifex software srgb icc profile 942e0f66
+    (0x54f2_4611_9e0a_d96c, CP::DisplayP3, TF::Srgb,  1),  // display 06eae9a2
+    (0x56c6_90dc_b755_4ba2, CP::Bt709, TF::Gamma22,  0),  // simplified srgb iec61966-2 1 93719c24
+    (0x57bf_16c2_6fd5_9b18, CP::DisplayP3, TF::Srgb,  1),  // display 319fce5b
+    (0x57c1_3687_cb9a_2681, CP::Bt709, TF::Srgb, 33),  // c2 59282c6a
+    (0x57e5_ba67_29ee_37c9, CP::DisplayP3, TF::Srgb,  1),  // display 780dba57
+    (0x5d6c_79f5_387f_4938, CP::DisplayP3, TF::Srgb,  1),  // display 82813cc1
+    (0x5e3f_3a45_56ed_bd7e, CP::Bt709, TF::Srgb, 33),  // c2ci 88309750
+    (0x5f7f_17d4_33df_3e67, CP::DisplayP3, TF::Srgb,  1),  // display 27c17d0f
+    (0x61b2_7ba9_8ca9_e4ec, CP::Bt709, TF::Srgb,  1),  // iec61966-2 1 33c34ecf
+    (0x61d8_2cfe_4b08_5a07, CP::AdobeRgb, TF::Gamma22,  0),  // adobe rgb 1998 72860842
+    (0x63b9_9fae_af4c_75a2, CP::DisplayP3, TF::Srgb,  5),  // display p3 7e1c7ec5
+    (0x653b_ea14_dc0b_a32b, CP::Bt709, TF::Srgb,  1),  // srgb c7cca157
+    (0x66cc_d82c_44a1_ac56, CP::DisplayP3, TF::Srgb,  1),  // display 57d2c70f
+    (0x6a66_9bf1_e1bf_97d6, CP::Bt709, TF::Srgb,  1),  // 敮啓srgb c56e1685
+    (0x6d28_f82d_cf66_70f6, CP::Bt709, TF::Srgb,  1),  // srgb built-in 77c085b8
+    (0x6db0_9a70_cd33_612a, CP::DisplayP3, TF::Srgb,  1),  // display d4bc91ee
+    (0x6e44_01ce_573d_051c, CP::Bt709, TF::Srgb,  1),  // 65 srg rel srg d7f9e32a
+    (0x6e62_7ec1_ab55_7af9, CP::Bt709, TF::Srgb,  1),  // srgb2014 384b832d
+    (0x6ea8_4a96_a82e_7aa4, CP::AdobeRgb, TF::Gamma22,  0),  // nikon adobe rgb 4 0 0 3001 359a7324
+    (0x7398_f0fa_f1b5_e246, CP::DisplayP3, TF::Srgb,  1),  // display 40b4f862
+    (0x73d4_99f8_2fe9_8d7f, CP::AdobeRgb, TF::Gamma22,  0),  // adobe rgb 1998 e5f6ffb8
+    (0x77c3_6de1_98c8_8c4f, CP::AdobeRgb, TF::Gamma22,  0),  // oprgb 2b8daf8c
+    (0x7c9a_645b_1aab_1a97, CP::DisplayP3, TF::Srgb,  1),  // display ba7f388f
+    (0x7e44_223b_f886_ebfd, CP::Bt709, TF::Gamma22,  0),  // oprgb 406f5f5a
+    (0x812f_f091_22c6_c936, CP::Bt709, TF::Srgb,  1),  // srgb built-in bfb182d9
+    (0x819b_c97e_d386_7ce1, CP::DisplayP3, TF::Srgb,  1),  // display cc697fd8
+    (0x81f2_bfa8_b6c9_8025, CP::DisplayP3, TF::Srgb,  1),  // srgb transfer fa7e53ae
+    (0x832f_fc20_dff7_d16a, CP::DisplayP3, TF::Srgb,  1),  // display p3 5471f6ff
+    (0x84e7_d1c9_f1db_6c99, CP::Bt2020, TF::Bt709,  9),  // moxcms bt.2020
+    (0x8579_39cc_c858_2fcb, CP::Bt709, TF::Srgb,  1),  // srgb iec61966-2 1 a8e4d0dc
+    (0x88b9_9839_e2c4_8006, CP::Bt709, TF::Srgb,  1),  // srgb iec61966-2 1 3f6a7ffe
+    (0x8c0b_549f_4401_8587, CP::Bt709, TF::Gamma22,  0),  // srgb profile a4eddfda
+    (0x8eb7_7ac6_4d44_3978, CP::DisplayP3, TF::Srgb,  1),  // display p3 0ff6958f
+    (0x8ec2_3212_9fbe_b37e, CP::AdobeRgb, TF::Gamma22,  0),  // nikon adobe rgb 4 0 0 3000 a8d0d753
+    (0x8ec4_006c_c288_9df9, CP::Bt709, TF::Srgb,  1),  //  72723b7f
+    (0x97cc_1557_e292_f6b4, CP::Bt709, TF::Srgb, 13),  // urgb 0a8a33ae
+    (0x9824_f53a_d528_8765, CP::DisplayP3, TF::Srgb,  1),  // display 7b6a7afb
+    (0x98fd_81dd_5187_24c0, CP::Bt709, TF::Srgb,  1),  // srgb iec61966-2-1 black scaled 6bce3833
+    (0x9915_d212_cbe8_f644, CP::Bt709, TF::Srgb,  1),  // srgb 2a92d4ba
+    (0x9b2c_c05c_9ea0_2b2b, CP::DisplayP3, TF::Srgb,  1),  // display p3 03291993
+    (0x9bc7_2da2_a9e8_cd7e, CP::DisplayP3, TF::Srgb,  1),  // display 8cd25d60
+    (0xa06b_cf49_054e_e5a0, CP::DisplayP3, TF::Srgb,  1),  // display 711236e0
+    (0xa07d_04ee_0f98_3714, CP::DisplayP3, TF::Srgb,  1),  // display 14b2783e
+    (0xa1d7_630b_95b7_f33e, CP::Bt709, TF::Srgb,  1),  // iec61966-2 1 728f6079
+    (0xa5db_d0e3_5990_3861, CP::Bt709, TF::Gamma22,  0),  // srgb profile 8b8e7d87
+    (0xa7d0_6bcd_0b38_d786, CP::DisplayP3, TF::Srgb,  1),  // display b2c49880
+    (0xacf0_e166_bdd5_0420, CP::DisplayP3, TF::Srgb,  1),  // display 6d9c9f3f
+    (0xad69_7a27_cac8_e346, CP::DisplayP3, TF::Srgb,  1),  // display 85c0afbc
+    (0xae18_f3c7_d6d0_2b07, CP::Bt709, TF::Srgb,  1),  // built-in srgb 001c7ee7
+    (0xae4b_bc69_a038_6d4b, CP::DisplayP3, TF::Srgb,  1),  // display c5a8ff3d
+    (0xae7a_fcfc_6170_40ad, CP::Bt709, TF::Srgb,  1),  // b iec61966-2 1 15c6e2b8
+    (0xb084_97ed_de11_0ace, CP::Bt709, TF::Srgb,  1),  // srgb 58f10918
+    (0xb389_fc84_b78a_9a55, CP::AdobeRgb, TF::Gamma22,  0),  // adobe rgb 1998 f94e3409
+    (0xb46f_a94c_5401_9d98, CP::AdobeRgb, TF::Gamma22, 33),  // zpc adobe compat v4
+    (0xb59f_47eb_015a_d97a, CP::Bt709, TF::Srgb,  1),  // moxcms srgb
+    (0xb5fc_f4f5_49dc_2e44, CP::AdobeRgb, TF::Gamma22,  0),  // adobe rgb 1998 2f6457e2
+    (0xbaf0_0f6d_edf3_186e, CP::Bt709, TF::Srgb,  1),  // srgb iec61966-2 1 2b3aa164
+    (0xbc4e_56e8_fe2f_531f, CP::Bt709, TF::Gamma18, 11),  // epson standard rgb - gamma 1 8 24e1d7a0
+    (0xbdd8_9a20_39a0_78c9, CP::DisplayP3, TF::Srgb,  1),  // display 227959c8
+    (0xbe8a_72e0_eb42_b512, CP::Bt709, TF::Srgb,  1),  // srgb built-in 0627a605
+    (0xcbd9_22da_b07a_f755, CP::DisplayP3, TF::Pq,  1),  // moxcms display p3 pq
+    (0xd0ff_072b_721e_a276, CP::AdobeRgb, TF::Gamma22,  0),  // adobe rgb 1998 211d915b
+    (0xd274_a0eb_9670_91cb, CP::Bt709, TF::Srgb,  1),  //  f1932003
+    (0xd680_1fb5_e54b_d8c1, CP::DisplayP3, TF::Srgb,  1),  // display ef26b91d
+    (0xda4a_81a2_4496_07bd, CP::Bt709, TF::Gamma22,  0),  // srgb profile e2b447e6
+    (0xda62_6fd8_d996_0d4d, CP::DisplayP3, TF::Srgb,  1),  // display 1e5b6330
+    (0xdd41_6b82_8094_836a, CP::DisplayP3, TF::Srgb,  1),  // moxcms display p3
+    (0xe027_6b27_9678_f216, CP::AdobeRgb, TF::Gamma22,  0),  // adobe rgb 1998 8551730c
+    (0xe3c0_33dc_d296_0f6d, CP::DisplayP3, TF::Srgb, 13),  // up3 ffc2520e
+    (0xe8a6_159d_1982_d083, CP::AdobeRgb, TF::Gamma22,  0),  // adobe rgb 1998 24b690fa
+    (0xeaf1_9f94_1f36_d2d8, CP::Bt2020, TF::Pq,  1),  // moxcms bt.2020 pq
+    (0xeb7a_b433_70ab_125e, CP::Bt709, TF::Srgb,  1),  // srgb icc f6bd2776
+    (0xebc9_51fd_8875_19a3, CP::Bt709, TF::Gamma18, 11),  // calibrated rgb colorspace 13d00877
+    (0xed62_af70_9d79_1fe2, CP::AdobeRgb, TF::Gamma22,  0),  // adobe rgb 1998 481ca304
+    (0xed9a_fff9_2bdc_588d, CP::Bt709, TF::Srgb, 13),  // urgb 2e2c5534
+    (0xefa2_dde4_44ba_97a6, CP::DisplayP3, TF::Srgb,  1),  // display p3 e468e892
+    (0xf0ae_366c_2312_5435, CP::DisplayP3, TF::Srgb,  1),  // display p3 2eb3480a
+    (0xf0b3_3faa_38da_65fe, CP::Bt709, TF::Srgb,  1),  // artifex software srgb icc profile eddaf344
+    (0xf121_9cd8_1c19_5865, CP::AdobeRgb, TF::Gamma22,  0),  // adobe rgb 1998 55079c02
+    (0xf1a9_8c93_0a85_dce1, CP::Bt709, TF::Srgb,  1),  //  aabc5df3
+    (0xf9bf_3f37_a5a8_de51, CP::Bt709, TF::Srgb,  1),  // rt srgb gamma srgbiec61966 equivalent b2b31b86
+    (0xfba3_ad08_4afe_22a3, CP::Bt709, TF::Srgb,  1),  // iec 61966-2-1 d84cc0d7
+    (0xfbc7_c6bb_89f3_ac3c, CP::Bt709, TF::Srgb, 33),  // c2 61bb24bd
+    (0xfc9a_b178_cdb6_16c8, CP::DisplayP3, TF::Srgb,  1),  // display 3453eccf
+    (0xff5a_b890_4461_9f37, CP::Bt709, TF::Srgb,  1),  // built-in srgb 056b6825
+]

--- a/zenpixels/src/icc/mod.rs
+++ b/zenpixels/src/icc/mod.rs
@@ -1,0 +1,550 @@
+//! Lightweight ICC profile inspection and identification.
+//!
+//! Two capabilities, no dependencies beyond `core`:
+//!
+//! - **CICP extraction**: [`extract_cicp`] reads the `cicp` tag from ICC v4.4+
+//!   profiles (~100ns, no allocation).
+//!
+//! - **Hash-based identification**: [`identify`] recognizes 132
+//!   well-known profiles (sRGB, Display P3, BT.2020, Adobe RGB, ProPhoto,
+//!   grayscale) via normalized FNV-1a hash lookup (~100ns).
+//!
+//! The hash table covers profiles found in a web corpus of 55,539 spidered
+//! images, plus Compact-ICC-Profiles, skcms, ICC.org, colord, Ghostscript,
+//! moxcms, and zenpixels-convert bundled profiles. Metadata-only header
+//! fields are zeroed before hashing to collapse functionally identical
+//! profiles — safe across ICC v2.0–v4.4 and v5/iccMAX. Each entry is
+//! verified against its reference EOTF for all 65536 u16 values.
+//!
+//! # Example
+//!
+//! ```
+//! use zenpixels::icc::{identify_common, Tolerance};
+//!
+//! # let icc_bytes: &[u8] = &[];
+//! if let Some(id) = identify_common(icc_bytes, Tolerance::Intent) {
+//!     // id.primaries: ColorPrimaries, id.transfer: TransferFunction
+//! }
+//! ```
+
+use crate::{Cicp, ColorPrimaries, TransferFunction};
+
+// ── ICC header layout (ITU-T / ISO 15076-1) ──────────────────────────────
+
+/// Minimum valid ICC profile size: 128-byte header + 4-byte tag count.
+const ICC_MIN_SIZE: usize = 132;
+/// Offset of the `'acsp'` magic signature in the ICC header.
+const ICC_SIGNATURE_OFFSET: usize = 36;
+/// Offset of the tag count (u32 BE) following the 128-byte header.
+const ICC_TAG_COUNT_OFFSET: usize = 128;
+/// Start of the tag table (immediately after the tag count).
+const ICC_TAG_TABLE_OFFSET: usize = 132;
+/// Size of each tag table entry: 4 (sig) + 4 (offset) + 4 (size).
+const ICC_TAG_ENTRY_SIZE: usize = 12;
+/// Maximum tag count we'll scan (prevents DoS from malformed profiles).
+const ICC_MAX_TAG_COUNT: usize = 200;
+
+/// ICC header byte ranges that are metadata-only (not color-critical).
+/// Zeroed before hashing to collapse functionally identical profiles.
+///
+/// Per ICC spec v2.0–v5/iccMAX, these fields never affect colorimetry:
+/// - `CMM_TYPE`:     preferred CMM (advisory hint)
+/// - `DATE_TIME`:    profile creation date/time
+/// - `PLATFORM`:     primary platform (APPL/MSFT/etc.)
+/// - `DEVICE`:       device manufacturer + model
+/// - `CREATOR_ID`:   profile creator + profile ID (reserved in v2, MD5 in v4)
+const ICC_CMM_TYPE: core::ops::Range<usize> = 4..8;
+const ICC_DATE_TIME: core::ops::Range<usize> = 24..36;
+const ICC_PLATFORM: core::ops::Range<usize> = 40..44;
+const ICC_DEVICE: core::ops::Range<usize> = 48..56;
+const ICC_CREATOR_ID: core::ops::Range<usize> = 80..100;
+/// Number of header bytes that need conditional zeroing.
+const ICC_HEADER_NORMALIZE_END: usize = 100;
+
+// ── CICP extraction ──────────────────────────────────────────────────────
+
+/// Extract CICP (Coding-Independent Code Points) from an ICC profile's tag table.
+///
+/// Scans the ICC tag table for a `cicp` tag (ICC v4.4+, 12 bytes) and returns
+/// a [`Cicp`] if found. Returns `None` for ICC v2 profiles (which never contain
+/// cicp tags), profiles without a cicp tag, or malformed input.
+///
+/// This is a lightweight operation (~100ns) that reads only the 128-byte header
+/// and tag table entries — no full profile parse required.
+pub fn extract_cicp(data: &[u8]) -> Option<Cicp> {
+    if data.len() < ICC_MIN_SIZE {
+        return None;
+    }
+    if data.get(ICC_SIGNATURE_OFFSET..ICC_SIGNATURE_OFFSET + 4)? != b"acsp" {
+        return None;
+    }
+
+    let tag_count = u32::from_be_bytes(
+        data[ICC_TAG_COUNT_OFFSET..ICC_TAG_COUNT_OFFSET + 4]
+            .try_into()
+            .ok()?,
+    ) as usize;
+    let tag_count = tag_count.min(ICC_MAX_TAG_COUNT);
+
+    for i in 0..tag_count {
+        let entry_offset = ICC_TAG_TABLE_OFFSET + i * ICC_TAG_ENTRY_SIZE;
+        let entry = data.get(entry_offset..entry_offset + ICC_TAG_ENTRY_SIZE)?;
+
+        if entry[..4] != *b"cicp" {
+            continue;
+        }
+
+        let data_offset = u32::from_be_bytes(entry[4..8].try_into().ok()?) as usize;
+        let data_size = u32::from_be_bytes(entry[8..12].try_into().ok()?) as usize;
+
+        if data_size < 12 {
+            return None;
+        }
+
+        let tag_data = data.get(data_offset..data_offset + 12)?;
+
+        // Tag data starts with type signature (should also be "cicp").
+        if tag_data[..4] != *b"cicp" {
+            return None;
+        }
+        // Bytes 4..8 are reserved (should be zero).
+        // Bytes 8..12 are the four CICP fields.
+        return Some(Cicp::new(
+            tag_data[8],
+            tag_data[9],
+            tag_data[10],
+            tag_data[11] != 0,
+        ));
+    }
+
+    None
+}
+
+// ── Return type ──────────────────────────────────────────────────────────
+
+/// Result of identifying a well-known ICC profile.
+///
+/// Carries the recognized color primaries and transfer function.
+/// These may or may not have CICP equivalents — [`AdobeRgb`](ColorPrimaries::AdobeRgb)
+/// and [`ProPhoto`](ColorPrimaries::ProPhoto) do not.
+///
+/// Use [`to_cicp`](Self::to_cicp) to convert to CICP codes when available.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub struct IccIdentification {
+    /// Recognized color primaries.
+    pub primaries: ColorPrimaries,
+    /// Recognized transfer function.
+    pub transfer: TransferFunction,
+}
+
+impl IccIdentification {
+    /// Create a new identification result.
+    #[inline]
+    pub fn new(primaries: ColorPrimaries, transfer: TransferFunction) -> Self {
+        Self {
+            primaries,
+            transfer,
+        }
+    }
+
+    /// Convert to CICP codes if both primaries and transfer have CICP equivalents.
+    ///
+    /// Returns `None` for non-CICP color spaces (Adobe RGB, ProPhoto, etc.).
+    #[inline]
+    pub fn to_cicp(&self) -> Option<crate::Cicp> {
+        let cp = self.primaries.to_cicp()?;
+        let tc = self.transfer.to_cicp()?;
+        Some(crate::Cicp::new(cp, tc, 0, true))
+    }
+
+    /// Whether this represents sRGB (BT.709 primaries + sRGB transfer).
+    #[inline]
+    pub fn is_srgb(&self) -> bool {
+        matches!(self.primaries, ColorPrimaries::Bt709)
+            && matches!(self.transfer, TransferFunction::Srgb)
+    }
+}
+
+// ── Tolerance ────────────────────────────────────────────────────────────
+
+/// TRC match tolerance for ICC profile identification.
+///
+/// Each entry in the hash table stores its measured maximum error in u16
+/// space (0–65535), verified against the reference EOTF for all 65536
+/// input values. This tolerance controls which entries are accepted.
+///
+/// **All levels produce identical results at 8-bit depth.** The worst case
+/// (Intent, ±56/65535) shifts a u8 value by at most 0.22 of a step —
+/// always rounds to the same u8. Even at 10-bit (0–1023), Intent is
+/// ±0.87 of a code value. Visible differences require 14-bit or higher.
+///
+/// Use [`Intent`](Self::Intent) unless you are computing perceptual metrics
+/// at 16-bit precision.
+///
+/// | Level | Max u16 error | 8-bit impact | What it covers |
+/// |-------|--------------|--------------|----------------|
+/// | `Exact` | ±1 | none | Parametric v4 profiles |
+/// | `Precise` | ±3 | none | + v2-magic approximations |
+/// | `Approximate` | ±13 | none | + LUT profiles, iPhone P3 |
+/// | `Intent` | ±56 | none | + Facebook sRGB, Chrome nano |
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[must_use]
+pub enum Tolerance {
+    /// ±1 in u16 — parametric v4 profiles only.
+    Exact = 1,
+    /// ±3 in u16 — includes v2-magic parametric approximations.
+    Precise = 3,
+    /// ±13 in u16 — includes LUT profiles and iPhone P3.
+    Approximate = 13,
+    /// ±56 in u16 — honors encoder intent. Identical output at 8-bit and 10-bit.
+    Intent = 56,
+}
+
+// ── Public API ───────────────────────────────────────────────────────────
+
+/// Identify a well-known ICC profile by normalized hash lookup.
+///
+/// Computes a normalized FNV-1a 64-bit hash (metadata fields zeroed) and
+/// checks against tables of known RGB and grayscale ICC profiles.
+///
+/// Returns `Some(IccIdentification)` for recognized profiles, `None` for
+/// unknown ones. Grayscale profiles return [`Bt709`](ColorPrimaries::Bt709)
+/// primaries (grayscale has no gamut, but D65 white point is assumed).
+///
+/// ~100ns. For the long tail of vendor/monitor profiles, use structural
+/// analysis via a CMS backend.
+pub fn identify_common(icc_bytes: &[u8], tolerance: Tolerance) -> Option<IccIdentification> {
+    let hash = fnv1a_64_normalized(icc_bytes);
+
+    // Try RGB table first.
+    if let Ok(idx) = KNOWN_RGB_PROFILES.binary_search_by_key(&hash, |e| e.0) {
+        let entry = &KNOWN_RGB_PROFILES[idx];
+        if entry.3 <= tolerance as u8 {
+            return Some(IccIdentification::new(entry.1, entry.2));
+        }
+    }
+
+    // Try grayscale table.
+    if let Ok(idx) = KNOWN_GRAY_PROFILES.binary_search_by_key(&hash, |e| e.0) {
+        let entry = &KNOWN_GRAY_PROFILES[idx];
+        if entry.2 <= tolerance as u8 {
+            return Some(IccIdentification::new(ColorPrimaries::Bt709, entry.1));
+        }
+    }
+
+    None
+}
+
+/// Check if an ICC profile is a known sRGB profile.
+///
+/// Convenience wrapper — returns `true` if the profile matches sRGB within
+/// [`Intent`](Tolerance::Intent) tolerance.
+#[inline]
+pub fn is_common_srgb(icc_bytes: &[u8]) -> bool {
+    identify_common(icc_bytes, Tolerance::Intent).is_some_and(|id| id.is_srgb())
+}
+
+// ── Hash function ────────────────────────────────────────────────────────
+
+/// FNV-1a 64-bit hash of ICC profile bytes with metadata normalization.
+///
+/// Zeroes metadata-only header fields before hashing so that functionally
+/// identical profiles (same colorants + TRC) produce the same hash even if
+/// they differ in creation date, CMM, platform, creator, or profile ID.
+///
+/// Zeroed ranges (all non-colorimetric per ICC spec v2.0–v5/iccMAX):
+/// - bytes  4– 7: preferred CMM type (advisory hint)
+/// - bytes 24–35: creation date/time (metadata)
+/// - bytes 40–43: primary platform (advisory hint)
+/// - bytes 48–55: device manufacturer + device model (identification)
+/// - bytes 80–99: profile creator + profile ID (reserved in v2, MD5 in v4)
+fn fnv1a_64_normalized(data: &[u8]) -> u64 {
+    const FNV_OFFSET: u64 = 0xcbf29ce484222325;
+    const FNV_PRIME: u64 = 0x100000001b3;
+    let mut hash = FNV_OFFSET;
+
+    fn is_metadata_field(i: usize) -> bool {
+        ICC_CMM_TYPE.contains(&i)
+            || ICC_DATE_TIME.contains(&i)
+            || ICC_PLATFORM.contains(&i)
+            || ICC_DEVICE.contains(&i)
+            || ICC_CREATOR_ID.contains(&i)
+    }
+
+    // Phase 1: header bytes — zero metadata fields.
+    let header_len = data.len().min(ICC_HEADER_NORMALIZE_END);
+    let mut i = 0;
+    while i < header_len {
+        let b = if is_metadata_field(i) { 0u8 } else { data[i] };
+        hash ^= b as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+        i += 1;
+    }
+
+    // Phase 2: remaining bytes — straight hash, no conditionals.
+    while i < data.len() {
+        hash ^= data[i] as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+        i += 1;
+    }
+    hash
+}
+
+// ── Hash tables ──────────────────────────────────────────────────────────
+//
+// Tables store enum variants directly — no code-to-enum mapping needed.
+// Shorthand aliases keep the .inc files readable.
+
+use ColorPrimaries as CP;
+use TransferFunction as TF;
+
+/// Well-known RGB ICC profiles: `(normalized_hash, primaries, transfer, max_u16_err)`.
+///
+/// Sorted by normalized hash for binary search. Generated by
+/// `scripts/gen_icc_tables.py` from the ICC profile corpus.
+#[rustfmt::skip]
+const KNOWN_RGB_PROFILES: &[(u64, CP, TF, u8)] =
+    include!("icc_table_rgb.inc");
+
+/// Well-known grayscale ICC profiles: `(normalized_hash, transfer, max_u16_err)`.
+///
+/// Sorted by normalized hash for binary search.
+#[rustfmt::skip]
+const KNOWN_GRAY_PROFILES: &[(u64, TF, u8)] =
+    include!("icc_table_gray.inc");
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rgb_table_sorted() {
+        for i in 1..KNOWN_RGB_PROFILES.len() {
+            assert!(
+                KNOWN_RGB_PROFILES[i - 1].0 < KNOWN_RGB_PROFILES[i].0,
+                "KNOWN_RGB_PROFILES not sorted at index {i}: 0x{:016x} >= 0x{:016x}",
+                KNOWN_RGB_PROFILES[i - 1].0,
+                KNOWN_RGB_PROFILES[i].0,
+            );
+        }
+    }
+
+    #[test]
+    fn gray_table_sorted() {
+        for i in 1..KNOWN_GRAY_PROFILES.len() {
+            assert!(
+                KNOWN_GRAY_PROFILES[i - 1].0 < KNOWN_GRAY_PROFILES[i].0,
+                "KNOWN_GRAY_PROFILES not sorted at index {i}: 0x{:016x} >= 0x{:016x}",
+                KNOWN_GRAY_PROFILES[i - 1].0,
+                KNOWN_GRAY_PROFILES[i].0,
+            );
+        }
+    }
+
+    #[test]
+    fn no_duplicate_hashes() {
+        let mut seen = alloc::collections::BTreeSet::new();
+        for entry in KNOWN_RGB_PROFILES {
+            assert!(
+                seen.insert(entry.0),
+                "duplicate RGB hash 0x{:016x}",
+                entry.0
+            );
+        }
+        for entry in KNOWN_GRAY_PROFILES {
+            assert!(
+                seen.insert(entry.0),
+                "duplicate gray hash 0x{:016x}",
+                entry.0
+            );
+        }
+    }
+
+    #[test]
+    fn all_errors_within_intent() {
+        for &(h, _, _, err) in KNOWN_RGB_PROFILES {
+            assert!(err <= 56, "RGB 0x{h:016x} err={err} > 56");
+        }
+        for &(h, _, err) in KNOWN_GRAY_PROFILES {
+            assert!(err <= 56, "gray 0x{h:016x} err={err} > 56");
+        }
+    }
+
+    #[test]
+    fn no_unknown_variants_in_tables() {
+        for &(h, cp, tc, _) in KNOWN_RGB_PROFILES {
+            assert_ne!(cp, ColorPrimaries::Unknown, "RGB 0x{h:016x}");
+            assert_ne!(tc, TransferFunction::Unknown, "RGB 0x{h:016x}");
+        }
+        for &(h, tc, _) in KNOWN_GRAY_PROFILES {
+            assert_ne!(tc, TransferFunction::Unknown, "gray 0x{h:016x}");
+        }
+    }
+
+    #[test]
+    fn table_coverage() {
+        let rgb_count = |cp: ColorPrimaries, tc: TransferFunction| {
+            KNOWN_RGB_PROFILES
+                .iter()
+                .filter(|e| e.1 == cp && e.2 == tc)
+                .count()
+        };
+        assert!(
+            rgb_count(CP::Bt709, TF::Srgb) >= 25,
+            "sRGB: {}",
+            rgb_count(CP::Bt709, TF::Srgb)
+        );
+        assert!(
+            rgb_count(CP::DisplayP3, TF::Srgb) >= 25,
+            "Display P3: {}",
+            rgb_count(CP::DisplayP3, TF::Srgb)
+        );
+        assert!(
+            rgb_count(CP::AdobeRgb, TF::Gamma22) >= 15,
+            "Adobe RGB: {}",
+            rgb_count(CP::AdobeRgb, TF::Gamma22)
+        );
+        assert!(
+            KNOWN_RGB_PROFILES.len() >= 90,
+            "RGB total: {}",
+            KNOWN_RGB_PROFILES.len()
+        );
+        assert!(
+            KNOWN_GRAY_PROFILES.len() >= 10,
+            "Gray total: {}",
+            KNOWN_GRAY_PROFILES.len()
+        );
+    }
+
+    #[test]
+    fn zero_filled_no_false_positive() {
+        for len in [410, 456, 480, 524, 548, 656, 736, 3024, 3144] {
+            let zeros = alloc::vec![0u8; len];
+            assert!(
+                identify_common(&zeros, Tolerance::Intent).is_none(),
+                "zeros({len}) falsely matched"
+            );
+        }
+    }
+
+    #[test]
+    fn hash_deterministic() {
+        let data = b"test data for hashing";
+        assert_eq!(fnv1a_64_normalized(data), fnv1a_64_normalized(data));
+    }
+
+    #[test]
+    fn hash_distinct() {
+        assert_ne!(fnv1a_64_normalized(b"abc"), fnv1a_64_normalized(b"abd"));
+    }
+
+    #[test]
+    fn normalization_zeroes_metadata() {
+        // Two profiles identical except for creation date (bytes 24-35)
+        let mut a = alloc::vec![0u8; 200];
+        let mut b = a.clone();
+        a[30] = 0xFF; // different date byte
+        b[30] = 0x01;
+        assert_eq!(fnv1a_64_normalized(&a), fnv1a_64_normalized(&b));
+
+        // But differ in color-critical field (byte 20 = PCS)
+        let mut c = a.clone();
+        c[20] = 0xFF;
+        assert_ne!(fnv1a_64_normalized(&a), fnv1a_64_normalized(&c));
+    }
+
+    #[test]
+    fn is_common_srgb_rejects_empty() {
+        assert!(!is_common_srgb(&[]));
+        assert!(!is_common_srgb(&[0; 100]));
+    }
+
+    // ── extract_cicp tests ───────────────────────────────────────────
+
+    /// Helper: build a minimal ICC profile with a cicp tag.
+    fn build_icc_with_cicp(cp: u8, tc: u8, mc: u8, fr: bool) -> alloc::vec::Vec<u8> {
+        let mut data = alloc::vec![0u8; 256];
+        data[0..4].copy_from_slice(&256u32.to_be_bytes());
+        data[36..40].copy_from_slice(b"acsp");
+        data[128..132].copy_from_slice(&1u32.to_be_bytes());
+        data[132..136].copy_from_slice(b"cicp");
+        data[136..140].copy_from_slice(&144u32.to_be_bytes());
+        data[140..144].copy_from_slice(&12u32.to_be_bytes());
+        data[144..148].copy_from_slice(b"cicp");
+        data[152] = cp;
+        data[153] = tc;
+        data[154] = mc;
+        data[155] = u8::from(fr);
+        data
+    }
+
+    #[test]
+    fn extract_cicp_srgb() {
+        let icc = build_icc_with_cicp(1, 13, 0, true);
+        let cicp = extract_cicp(&icc).unwrap();
+        assert_eq!(cicp.color_primaries, 1);
+        assert_eq!(cicp.transfer_characteristics, 13);
+        assert_eq!(cicp.matrix_coefficients, 0);
+        assert!(cicp.full_range);
+    }
+
+    #[test]
+    fn extract_cicp_pq() {
+        let icc = build_icc_with_cicp(9, 16, 0, true);
+        let cicp = extract_cicp(&icc).unwrap();
+        assert_eq!(cicp.color_primaries, 9);
+        assert_eq!(cicp.transfer_characteristics, 16);
+    }
+
+    #[test]
+    fn extract_cicp_empty() {
+        assert!(extract_cicp(&[]).is_none());
+        assert!(extract_cicp(&[0; 100]).is_none());
+    }
+
+    #[test]
+    fn extract_cicp_no_acsp() {
+        let mut icc = build_icc_with_cicp(1, 13, 0, true);
+        icc[36..40].copy_from_slice(b"xxxx");
+        assert!(extract_cicp(&icc).is_none());
+    }
+
+    #[test]
+    fn extract_cicp_no_tag() {
+        let mut data = alloc::vec![0u8; 256];
+        data[0..4].copy_from_slice(&256u32.to_be_bytes());
+        data[36..40].copy_from_slice(b"acsp");
+        data[128..132].copy_from_slice(&1u32.to_be_bytes());
+        data[132..136].copy_from_slice(b"desc"); // not cicp
+        data[136..140].copy_from_slice(&144u32.to_be_bytes());
+        data[140..144].copy_from_slice(&12u32.to_be_bytes());
+        assert!(extract_cicp(&data).is_none());
+    }
+
+    #[test]
+    fn extract_cicp_tag_too_small() {
+        let mut icc = build_icc_with_cicp(1, 13, 0, true);
+        icc[140..144].copy_from_slice(&8u32.to_be_bytes()); // size < 12
+        assert!(extract_cicp(&icc).is_none());
+    }
+
+    #[test]
+    fn extract_cicp_type_mismatch() {
+        let mut icc = build_icc_with_cicp(1, 13, 0, true);
+        icc[144..148].copy_from_slice(b"xxxx"); // wrong type sig
+        assert!(extract_cicp(&icc).is_none());
+    }
+
+    #[test]
+    fn extract_cicp_malicious_tag_count() {
+        let mut data = alloc::vec![0u8; 256];
+        data[0..4].copy_from_slice(&256u32.to_be_bytes());
+        data[36..40].copy_from_slice(b"acsp");
+        // Absurd tag count — capped to 200
+        data[128..132].copy_from_slice(&u32::MAX.to_be_bytes());
+        assert!(extract_cicp(&data).is_none());
+    }
+}

--- a/zenpixels/src/lib.rs
+++ b/zenpixels/src/lib.rs
@@ -44,6 +44,8 @@ pub mod policy;
 pub mod cicp;
 pub mod color;
 pub mod hdr;
+#[cfg(feature = "icc")]
+pub mod icc;
 pub mod pixel_types;
 
 pub mod buffer;


### PR DESCRIPTION
## Summary

- Add `ColorPrimaries::AdobeRgb` (200), `ColorPrimaries::ProPhoto` (201)
- Add `TransferFunction::Gamma22` (200), `TransferFunction::Gamma18` (201)
- Add `zenpixels::icc` module behind `icc-identify` feature (default on)

The `icc` module provides fast-path ICC profile identification via normalized hash lookup — 132 entries (118 RGB + 14 grayscale) covering the profiles found in 55,539 spidered web images.

Normalization zeroes metadata-only ICC header fields before FNV-1a hashing, collapsing 528 unique web blobs to 132 entries (e.g., GIMP's 172 per-export sRGB variants → 1 hash). Safe across ICC v2.0–v5/iccMAX.

All entries 3-way verified: mega_test f64 vs moxcms f32 vs canonical EOTF. Max divergence ≤1 (f32 rounding).

Non-CICP discriminant values use 200+ range to avoid future CICP code collisions.

## Public API

```rust
use zenpixels::icc::{identify_well_known_icc, IccMatchTolerance, IccIdentification};

if let Some(id) = identify_well_known_icc(icc_bytes, IccMatchTolerance::Intent) {
    // id.primaries: ColorPrimaries (Bt709, DisplayP3, AdobeRgb, ProPhoto, ...)
    // id.transfer: TransferFunction (Srgb, Gamma22, Pq, ...)
    // id.to_cicp(): Option<Cicp> — None for non-CICP spaces
    // id.is_srgb(): bool
}
```

## Test plan

- [x] 193 zenpixels tests pass (18 ICC-specific)
- [x] 175 pass with `--no-default-features` (ICC module correctly gated)
- [x] Tables sorted, no duplicates, all codes map to known enum variants
- [x] All errors within Intent tolerance (≤56 u16)
- [x] Zero-filled buffers produce no false positives
- [x] Hash normalization correctly zeroes metadata, preserves color-critical fields
- [ ] CI (linux, windows, macOS, wasm32, MSRV 1.85)