### PR TITLE
feat: add CMYK pixel format support

### DIFF
--- a/zenpixels-convert/src/adapt.rs
+++ b/zenpixels-convert/src/adapt.rs
@@ -66,8 +66,20 @@ use crate::convert::ConvertPlan;
 use crate::converter::RowConverter;
 use crate::negotiate::{ConvertIntent, best_match};
 use crate::policy::{AlphaPolicy, ConvertOptions};
-use crate::{ConvertError, PixelDescriptor};
+use crate::{ColorModel, ConvertError, PixelDescriptor};
 use whereat::{At, ResultAtExt};
+
+/// Assert that a descriptor is not CMYK.
+///
+/// CMYK is device-dependent and cannot be adapted by zenpixels-convert.
+/// Use a CMS (e.g., moxcms) with an ICC profile for CMYK↔RGB conversion.
+fn assert_not_cmyk(desc: &PixelDescriptor) {
+    assert!(
+        desc.color_model() != ColorModel::Cmyk,
+        "CMYK pixel data cannot be processed by zenpixels-convert. \
+         Use a CMS (e.g., moxcms) with an ICC profile for CMYK↔RGB conversion."
+    );
+}
 
 /// Result of format adaptation: the converted data and its descriptor.
 #[derive(Clone, Debug)]
@@ -130,6 +142,7 @@ pub fn adapt_for_encode_with_intent<'a>(
     supported: &[PixelDescriptor],
     intent: ConvertIntent,
 ) -> Result<Adapted<'a>, At<ConvertError>> {
+    assert_not_cmyk(&descriptor);
     if supported.is_empty() {
         return Err(whereat::at!(ConvertError::EmptyFormatList));
     }
@@ -212,6 +225,8 @@ pub fn convert_buffer(
     from: PixelDescriptor,
     to: PixelDescriptor,
 ) -> Result<Vec<u8>, At<ConvertError>> {
+    assert_not_cmyk(&from);
+    assert_not_cmyk(&to);
     if from == to {
         return Ok(src.to_vec());
     }
@@ -253,6 +268,7 @@ pub fn adapt_for_encode_explicit<'a>(
     supported: &[PixelDescriptor],
     options: &ConvertOptions,
 ) -> Result<Adapted<'a>, At<ConvertError>> {
+    assert_not_cmyk(&descriptor);
     if supported.is_empty() {
         return Err(whereat::at!(ConvertError::EmptyFormatList));
     }
@@ -474,6 +490,46 @@ mod tests {
 
         assert!(matches!(result.data, Cow::Borrowed(_)));
         assert_eq!(result.descriptor, desc);
+    }
+
+    #[test]
+    #[should_panic(expected = "CMYK pixel data cannot be processed")]
+    fn cmyk_rejected_by_adapt_for_encode() {
+        let cmyk_data = vec![0u8; 4 * 4]; // 4 pixels
+        let _ = adapt_for_encode(
+            &cmyk_data,
+            PixelDescriptor::CMYK8,
+            2,
+            2,
+            8,
+            &[PixelDescriptor::RGB8_SRGB],
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "CMYK pixel data cannot be processed")]
+    fn cmyk_rejected_by_convert_buffer() {
+        let cmyk_data = vec![0u8; 4 * 4];
+        let _ = convert_buffer(
+            &cmyk_data,
+            2,
+            2,
+            PixelDescriptor::CMYK8,
+            PixelDescriptor::RGB8_SRGB,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "CMYK pixel data cannot be processed")]
+    fn cmyk_rejected_by_convert_buffer_as_target() {
+        let rgb_data = vec![0u8; 3 * 4];
+        let _ = convert_buffer(
+            &rgb_data,
+            2,
+            2,
+            PixelDescriptor::RGB8_SRGB,
+            PixelDescriptor::CMYK8,
+        );
     }
 
     #[test]

--- a/zenpixels-convert/src/convert.rs
+++ b/zenpixels-convert/src/convert.rs
@@ -122,12 +122,31 @@ pub(crate) enum ConvertStep {
     GamutMatrixRgbaF32([f32; 9]),
 }
 
+/// Assert that a descriptor is not CMYK.
+///
+/// CMYK is device-dependent and cannot be converted by zenpixels-convert.
+/// Use a CMS (e.g., moxcms) with an ICC profile for CMYK↔RGB conversion.
+fn assert_not_cmyk(desc: &PixelDescriptor) {
+    assert!(
+        desc.color_model() != crate::ColorModel::Cmyk,
+        "CMYK pixel data cannot be processed by zenpixels-convert. \
+         Use a CMS (e.g., moxcms) with an ICC profile for CMYK↔RGB conversion."
+    );
+}
+
 impl ConvertPlan {
     /// Create a conversion plan from `from` to `to`.
     ///
     /// Returns `Err` if no conversion path exists.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either `from` or `to` uses [`ColorModel::Cmyk`].
+    /// CMYK requires a CMS with an ICC profile for conversion.
     #[track_caller]
     pub fn new(from: PixelDescriptor, to: PixelDescriptor) -> Result<Self, At<ConvertError>> {
+        assert_not_cmyk(&from);
+        assert_not_cmyk(&to);
         if from == to {
             return Ok(Self {
                 from,
@@ -390,12 +409,19 @@ impl ConvertPlan {
     /// Validates that the planned conversion steps are allowed by the given
     /// policies before creating the plan. Returns an error if a forbidden
     /// operation would be required.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either `from` or `to` uses [`ColorModel::Cmyk`].
+    /// CMYK requires a CMS with an ICC profile for conversion.
     #[track_caller]
     pub fn new_explicit(
         from: PixelDescriptor,
         to: PixelDescriptor,
         options: &ConvertOptions,
     ) -> Result<Self, At<ConvertError>> {
+        assert_not_cmyk(&from);
+        assert_not_cmyk(&to);
         // Check alpha removal policy.
         let drops_alpha = from.alpha().is_some() && to.alpha().is_none();
         if drops_alpha && options.alpha_policy == AlphaPolicy::Forbid {

--- a/zenpixels-convert/src/converter.rs
+++ b/zenpixels-convert/src/converter.rs
@@ -1360,4 +1360,14 @@ mod tests {
             "straight→premul→straight should cancel"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // CMYK guard
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[should_panic(expected = "CMYK pixel data cannot be processed")]
+    fn cmyk_rejected_by_row_converter() {
+        let _ = RowConverter::new(PixelDescriptor::CMYK8, PixelDescriptor::RGB8_SRGB);
+    }
 }

--- a/zenpixels-convert/src/ext.rs
+++ b/zenpixels-convert/src/ext.rs
@@ -167,10 +167,21 @@ pub trait PixelBufferConvertTypedExt: PixelBufferConvertExt {
     fn to_bgra8(&self) -> PixelBuffer<rgb::alt::BGRA<u8>>;
 }
 
+/// Assert that a descriptor is not CMYK.
+fn assert_not_cmyk(desc: &PixelDescriptor) {
+    assert!(
+        desc.color_model() != crate::ColorModel::Cmyk,
+        "CMYK pixel data cannot be processed by zenpixels-convert. \
+         Use a CMS (e.g., moxcms) with an ICC profile for CMYK↔RGB conversion."
+    );
+}
+
 impl PixelBufferConvertExt for PixelBuffer {
     #[track_caller]
     fn convert_to(&self, target: PixelDescriptor) -> Result<PixelBuffer, At<crate::ConvertError>> {
         let src_desc = self.descriptor();
+        assert_not_cmyk(&src_desc);
+        assert_not_cmyk(&target);
         if src_desc == target {
             // Identity — just copy.
             let dst_stride = target.aligned_stride(self.width());
@@ -338,6 +349,24 @@ fn convert_to_typed<Q: Pixel>(buf: &PixelBuffer, target: PixelDescriptor) -> Pix
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- CMYK guard tests ---
+
+    #[test]
+    #[should_panic(expected = "CMYK pixel data cannot be processed")]
+    fn cmyk_rejected_by_convert_to() {
+        let cmyk_data = vec![0u8; 4 * 4]; // 4 pixels
+        let buf = PixelBuffer::from_vec(cmyk_data, 2, 2, PixelDescriptor::CMYK8).unwrap();
+        let _ = buf.convert_to(PixelDescriptor::RGB8_SRGB);
+    }
+
+    #[test]
+    #[should_panic(expected = "CMYK pixel data cannot be processed")]
+    fn cmyk_rejected_as_convert_target() {
+        let rgb_data = vec![0u8; 3 * 4]; // 4 pixels
+        let buf = PixelBuffer::from_vec(rgb_data, 2, 2, PixelDescriptor::RGB8_SRGB).unwrap();
+        let _ = buf.convert_to(PixelDescriptor::CMYK8);
+    }
 
     // --- TransferFunction linearize/delinearize tests ---
 

--- a/zenpixels/src/descriptor.rs
+++ b/zenpixels/src/descriptor.rs
@@ -116,6 +116,8 @@ pub enum ChannelLayout {
     Oklab = 6,
     /// Oklab perceptual color with alpha: L, a, b, alpha.
     OklabA = 7,
+    /// C, M, Y, K channel order.
+    Cmyk = 8,
 }
 
 impl ChannelLayout {
@@ -127,7 +129,7 @@ impl ChannelLayout {
             Self::Gray => 1,
             Self::GrayAlpha => 2,
             Self::Rgb | Self::Oklab => 3,
-            Self::Rgba | Self::Bgra | Self::OklabA => 4,
+            Self::Rgba | Self::Bgra | Self::OklabA | Self::Cmyk => 4,
             _ => 0,
         }
     }
@@ -154,6 +156,7 @@ impl fmt::Display for ChannelLayout {
             Self::Bgra => f.write_str("BGRA"),
             Self::Oklab => f.write_str("Oklab"),
             Self::OklabA => f.write_str("OklabA"),
+            Self::Cmyk => f.write_str("CMYK"),
             _ => write!(f, "ChannelLayout({})", *self as u8),
         }
     }
@@ -967,6 +970,11 @@ impl PixelDescriptor {
         signal_range: SignalRange::Full,
     };
 
+    // -- CMYK constants --------------------------------------------------------
+
+    /// 8-bit CMYK, no transfer function or primaries.
+    pub const CMYK8: Self = Self::from_pixel_format(PixelFormat::Cmyk8);
+
     // -- Methods --------------------------------------------------------------
 
     /// Number of channels.
@@ -1176,6 +1184,10 @@ pub enum ColorModel {
     YCbCr = 2,
     /// Oklab perceptual color space (L, a, b).
     Oklab = 3,
+    /// Cyan, magenta, yellow, key (black). Device-dependent printing color space.
+    /// RGB primaries and transfer functions do not apply to CMYK data.
+    /// Use a CMS with an ICC profile for CMYK↔RGB conversion.
+    Cmyk = 4,
 }
 
 impl ColorModel {
@@ -1185,18 +1197,22 @@ impl ColorModel {
     pub const fn color_channels(self) -> u8 {
         match self {
             Self::Gray => 1,
+            Self::Cmyk => 4,
             _ => 3,
         }
     }
 }
 
 impl fmt::Display for ColorModel {
+    #[allow(unreachable_patterns)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Gray => f.write_str("Gray"),
             Self::Rgb => f.write_str("RGB"),
             Self::YCbCr => f.write_str("YCbCr"),
             Self::Oklab => f.write_str("Oklab"),
+            Self::Cmyk => f.write_str("CMYK"),
+            _ => write!(f, "ColorModel({})", *self as u8),
         }
     }
 }
@@ -1260,6 +1276,8 @@ pub enum PixelFormat {
     Bgrx8 = 15,
     OklabF32 = 16,
     OklabaF32 = 17,
+    /// 8-bit CMYK (4 bytes per pixel, no transfer function).
+    Cmyk8 = 18,
 }
 
 impl PixelFormat {
@@ -1274,7 +1292,8 @@ impl PixelFormat {
             | Self::GrayA8
             | Self::Bgra8
             | Self::Rgbx8
-            | Self::Bgrx8 => ChannelType::U8,
+            | Self::Bgrx8
+            | Self::Cmyk8 => ChannelType::U8,
             Self::Rgb16 | Self::Rgba16 | Self::Gray16 | Self::GrayA16 => ChannelType::U16,
             Self::RgbF32
             | Self::RgbaF32
@@ -1298,6 +1317,7 @@ impl PixelFormat {
             Self::Bgra8 | Self::Bgrx8 => ChannelLayout::Bgra,
             Self::OklabF32 => ChannelLayout::Oklab,
             Self::OklabaF32 => ChannelLayout::OklabA,
+            Self::Cmyk8 => ChannelLayout::Cmyk,
             _ => ChannelLayout::Rgb,
         }
     }
@@ -1314,6 +1334,7 @@ impl PixelFormat {
             | Self::GrayA16
             | Self::GrayAF32 => ColorModel::Gray,
             Self::OklabF32 | Self::OklabaF32 => ColorModel::Oklab,
+            Self::Cmyk8 => ColorModel::Cmyk,
             _ => ColorModel::Rgb,
         }
     }
@@ -1367,7 +1388,8 @@ impl PixelFormat {
             | Self::Gray8
             | Self::Gray16
             | Self::GrayF32
-            | Self::OklabF32 => None,
+            | Self::OklabF32
+            | Self::Cmyk8 => None,
             Self::Rgbx8 | Self::Bgrx8 => Some(AlphaMode::Undefined),
             _ => Some(AlphaMode::Straight),
         }
@@ -1395,6 +1417,7 @@ impl PixelFormat {
             Self::Bgrx8 => "BGRX8",
             Self::OklabF32 => "OklabF32",
             Self::OklabaF32 => "OklabaF32",
+            Self::Cmyk8 => "CMYK8",
             _ => "Unknown",
         }
     }
@@ -1434,6 +1457,8 @@ impl PixelFormat {
             (ChannelType::F32, ChannelLayout::Oklab, _) => Some(Self::OklabF32),
             (ChannelType::F32, ChannelLayout::OklabA, _) => Some(Self::OklabaF32),
 
+            (ChannelType::U8, ChannelLayout::Cmyk, _) => Some(Self::Cmyk8),
+
             _ => None,
         }
     }
@@ -1460,6 +1485,7 @@ impl PixelFormat {
             Self::Bgrx8 => PixelDescriptor::BGRX8,
             Self::OklabF32 => PixelDescriptor::OKLABF32,
             Self::OklabaF32 => PixelDescriptor::OKLABAF32,
+            Self::Cmyk8 => PixelDescriptor::CMYK8,
             _ => PixelDescriptor::RGB8,
         }
     }
@@ -1599,6 +1625,7 @@ mod tests {
         assert_eq!(ColorModel::Rgb.color_channels(), 3);
         assert_eq!(ColorModel::YCbCr.color_channels(), 3);
         assert_eq!(ColorModel::Oklab.color_channels(), 3);
+        assert_eq!(ColorModel::Cmyk.color_channels(), 4);
     }
 
     // --- PlaneSemantic tests ---
@@ -1914,6 +1941,7 @@ mod tests {
         assert_eq!(format!("{}", ColorModel::Rgb), "RGB");
         assert_eq!(format!("{}", ColorModel::YCbCr), "YCbCr");
         assert_eq!(format!("{}", ColorModel::Oklab), "Oklab");
+        assert_eq!(format!("{}", ColorModel::Cmyk), "CMYK");
     }
 
     // --- SignalRange default ---
@@ -1928,5 +1956,59 @@ mod tests {
     #[test]
     fn color_primaries_default() {
         assert_eq!(ColorPrimaries::default(), ColorPrimaries::Bt709);
+    }
+
+    // --- CMYK tests ---
+
+    #[test]
+    fn cmyk8_descriptor() {
+        let d = PixelDescriptor::CMYK8;
+        assert_eq!(d.color_model(), ColorModel::Cmyk);
+        assert_eq!(d.channels(), 4);
+        assert_eq!(d.bytes_per_pixel(), 4);
+        assert_eq!(d.layout(), ChannelLayout::Cmyk);
+        assert_eq!(d.channel_type(), ChannelType::U8);
+        assert_eq!(d.transfer(), TransferFunction::Unknown);
+        assert_eq!(d.primaries, ColorPrimaries::Bt709);
+        assert!(!d.has_alpha());
+        assert!(d.is_opaque());
+    }
+
+    #[test]
+    fn cmyk8_pixel_format() {
+        let fmt = PixelFormat::Cmyk8;
+        assert_eq!(fmt.channels(), 4);
+        assert_eq!(fmt.bytes_per_pixel(), 4);
+        assert_eq!(fmt.channel_type(), ChannelType::U8);
+        assert_eq!(fmt.layout(), ChannelLayout::Cmyk);
+        assert_eq!(fmt.color_model(), ColorModel::Cmyk);
+        assert!(!fmt.has_alpha_bytes());
+        assert!(!fmt.is_grayscale());
+        assert_eq!(fmt.name(), "CMYK8");
+        assert_eq!(fmt.default_alpha(), None);
+    }
+
+    #[test]
+    fn cmyk8_from_parts_roundtrip() {
+        let fmt = PixelFormat::Cmyk8;
+        let rebuilt =
+            PixelFormat::from_parts(fmt.channel_type(), fmt.layout(), fmt.default_alpha());
+        assert_eq!(rebuilt, Some(fmt));
+    }
+
+    #[test]
+    fn cmyk8_descriptor_roundtrip() {
+        let desc = PixelFormat::Cmyk8.descriptor();
+        assert_eq!(desc, PixelDescriptor::CMYK8);
+    }
+
+    #[test]
+    fn cmyk_channel_layout_display() {
+        assert_eq!(format!("{}", ChannelLayout::Cmyk), "CMYK");
+    }
+
+    #[test]
+    fn cmyk_channel_layout_no_alpha() {
+        assert!(!ChannelLayout::Cmyk.has_alpha());
     }
 }

--- a/zenpixels/src/icc/mod.rs
+++ b/zenpixels/src/icc/mod.rs
@@ -569,6 +569,23 @@ pub fn is_common_srgb(icc_bytes: &[u8]) -> bool {
     identify_common(icc_bytes).is_some_and(|id| id.is_srgb())
 }
 
+/// Read the ICC profile's data color space from the header (bytes 16–19).
+///
+/// Returns the [`ColorModel`] corresponding to the four-byte signature
+/// at offset 16 in the ICC header, or `None` if the profile is too short
+/// or uses an unrecognized color space.
+pub fn profile_color_space(icc_bytes: &[u8]) -> Option<crate::ColorModel> {
+    if icc_bytes.len() < 20 {
+        return None;
+    }
+    match &icc_bytes[16..20] {
+        b"RGB " => Some(crate::ColorModel::Rgb),
+        b"GRAY" => Some(crate::ColorModel::Gray),
+        b"CMYK" => Some(crate::ColorModel::Cmyk),
+        _ => None,
+    }
+}
+
 // ── Hash function ────────────────────────────────────────────────────────
 
 /// FNV-1a 64-bit hash of ICC profile bytes with metadata normalization.
@@ -996,5 +1013,34 @@ mod tests {
         eprintln!("Lab PCS:                         {unsafe_lab}");
         eprintln!("Non-Bradford chad:               {unsafe_chad}");
         eprintln!("No matrix-shaper tags:           {no_matrix}");
+    }
+
+    // --- profile_color_space tests ---
+
+    #[test]
+    fn profile_color_space_detection() {
+        // Minimal valid ICC header with CMYK color space at bytes 16-19
+        let mut header = vec![0u8; 128];
+        header[16..20].copy_from_slice(b"CMYK");
+        assert_eq!(profile_color_space(&header), Some(crate::ColorModel::Cmyk));
+
+        header[16..20].copy_from_slice(b"RGB ");
+        assert_eq!(profile_color_space(&header), Some(crate::ColorModel::Rgb));
+
+        header[16..20].copy_from_slice(b"GRAY");
+        assert_eq!(profile_color_space(&header), Some(crate::ColorModel::Gray));
+    }
+
+    #[test]
+    fn profile_color_space_too_short() {
+        assert_eq!(profile_color_space(&[0u8; 19]), None);
+        assert_eq!(profile_color_space(&[]), None);
+    }
+
+    #[test]
+    fn profile_color_space_unknown() {
+        let mut header = vec![0u8; 128];
+        header[16..20].copy_from_slice(b"Lab ");
+        assert_eq!(profile_color_space(&header), None);
     }
 }


### PR DESCRIPTION
## Summary

- Add `ColorModel::Cmyk`, `ChannelLayout::Cmyk`, `PixelFormat::Cmyk8`, and `PixelDescriptor::CMYK8` to zenpixels
- Add `icc::profile_color_space()` for reading the data color space from an ICC profile header (RGB/Gray/CMYK)
- Add panic guards in zenpixels-convert that reject CMYK data at all conversion entry points (ConvertPlan, RowConverter, adapt_for_encode, convert_buffer, PixelBufferConvertExt)

CMYK is device-dependent and requires a CMS with an ICC profile for conversion to/from RGB. Transfer functions and gamut matrices do not apply to CMYK data.

Closes #13

## Test plan

- [x] 9 new unit tests in zenpixels for CMYK descriptor, pixel format, from_parts roundtrip, channel layout, and ICC profile_color_space
- [x] 6 new `#[should_panic]` tests in zenpixels-convert verifying CMYK rejection at adapt, convert_buffer, RowConverter, and PixelBufferConvertExt entry points
- [x] All 261 existing zenpixels tests pass
- [x] All existing zenpixels-convert tests pass
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean