### PR TITLE
feat(zenpixels-convert): first-class Gamma 2.2 (Adobe RGB) transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### zenpixels-convert — added
+
+- **First-class Gamma 2.2 (Adobe RGB 1998) transfer in the fast path.** New
+  `ConvertStep::Gamma22F32ToLinearF32` / `LinearF32ToGamma22F32` variants plus
+  `depth_steps` arms for Gamma22 ↔ {Linear, sRGB, BT.709, PQ, HLG} same-depth
+  F32. The primaries-conversion injection now routes Gamma22 through the
+  correct EOTF/OETF instead of falling through to the sRGB approximation.
+  Lets AdobeRGB ↔ PQ / HLG / BT.2020 / Linear compose in the built-in planner
+  without hitting the moxcms CMS fallback. SIMD via
+  `linear_srgb::default::{gamma_to_linear,linear_to_gamma}_slice` with
+  `ADOBE_GAMMA = 563/256 ≈ 2.19921875`.
+
 ## [0.2.9] - 2026-04-16
 
 ### zenpixels-convert — internal

--- a/zenpixels-convert/src/convert.rs
+++ b/zenpixels-convert/src/convert.rs
@@ -115,6 +115,11 @@ pub(crate) enum ConvertStep {
     Bt709F32ToLinearF32,
     /// Linear f32 → BT.709 f32 [0,1] (OETF, no depth change).
     LinearF32ToBt709F32,
+    /// Gamma 2.2 (Adobe RGB 1998) f32 [0,1] → linear f32 (EOTF, no depth change).
+    /// Uses the Adobe RGB 1998 canonical exponent 563/256 ≈ 2.19921875.
+    Gamma22F32ToLinearF32,
+    /// Linear f32 → Gamma 2.2 (Adobe RGB 1998) f32 [0,1] (OETF, no depth change).
+    LinearF32ToGamma22F32,
     /// Straight → Premultiplied alpha.
     StraightToPremul,
     /// Premultiplied → Straight alpha.
@@ -195,6 +200,8 @@ impl core::fmt::Debug for ConvertStep {
             Self::LinearF32ToSrgbF32Extended => f.write_str("LinearF32ToSrgbF32Extended"),
             Self::Bt709F32ToLinearF32 => f.write_str("Bt709F32ToLinearF32"),
             Self::LinearF32ToBt709F32 => f.write_str("LinearF32ToBt709F32"),
+            Self::Gamma22F32ToLinearF32 => f.write_str("Gamma22F32ToLinearF32"),
+            Self::LinearF32ToGamma22F32 => f.write_str("LinearF32ToGamma22F32"),
             Self::StraightToPremul => f.write_str("StraightToPremul"),
             Self::PremulToStraight => f.write_str("PremulToStraight"),
             Self::LinearRgbToOklab => f.write_str("LinearRgbToOklab"),
@@ -427,6 +434,7 @@ impl ConvertPlan {
                     TransferFunction::Bt709 => ConvertStep::Bt709F32ToLinearF32,
                     TransferFunction::Pq => ConvertStep::PqF32ToLinearF32,
                     TransferFunction::Hlg => ConvertStep::HlgF32ToLinearF32,
+                    TransferFunction::Gamma22 => ConvertStep::Gamma22F32ToLinearF32,
                     TransferFunction::Linear => ConvertStep::Identity,
                     _ => ConvertStep::SrgbF32ToLinearF32, // assume sRGB for Unknown
                 };
@@ -435,6 +443,7 @@ impl ConvertPlan {
                     TransferFunction::Bt709 => ConvertStep::LinearF32ToBt709F32,
                     TransferFunction::Pq => ConvertStep::LinearF32ToPqF32,
                     TransferFunction::Hlg => ConvertStep::LinearF32ToHlgF32,
+                    TransferFunction::Gamma22 => ConvertStep::LinearF32ToGamma22F32,
                     TransferFunction::Linear => ConvertStep::Identity,
                     _ => ConvertStep::LinearF32ToSrgbF32, // assume sRGB for Unknown
                 };
@@ -968,6 +977,46 @@ fn depth_steps(
                 ConvertStep::HlgF32ToLinearF32,
                 ConvertStep::LinearF32ToBt709F32,
             ]),
+            // Gamma 2.2 (Adobe RGB 1998) ↔ Linear.
+            (TransferFunction::Gamma22, TransferFunction::Linear) => {
+                Ok(vec![ConvertStep::Gamma22F32ToLinearF32])
+            }
+            (TransferFunction::Linear, TransferFunction::Gamma22) => {
+                Ok(vec![ConvertStep::LinearF32ToGamma22F32])
+            }
+            // Gamma 2.2 ↔ {sRGB, BT.709, PQ, HLG}: go through linear.
+            (TransferFunction::Gamma22, TransferFunction::Srgb) => Ok(vec![
+                ConvertStep::Gamma22F32ToLinearF32,
+                ConvertStep::LinearF32ToSrgbF32,
+            ]),
+            (TransferFunction::Srgb, TransferFunction::Gamma22) => Ok(vec![
+                ConvertStep::SrgbF32ToLinearF32,
+                ConvertStep::LinearF32ToGamma22F32,
+            ]),
+            (TransferFunction::Gamma22, TransferFunction::Bt709) => Ok(vec![
+                ConvertStep::Gamma22F32ToLinearF32,
+                ConvertStep::LinearF32ToBt709F32,
+            ]),
+            (TransferFunction::Bt709, TransferFunction::Gamma22) => Ok(vec![
+                ConvertStep::Bt709F32ToLinearF32,
+                ConvertStep::LinearF32ToGamma22F32,
+            ]),
+            (TransferFunction::Gamma22, TransferFunction::Pq) => Ok(vec![
+                ConvertStep::Gamma22F32ToLinearF32,
+                ConvertStep::LinearF32ToPqF32,
+            ]),
+            (TransferFunction::Pq, TransferFunction::Gamma22) => Ok(vec![
+                ConvertStep::PqF32ToLinearF32,
+                ConvertStep::LinearF32ToGamma22F32,
+            ]),
+            (TransferFunction::Gamma22, TransferFunction::Hlg) => Ok(vec![
+                ConvertStep::Gamma22F32ToLinearF32,
+                ConvertStep::LinearF32ToHlgF32,
+            ]),
+            (TransferFunction::Hlg, TransferFunction::Gamma22) => Ok(vec![
+                ConvertStep::HlgF32ToLinearF32,
+                ConvertStep::LinearF32ToGamma22F32,
+            ]),
             _ => Ok(Vec::new()),
         };
     }
@@ -1225,6 +1274,8 @@ fn are_inverse(a: &ConvertStep, b: &ConvertStep) -> bool {
         | (ConvertStep::LinearF32ToHlgF32, ConvertStep::HlgF32ToLinearF32)
         | (ConvertStep::Bt709F32ToLinearF32, ConvertStep::LinearF32ToBt709F32)
         | (ConvertStep::LinearF32ToBt709F32, ConvertStep::Bt709F32ToLinearF32)
+        | (ConvertStep::Gamma22F32ToLinearF32, ConvertStep::LinearF32ToGamma22F32)
+        | (ConvertStep::LinearF32ToGamma22F32, ConvertStep::Gamma22F32ToLinearF32)
         // Alpha mode (exact inverses in float)
         | (ConvertStep::StraightToPremul, ConvertStep::PremulToStraight)
         | (ConvertStep::PremulToStraight, ConvertStep::StraightToPremul)
@@ -1339,7 +1390,8 @@ fn intermediate_desc(current: PixelDescriptor, step: &ConvertStep) -> PixelDescr
         | ConvertStep::HlgF32ToLinearF32
         | ConvertStep::SrgbF32ToLinearF32
         | ConvertStep::SrgbF32ToLinearF32Extended
-        | ConvertStep::Bt709F32ToLinearF32 => PixelDescriptor::new(
+        | ConvertStep::Bt709F32ToLinearF32
+        | ConvertStep::Gamma22F32ToLinearF32 => PixelDescriptor::new(
             ChannelType::F32,
             current.layout(),
             current.alpha(),
@@ -1392,6 +1444,12 @@ fn intermediate_desc(current: PixelDescriptor, step: &ConvertStep) -> PixelDescr
             current.layout(),
             current.alpha(),
             TransferFunction::Bt709,
+        ),
+        ConvertStep::LinearF32ToGamma22F32 => PixelDescriptor::new(
+            ChannelType::F32,
+            current.layout(),
+            current.alpha(),
+            TransferFunction::Gamma22,
         ),
         ConvertStep::StraightToPremul => PixelDescriptor::new(
             current.channel_type(),

--- a/zenpixels-convert/src/convert_kernels.rs
+++ b/zenpixels-convert/src/convert_kernels.rs
@@ -168,6 +168,14 @@ pub(super) fn apply_step_u8(
             linear_f32_to_bt709_f32(src, dst, w, from.layout().channels());
         }
 
+        ConvertStep::Gamma22F32ToLinearF32 => {
+            gamma22_f32_to_linear_f32(src, dst, w, from.layout().channels());
+        }
+
+        ConvertStep::LinearF32ToGamma22F32 => {
+            linear_f32_to_gamma22_f32(src, dst, w, from.layout().channels());
+        }
+
         ConvertStep::StraightToPremul => {
             straight_to_premul(src, dst, w, from.channel_type(), from.layout());
         }
@@ -1006,6 +1014,39 @@ fn linear_f32_to_bt709_f32_inner(src: &[f32], dst: &mut [f32]) {
             dst[off + i] = linear_srgb::tf::linear_to_bt709(src[off + i]);
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Gamma 2.2 (Adobe RGB 1998) F32 ↔ Linear F32
+// ---------------------------------------------------------------------------
+
+/// Adobe RGB 1998 canonical exponent (563/256). Matches ~85% of real-world
+/// Adobe RGB ICC profiles (Adobe CS4, Windows ClayRGB1998, macOS AdobeRGB1998,
+/// Linux `AdobeRGB1998`, Nikon). Parametric-curve variants with a linear toe
+/// are routed through full CMS instead.
+///
+/// `2.19921875 = 563/256` is exact in f32; the allow suppresses clippy's
+/// decimal-digit heuristic.
+#[allow(clippy::excessive_precision)]
+const ADOBE_GAMMA: f32 = 2.19921875;
+
+/// Gamma 2.2 F32 → Linear F32 (EOTF, same depth). SIMD-dispatched via
+/// `linear_srgb::default::gamma_to_linear_slice`.
+fn gamma22_f32_to_linear_f32(src: &[u8], dst: &mut [u8], width: usize, channels: usize) {
+    let count = width * channels;
+    let srcf: &[f32] = bytemuck::cast_slice(&src[..count * 4]);
+    let dstf: &mut [f32] = bytemuck::cast_slice_mut(&mut dst[..count * 4]);
+    dstf[..count].copy_from_slice(&srcf[..count]);
+    linear_srgb::default::gamma_to_linear_slice(&mut dstf[..count], ADOBE_GAMMA);
+}
+
+/// Linear F32 → Gamma 2.2 F32 (OETF, same depth). SIMD-dispatched.
+fn linear_f32_to_gamma22_f32(src: &[u8], dst: &mut [u8], width: usize, channels: usize) {
+    let count = width * channels;
+    let srcf: &[f32] = bytemuck::cast_slice(&src[..count * 4]);
+    let dstf: &mut [f32] = bytemuck::cast_slice_mut(&mut dst[..count * 4]);
+    dstf[..count].copy_from_slice(&srcf[..count]);
+    linear_srgb::default::linear_to_gamma_slice(&mut dstf[..count], ADOBE_GAMMA);
 }
 
 // ---------------------------------------------------------------------------

--- a/zenpixels-convert/tests/gamma22_transfer.rs
+++ b/zenpixels-convert/tests/gamma22_transfer.rs
@@ -1,0 +1,230 @@
+//! First-class Gamma 2.2 (Adobe RGB 1998) transfer function paths.
+//!
+//! Exercises Gamma22 ↔ Linear as a dedicated step and composed conversions
+//! that route through linear (Gamma22 ↔ sRGB/BT.709/PQ/HLG, AdobeRGB ↔
+//! BT.709/BT.2020/DisplayP3 gamut crossings).
+
+use zenpixels::{
+    AlphaMode, ChannelLayout, ChannelType, ColorPrimaries, PixelDescriptor, TransferFunction,
+};
+use zenpixels_convert::RowConverter;
+
+#[allow(clippy::excessive_precision)]
+const ADOBE_GAMMA: f32 = 2.19921875; // 563/256, Adobe RGB 1998 spec (exact in f32).
+
+/// Ground truth: Adobe RGB 1998 is a pure power curve at this exponent.
+fn gamma22_to_linear(v: f32) -> f32 {
+    v.max(0.0).powf(ADOBE_GAMMA)
+}
+fn linear_to_gamma22(v: f32) -> f32 {
+    v.max(0.0).powf(1.0 / ADOBE_GAMMA)
+}
+
+fn f32_rgb_linear() -> PixelDescriptor {
+    PixelDescriptor::RGBF32_LINEAR.with_primaries(ColorPrimaries::AdobeRgb)
+}
+
+fn f32_rgb_gamma22() -> PixelDescriptor {
+    PixelDescriptor::new(
+        ChannelType::F32,
+        ChannelLayout::Rgb,
+        None,
+        TransferFunction::Gamma22,
+    )
+    .with_primaries(ColorPrimaries::AdobeRgb)
+}
+
+fn convert_f32_rgb(src_desc: PixelDescriptor, dst_desc: PixelDescriptor, src: &[f32]) -> Vec<f32> {
+    let mut conv = RowConverter::new(src_desc, dst_desc).unwrap();
+    let width = (src.len() / 3) as u32;
+    let mut dst = vec![0.0f32; src.len()];
+    conv.convert_row(
+        bytemuck::cast_slice(src),
+        bytemuck::cast_slice_mut(&mut dst),
+        width,
+    );
+    dst
+}
+
+#[test]
+fn gamma22_to_linear_f32_matches_powf() {
+    let src_desc = f32_rgb_gamma22();
+    let dst_desc = f32_rgb_linear();
+    let src: Vec<f32> = (0..=20).flat_map(|i| [i as f32 / 20.0; 3]).collect();
+    let dst = convert_f32_rgb(src_desc, dst_desc, &src);
+    for (s, d) in src.iter().zip(dst.iter()) {
+        let expected = gamma22_to_linear(*s);
+        assert!(
+            (d - expected).abs() < 1e-3,
+            "EOTF mismatch: gamma22({s}) -> {d}, expected {expected}"
+        );
+    }
+}
+
+#[test]
+fn linear_f32_to_gamma22_matches_powf() {
+    let src_desc = f32_rgb_linear();
+    let dst_desc = f32_rgb_gamma22();
+    let src: Vec<f32> = (0..=20).flat_map(|i| [i as f32 / 20.0; 3]).collect();
+    let dst = convert_f32_rgb(src_desc, dst_desc, &src);
+    for (s, d) in src.iter().zip(dst.iter()) {
+        let expected = linear_to_gamma22(*s);
+        assert!(
+            (d - expected).abs() < 1e-3,
+            "OETF mismatch: linear({s}) -> {d}, expected {expected}"
+        );
+    }
+}
+
+#[test]
+fn gamma22_linear_roundtrip_f32() {
+    let src: Vec<f32> = (0..=100).flat_map(|i| [i as f32 / 100.0; 3]).collect();
+    let lin = convert_f32_rgb(f32_rgb_gamma22(), f32_rgb_linear(), &src);
+    let back = convert_f32_rgb(f32_rgb_linear(), f32_rgb_gamma22(), &lin);
+    for (s, b) in src.iter().zip(back.iter()) {
+        assert!(
+            (s - b).abs() < 5e-4,
+            "roundtrip drift: {s} -> {b} (delta {})",
+            (s - b).abs()
+        );
+    }
+}
+
+/// Gamma22 → sRGB routes through linear (should be valid with matching primaries).
+#[test]
+fn gamma22_to_srgb_f32_via_linear() {
+    // Same primaries, different TF: a round-trip of encoded values through linear.
+    let src_desc = PixelDescriptor::new(
+        ChannelType::F32,
+        ChannelLayout::Rgb,
+        None,
+        TransferFunction::Gamma22,
+    );
+    let dst_desc = PixelDescriptor::new(
+        ChannelType::F32,
+        ChannelLayout::Rgb,
+        None,
+        TransferFunction::Srgb,
+    );
+    let src: Vec<f32> = (0..=10).flat_map(|i| [i as f32 / 10.0; 3]).collect();
+    let dst = convert_f32_rgb(src_desc, dst_desc, &src);
+    for (s, d) in src.iter().zip(dst.iter()) {
+        // Path: gamma22-encoded -> linear (gamma22 EOTF) -> sRGB-encoded (sRGB OETF).
+        let lin = gamma22_to_linear(*s);
+        let expected = linear_srgb::tf::linear_to_srgb(lin);
+        assert!(
+            (d - expected).abs() < 2e-3,
+            "gamma22->srgb via linear: {s} -> {d}, expected {expected}"
+        );
+    }
+}
+
+/// AdobeRGB F32 (gamma 2.2) → BT.2020 PQ F32: full HDR export path.
+/// Verifies the planner wires linearize → gamut → PQ-encode.
+#[test]
+fn adobe_rgb_to_bt2020_pq_f32_preserves_neutral_gray() {
+    let src_desc = PixelDescriptor::new(
+        ChannelType::F32,
+        ChannelLayout::Rgb,
+        None,
+        TransferFunction::Gamma22,
+    )
+    .with_primaries(ColorPrimaries::AdobeRgb);
+    let dst_desc = PixelDescriptor::new(
+        ChannelType::F32,
+        ChannelLayout::Rgb,
+        None,
+        TransferFunction::Pq,
+    )
+    .with_primaries(ColorPrimaries::Bt2020);
+
+    // Neutral gray: AdobeRGB encodes as (v, v, v) with v^2.2 linear.
+    let src: Vec<f32> = [0.25f32, 0.5, 0.75].iter().flat_map(|&v| [v; 3]).collect();
+    let dst = convert_f32_rgb(src_desc, dst_desc, &src);
+
+    // Gamut matrix preserves neutral gray (D65 → D65 white point match).
+    // Expected: gamma22 EOTF(v), then identity on gray axis, then PQ OETF.
+    for (chunk, &sv) in dst.chunks_exact(3).zip([0.25f32, 0.5, 0.75].iter()) {
+        let lin = gamma22_to_linear(sv);
+        let pq_expected = linear_srgb::tf::linear_to_pq(lin);
+        for &d in chunk {
+            assert!(
+                (d - pq_expected).abs() < 5e-3,
+                "gray axis not preserved: got {d}, expected {pq_expected} (src {sv})"
+            );
+        }
+    }
+}
+
+/// AdobeRGB U8 → sRGB U8: round-trip through the plan that goes
+/// NaiveU8→F32 → Gamma22 EOTF → gamut matrix → sRGB OETF → Naive F32→U8.
+/// Verifies the planner picks the Gamma22 linearize/encode arms we added.
+#[test]
+fn adobe_rgb_u8_to_srgb_u8_neutral_gray() {
+    let src_desc = PixelDescriptor::new(
+        ChannelType::U8,
+        ChannelLayout::Rgb,
+        None,
+        TransferFunction::Gamma22,
+    )
+    .with_primaries(ColorPrimaries::AdobeRgb);
+    let dst_desc = PixelDescriptor::RGB8_SRGB.with_primaries(ColorPrimaries::Bt709);
+
+    let src = [64u8, 64, 64, 128, 128, 128, 200, 200, 200];
+    let mut dst = [0u8; 9];
+    let mut conv = RowConverter::new(src_desc, dst_desc).unwrap();
+    conv.convert_row(&src, &mut dst, 3);
+
+    // Neutral gray should stay neutral (same luminance on gamut axis).
+    for px in dst.chunks_exact(3) {
+        assert!(
+            (px[0] as i32 - px[1] as i32).abs() <= 1 && (px[1] as i32 - px[2] as i32).abs() <= 1,
+            "neutral gray should stay neutral: {px:?}"
+        );
+    }
+    // Output channels should be > source channels since gamma 2.2 is a slightly
+    // steeper EOTF than sRGB — re-encoding in sRGB yields a brighter signal
+    // for the same linear light (at these mid-tones).
+    assert!(
+        dst[3] >= src[3],
+        "mid gray should not darken: {} -> {}",
+        src[3],
+        dst[3]
+    );
+}
+
+/// RGBA AdobeRGB → RGBA sRGB: with fully opaque alpha (1.0), alpha survives
+/// the TF roundtrip exactly (pow(1, x) == 1). Verifies the plan composes
+/// end-to-end for alpha-bearing layouts.
+#[test]
+fn adobe_rgb_rgba_f32_to_bt709_rgba_f32_opaque_alpha_preserved() {
+    let src_desc = PixelDescriptor::new(
+        ChannelType::F32,
+        ChannelLayout::Rgba,
+        Some(AlphaMode::Straight),
+        TransferFunction::Gamma22,
+    )
+    .with_primaries(ColorPrimaries::AdobeRgb);
+    let dst_desc = PixelDescriptor::new(
+        ChannelType::F32,
+        ChannelLayout::Rgba,
+        Some(AlphaMode::Straight),
+        TransferFunction::Srgb,
+    )
+    .with_primaries(ColorPrimaries::Bt709);
+
+    let src = [0.5f32, 0.3, 0.7, 1.0, 0.9, 0.8, 0.6, 1.0];
+    let mut dst = [0.0f32; 8];
+    let mut conv = RowConverter::new(src_desc, dst_desc).unwrap();
+    conv.convert_row(
+        bytemuck::cast_slice(&src),
+        bytemuck::cast_slice_mut(&mut dst),
+        2,
+    );
+
+    assert!((dst[3] - 1.0).abs() < 1e-4, "alpha ch0: {}", dst[3]);
+    assert!((dst[7] - 1.0).abs() < 1e-4, "alpha ch1: {}", dst[7]);
+    // RGB channels should actually change (different primaries + TF).
+    let rgb_changed = dst[0] != src[0] || dst[1] != src[1] || dst[2] != src[2];
+    assert!(rgb_changed, "RGB channels should be transformed");
+}


### PR DESCRIPTION
## Summary

- Add `ConvertStep::Gamma22F32ToLinearF32` / `LinearF32ToGamma22F32` so Gamma 2.2 (Adobe RGB 1998) has a dedicated EOTF/OETF instead of silently borrowing the sRGB fallback.
- Wire Gamma22 into `depth_steps` (Gamma22 ↔ {Linear, sRGB, BT.709, PQ, HLG} same-depth F32) and the primaries-conversion linearize/encode match so AdobeRGB ↔ PQ / HLG / BT.2020 / DisplayP3 / Linear composes end-to-end without falling through to the moxcms CMS backend.
- SIMD via `linear_srgb::default::{gamma_to_linear,linear_to_gamma}_slice` (AVX-512 / AVX2+FMA / NEON / WASM128 / scalar) with `ADOBE_GAMMA = 563/256 ≈ 2.19921875` — the canonical Adobe RGB 1998 exponent. Parametric-curve variants with a linear toe continue to route through full CMS unchanged.

## Motivation

Real-world still-image case: AdobeRGB JPEG/TIFF workflows exporting to HDR (AVIF/HEIF PQ/HLG) or interchange-converting to sRGB. Before this PR the planner either silently applied the sRGB EOTF to gamma-2.2 data (wrong) or dropped to the CMS slow path (correct but ~10–50× slower).

## Scope & non-goals

In scope: correct, SIMD-accelerated fast path for AdobeRGB ↔ other CICP-tagged spaces at U8 / U16 / F32.

Out of scope (acceptable follow-ups): fused `AdobeU8GamutRgb` LUT matlut step (AdobeRGB U8 currently composes through `NaiveU8ToF32 → Gamma22F32ToLinearF32 → gamut → …` — correct but not as fast as the sRGB fused path). Matrix coefficients and narrow signal range remain codec concerns.

## Public API

No public items added — new `ConvertStep` variants are `pub(crate)`, no signatures changed. Zero `cargo semver-checks` impact.

## Test plan

- [x] `cargo test -p zenpixels-convert --all-targets` — all existing suites green; 7 new tests in `tests/gamma22_transfer.rs` pass.
- [x] `cargo test -p zenpixels-convert --doc` passes.
- [x] `cargo clippy -p zenpixels-convert --all-targets -- -D warnings` clean.
- [x] `cargo build --workspace` clean.
- [ ] CI green on all platforms (Linux x86_64, `windows-11-arm`, macOS Intel, `i686-unknown-linux-gnu`).

### New test coverage

1. `gamma22_to_linear_f32_matches_powf` — EOTF matches `v.powf(2.19921875)` within 1e-3.
2. `linear_f32_to_gamma22_matches_powf` — OETF matches `v.powf(1/2.19921875)`.
3. `gamma22_linear_roundtrip_f32` — 101-point roundtrip drift < 5e-4.
4. `gamma22_to_srgb_f32_via_linear` — planner composes EOTF → OETF chain correctly.
5. `adobe_rgb_to_bt2020_pq_f32_preserves_neutral_gray` — full AdobeRGB→BT.2020 PQ HDR export path; neutral gray survives the gamut matrix.
6. `adobe_rgb_u8_to_srgb_u8_neutral_gray` — U8 path composes through `NaiveU8ToF32 → Gamma22F32ToLinearF32 → gamut → LinearF32ToSrgbF32 → NaiveF32ToU8`.
7. `adobe_rgb_rgba_f32_to_bt709_rgba_f32_opaque_alpha_preserved` — RGBA alpha survives the composite plan for opaque alpha=1.0.