### PR TITLE
fix(zenpixels-convert): planner no longer silently passes bytes through on TF changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## [Unreleased]
 
+### zenpixels-convert — fixed
+
+- **Planner no longer silently passes bytes through on TF changes** (fixes
+  issue [#19][] [A] and [B]). Previously, several descriptor pairs emitted
+  `[Identity]` or a naked depth-scale step labeled with the target TF but
+  applying no EOTF/OETF — producing wrong pixels with no error. Affected:
+  - Same-depth integer TF changes (U8 / U16): `Gamma22 → Srgb`, `Srgb →
+    Bt709`, `Pq → Srgb`, every other cross-TF pair. Now routes through an
+    F32 linear intermediate.
+  - Integer↔F32 cross-TF combinations without a fused kernel: `U8 Gamma22
+    → F32 Linear`, `U8 Bt709 → F32 Linear`, `U16 Gamma22 → F32 Linear`,
+    etc. Now composes `NaiveU8ToF32 / U16ToF32` with the appropriate F32
+    EOTF/OETF steps. Mid-gray error was up to 55× off for PQ inputs.
+  - `U8 Bt709 → F32 Linear` and `F32 Linear → U8 Bt709` previously used
+    the sRGB-specific fused kernel (`SrgbU8ToLinearF32` /
+    `LinearF32ToSrgbU8`), producing ~17% linear-light error vs the correct
+    BT.709 EOTF. Fused path now narrowed to sRGB; BT.709 composes through
+    the correct step.
+  - U16↔U8 and U8↔U16 cross-depth cross-TF combinations now compose
+    through F32 linear when a fused kernel doesn't exist.
+  Unknown TF on either side continues to pass bytes through as before (the
+  explicit-intent API is tracked in #19 [C]/[D] for deprecate-and-add).
+  Adds 54 regression tests in `tests/planner_silent_passthrough.rs`
+  covering every TF × depth combination, HDR (PQ/HLG), extended-range
+  out-of-gamut (`with_clip_out_of_gamut(false)`), and cross-primaries
+  crossings.
+
 ### zenpixels-convert — added
 
 - **First-class Gamma 2.2 (Adobe RGB 1998) transfer in the fast path.** New
@@ -13,6 +40,8 @@
   without hitting the moxcms CMS fallback. SIMD via
   `linear_srgb::default::{gamma_to_linear,linear_to_gamma}_slice` with
   `ADOBE_GAMMA = 563/256 ≈ 2.19921875`.
+
+[#19]: https://github.com/imazen/zenpixels/issues/19
 
 ## [0.2.9] - 2026-04-16
 

--- a/zenpixels-convert/src/convert.rs
+++ b/zenpixels-convert/src/convert.rs
@@ -275,10 +275,10 @@ impl ConvertPlan {
         let need_alpha_change =
             from.alpha() != to.alpha() && from.alpha().is_some() && to.alpha().is_some();
 
-        // Depth/TF steps are needed when depth changes, or when both are F32
-        // and transfer functions differ.
-        let need_depth_or_tf = need_depth_change
-            || (from.channel_type() == ChannelType::F32 && from.transfer() != to.transfer());
+        // Depth/TF steps are needed when depth changes, or when transfer
+        // functions differ (at any depth — integer TF changes route through
+        // an F32 linear intermediate, handled in `depth_steps`).
+        let need_depth_or_tf = need_depth_change || from.transfer() != to.transfer();
 
         // If we need to change depth AND layout, plan the optimal order.
         if need_layout_change {
@@ -878,11 +878,83 @@ fn layout_steps(from: ChannelLayout, to: ChannelLayout) -> Vec<ConvertStep> {
     }
 }
 
+/// F32→F32 linearize step for a transfer function, or `None` if the TF is
+/// already linear (or Unknown — caller decides how to handle Unknown).
+fn f32_linearize_step(tf: TransferFunction) -> Option<ConvertStep> {
+    match tf {
+        TransferFunction::Linear => None,
+        TransferFunction::Srgb => Some(ConvertStep::SrgbF32ToLinearF32),
+        TransferFunction::Bt709 => Some(ConvertStep::Bt709F32ToLinearF32),
+        TransferFunction::Pq => Some(ConvertStep::PqF32ToLinearF32),
+        TransferFunction::Hlg => Some(ConvertStep::HlgF32ToLinearF32),
+        TransferFunction::Gamma22 => Some(ConvertStep::Gamma22F32ToLinearF32),
+        TransferFunction::Unknown => None,
+        _ => None,
+    }
+}
+
+/// F32→F32 OETF step for a transfer function, or `None` if the TF is linear
+/// (or Unknown).
+fn f32_encode_step(tf: TransferFunction) -> Option<ConvertStep> {
+    match tf {
+        TransferFunction::Linear => None,
+        TransferFunction::Srgb => Some(ConvertStep::LinearF32ToSrgbF32),
+        TransferFunction::Bt709 => Some(ConvertStep::LinearF32ToBt709F32),
+        TransferFunction::Pq => Some(ConvertStep::LinearF32ToPqF32),
+        TransferFunction::Hlg => Some(ConvertStep::LinearF32ToHlgF32),
+        TransferFunction::Gamma22 => Some(ConvertStep::LinearF32ToGamma22F32),
+        TransferFunction::Unknown => None,
+        _ => None,
+    }
+}
+
+/// F32→F32 TF-change steps: linearize (if not already linear) then encode
+/// (if target is not linear).
+///
+/// Returns empty when `from == to`, or when either side is `Unknown` — when
+/// one side's TF is unknown we can't mechanically compute a correct
+/// conversion, so we preserve bytes as-is. Addressing the Unknown ambiguity
+/// via explicit opt-in API is tracked as issue #19 [C]/[D] (deprecate-and-add).
+fn f32_tf_pair_steps(from: TransferFunction, to: TransferFunction) -> Vec<ConvertStep> {
+    if from == to || from == TransferFunction::Unknown || to == TransferFunction::Unknown {
+        return Vec::new();
+    }
+    let mut steps = Vec::with_capacity(2);
+    if let Some(s) = f32_linearize_step(from) {
+        steps.push(s);
+    }
+    if let Some(s) = f32_encode_step(to) {
+        steps.push(s);
+    }
+    steps
+}
+
+/// Integer→F32 scale step for a given integer channel type. Panics for F32
+/// (caller must check); CMYK is rejected upstream by `assert_not_cmyk`.
+fn int_to_f32_step(ct: ChannelType) -> ConvertStep {
+    match ct {
+        ChannelType::U8 => ConvertStep::NaiveU8ToF32,
+        ChannelType::U16 => ConvertStep::U16ToF32,
+        _ => unreachable!("int_to_f32_step called with non-integer channel type"),
+    }
+}
+
+/// F32→integer scale step.
+fn f32_to_int_step(ct: ChannelType) -> ConvertStep {
+    match ct {
+        ChannelType::U8 => ConvertStep::NaiveF32ToU8,
+        ChannelType::U16 => ConvertStep::F32ToU16,
+        _ => unreachable!("f32_to_int_step called with non-integer channel type"),
+    }
+}
+
 /// Determine the depth conversion step(s), considering transfer functions.
 ///
-/// Returns one or two steps. Two steps are needed when the conversion
-/// requires going through an intermediate format (e.g. PQ U16 → sRGB U8
-/// goes PQ U16 → Linear F32 → sRGB U8).
+/// Returns one or more steps. Multi-step conversions route through an F32
+/// linear intermediate (e.g. PQ U16 → sRGB U8 goes PQ U16 → Linear F32 →
+/// sRGB U8), and same-depth integer TF changes route through an F32 linear
+/// intermediate too: passing integer bytes through unchanged under a new
+/// TF label produces wrong pixels.
 fn depth_steps(
     from: ChannelType,
     to: ChannelType,
@@ -893,151 +965,61 @@ fn depth_steps(
         return Ok(Vec::new());
     }
 
-    // Same depth, different transfer function.
-    // For integer types, TF changes are metadata-only (no math).
-    // For F32, we can apply EOTF/OETF in place.
-    if from == to && from != ChannelType::F32 {
-        return Ok(Vec::new());
+    // Same depth, F32: apply EOTF/OETF in place.
+    if from == to && from == ChannelType::F32 {
+        return Ok(f32_tf_pair_steps(from_tf, to_tf));
     }
 
-    if from == to && from == ChannelType::F32 {
-        return match (from_tf, to_tf) {
-            (TransferFunction::Pq, TransferFunction::Linear) => {
-                Ok(vec![ConvertStep::PqF32ToLinearF32])
-            }
-            (TransferFunction::Linear, TransferFunction::Pq) => {
-                Ok(vec![ConvertStep::LinearF32ToPqF32])
-            }
-            (TransferFunction::Hlg, TransferFunction::Linear) => {
-                Ok(vec![ConvertStep::HlgF32ToLinearF32])
-            }
-            (TransferFunction::Linear, TransferFunction::Hlg) => {
-                Ok(vec![ConvertStep::LinearF32ToHlgF32])
-            }
-            // PQ ↔ HLG: go through linear.
-            (TransferFunction::Pq, TransferFunction::Hlg) => Ok(vec![
-                ConvertStep::PqF32ToLinearF32,
-                ConvertStep::LinearF32ToHlgF32,
-            ]),
-            (TransferFunction::Hlg, TransferFunction::Pq) => Ok(vec![
-                ConvertStep::HlgF32ToLinearF32,
-                ConvertStep::LinearF32ToPqF32,
-            ]),
-            (TransferFunction::Srgb, TransferFunction::Linear) => {
-                Ok(vec![ConvertStep::SrgbF32ToLinearF32])
-            }
-            (TransferFunction::Linear, TransferFunction::Srgb) => {
-                Ok(vec![ConvertStep::LinearF32ToSrgbF32])
-            }
-            (TransferFunction::Bt709, TransferFunction::Linear) => {
-                Ok(vec![ConvertStep::Bt709F32ToLinearF32])
-            }
-            (TransferFunction::Linear, TransferFunction::Bt709) => {
-                Ok(vec![ConvertStep::LinearF32ToBt709F32])
-            }
-            // sRGB ↔ BT.709: go through linear.
-            (TransferFunction::Srgb, TransferFunction::Bt709) => Ok(vec![
-                ConvertStep::SrgbF32ToLinearF32,
-                ConvertStep::LinearF32ToBt709F32,
-            ]),
-            (TransferFunction::Bt709, TransferFunction::Srgb) => Ok(vec![
-                ConvertStep::Bt709F32ToLinearF32,
-                ConvertStep::LinearF32ToSrgbF32,
-            ]),
-            // sRGB/BT.709 ↔ PQ/HLG: go through linear.
-            (TransferFunction::Srgb, TransferFunction::Pq) => Ok(vec![
-                ConvertStep::SrgbF32ToLinearF32,
-                ConvertStep::LinearF32ToPqF32,
-            ]),
-            (TransferFunction::Srgb, TransferFunction::Hlg) => Ok(vec![
-                ConvertStep::SrgbF32ToLinearF32,
-                ConvertStep::LinearF32ToHlgF32,
-            ]),
-            (TransferFunction::Pq, TransferFunction::Srgb) => Ok(vec![
-                ConvertStep::PqF32ToLinearF32,
-                ConvertStep::LinearF32ToSrgbF32,
-            ]),
-            (TransferFunction::Hlg, TransferFunction::Srgb) => Ok(vec![
-                ConvertStep::HlgF32ToLinearF32,
-                ConvertStep::LinearF32ToSrgbF32,
-            ]),
-            (TransferFunction::Bt709, TransferFunction::Pq) => Ok(vec![
-                ConvertStep::Bt709F32ToLinearF32,
-                ConvertStep::LinearF32ToPqF32,
-            ]),
-            (TransferFunction::Bt709, TransferFunction::Hlg) => Ok(vec![
-                ConvertStep::Bt709F32ToLinearF32,
-                ConvertStep::LinearF32ToHlgF32,
-            ]),
-            (TransferFunction::Pq, TransferFunction::Bt709) => Ok(vec![
-                ConvertStep::PqF32ToLinearF32,
-                ConvertStep::LinearF32ToBt709F32,
-            ]),
-            (TransferFunction::Hlg, TransferFunction::Bt709) => Ok(vec![
-                ConvertStep::HlgF32ToLinearF32,
-                ConvertStep::LinearF32ToBt709F32,
-            ]),
-            // Gamma 2.2 (Adobe RGB 1998) ↔ Linear.
-            (TransferFunction::Gamma22, TransferFunction::Linear) => {
-                Ok(vec![ConvertStep::Gamma22F32ToLinearF32])
-            }
-            (TransferFunction::Linear, TransferFunction::Gamma22) => {
-                Ok(vec![ConvertStep::LinearF32ToGamma22F32])
-            }
-            // Gamma 2.2 ↔ {sRGB, BT.709, PQ, HLG}: go through linear.
-            (TransferFunction::Gamma22, TransferFunction::Srgb) => Ok(vec![
-                ConvertStep::Gamma22F32ToLinearF32,
-                ConvertStep::LinearF32ToSrgbF32,
-            ]),
-            (TransferFunction::Srgb, TransferFunction::Gamma22) => Ok(vec![
-                ConvertStep::SrgbF32ToLinearF32,
-                ConvertStep::LinearF32ToGamma22F32,
-            ]),
-            (TransferFunction::Gamma22, TransferFunction::Bt709) => Ok(vec![
-                ConvertStep::Gamma22F32ToLinearF32,
-                ConvertStep::LinearF32ToBt709F32,
-            ]),
-            (TransferFunction::Bt709, TransferFunction::Gamma22) => Ok(vec![
-                ConvertStep::Bt709F32ToLinearF32,
-                ConvertStep::LinearF32ToGamma22F32,
-            ]),
-            (TransferFunction::Gamma22, TransferFunction::Pq) => Ok(vec![
-                ConvertStep::Gamma22F32ToLinearF32,
-                ConvertStep::LinearF32ToPqF32,
-            ]),
-            (TransferFunction::Pq, TransferFunction::Gamma22) => Ok(vec![
-                ConvertStep::PqF32ToLinearF32,
-                ConvertStep::LinearF32ToGamma22F32,
-            ]),
-            (TransferFunction::Gamma22, TransferFunction::Hlg) => Ok(vec![
-                ConvertStep::Gamma22F32ToLinearF32,
-                ConvertStep::LinearF32ToHlgF32,
-            ]),
-            (TransferFunction::Hlg, TransferFunction::Gamma22) => Ok(vec![
-                ConvertStep::HlgF32ToLinearF32,
-                ConvertStep::LinearF32ToGamma22F32,
-            ]),
-            _ => Ok(Vec::new()),
-        };
+    // Same depth, integer: TF change requires re-encoding. Route through F32
+    // linear intermediate — passing bytes through labeled as a different TF
+    // produces wrong pixels.
+    //
+    // Exception: if either TF is Unknown, we don't know the correct conversion.
+    // Preserve bytes exactly (no F32 round-trip — that would introduce U8/U16
+    // rounding error for no semantic benefit). Addressed properly by issue
+    // #19 [C]/[D] via opt-in deprecate-and-add.
+    if from == to && from != ChannelType::F32 {
+        if from_tf == TransferFunction::Unknown || to_tf == TransferFunction::Unknown {
+            return Ok(Vec::new());
+        }
+        let mut steps = Vec::with_capacity(4);
+        steps.push(int_to_f32_step(from));
+        steps.extend(f32_tf_pair_steps(from_tf, to_tf));
+        steps.push(f32_to_int_step(to));
+        return Ok(steps);
     }
 
     match (from, to) {
         (ChannelType::U8, ChannelType::F32) => {
-            if (from_tf == TransferFunction::Srgb || from_tf == TransferFunction::Bt709)
-                && to_tf == TransferFunction::Linear
-            {
+            // Fused sRGB EOTF kernel — sRGB only. BT.709 uses a different EOTF
+            // (~17% linear-light error at mid-gray if we routed it through the
+            // sRGB kernel) and must compose through the F32 BT.709 EOTF step.
+            if from_tf == TransferFunction::Srgb && to_tf == TransferFunction::Linear {
                 Ok(vec![ConvertStep::SrgbU8ToLinearF32])
-            } else {
+            } else if from_tf == to_tf {
                 Ok(vec![ConvertStep::NaiveU8ToF32])
+            } else {
+                // Cross-depth + cross-TF: linearize/encode after the U8→F32 scale.
+                // Previously dropped the TF math and returned bytes labeled with
+                // the target TF — silent wrong pixels for any TF pair other than
+                // {Srgb,Bt709}→Linear.
+                let mut steps = Vec::with_capacity(3);
+                steps.push(ConvertStep::NaiveU8ToF32);
+                steps.extend(f32_tf_pair_steps(from_tf, to_tf));
+                Ok(steps)
             }
         }
         (ChannelType::F32, ChannelType::U8) => {
-            if from_tf == TransferFunction::Linear
-                && (to_tf == TransferFunction::Srgb || to_tf == TransferFunction::Bt709)
-            {
+            // Fused sRGB OETF kernel — sRGB only (same reason as above).
+            if from_tf == TransferFunction::Linear && to_tf == TransferFunction::Srgb {
                 Ok(vec![ConvertStep::LinearF32ToSrgbU8])
-            } else {
+            } else if from_tf == to_tf {
                 Ok(vec![ConvertStep::NaiveF32ToU8])
+            } else {
+                // Linearize/encode in F32 first, then compress to U8.
+                let mut steps = f32_tf_pair_steps(from_tf, to_tf);
+                steps.push(ConvertStep::NaiveF32ToU8);
+                Ok(steps)
             }
         }
         (ChannelType::U16, ChannelType::F32) => {
@@ -1049,7 +1031,13 @@ fn depth_steps(
                 (TransferFunction::Hlg, TransferFunction::Linear) => {
                     Ok(vec![ConvertStep::HlgU16ToLinearF32])
                 }
-                _ => Ok(vec![ConvertStep::U16ToF32]),
+                (a, b) if a == b => Ok(vec![ConvertStep::U16ToF32]),
+                _ => {
+                    let mut steps = Vec::with_capacity(3);
+                    steps.push(ConvertStep::U16ToF32);
+                    steps.extend(f32_tf_pair_steps(from_tf, to_tf));
+                    Ok(steps)
+                }
             }
         }
         (ChannelType::F32, ChannelType::U16) => {
@@ -1061,7 +1049,12 @@ fn depth_steps(
                 (TransferFunction::Linear, TransferFunction::Hlg) => {
                     Ok(vec![ConvertStep::LinearF32ToHlgU16])
                 }
-                _ => Ok(vec![ConvertStep::F32ToU16]),
+                (a, b) if a == b => Ok(vec![ConvertStep::F32ToU16]),
+                _ => {
+                    let mut steps = f32_tf_pair_steps(from_tf, to_tf);
+                    steps.push(ConvertStep::F32ToU16);
+                    Ok(steps)
+                }
             }
         }
         (ChannelType::U16, ChannelType::U8) => {
@@ -1076,11 +1069,27 @@ fn depth_steps(
                     ConvertStep::HlgU16ToLinearF32,
                     ConvertStep::LinearF32ToSrgbU8,
                 ])
-            } else {
+            } else if from_tf == to_tf {
                 Ok(vec![ConvertStep::U16ToU8])
+            } else {
+                let mut steps = Vec::with_capacity(4);
+                steps.push(ConvertStep::U16ToF32);
+                steps.extend(f32_tf_pair_steps(from_tf, to_tf));
+                steps.push(ConvertStep::NaiveF32ToU8);
+                Ok(steps)
             }
         }
-        (ChannelType::U8, ChannelType::U16) => Ok(vec![ConvertStep::U8ToU16]),
+        (ChannelType::U8, ChannelType::U16) => {
+            if from_tf == to_tf {
+                Ok(vec![ConvertStep::U8ToU16])
+            } else {
+                let mut steps = Vec::with_capacity(4);
+                steps.push(ConvertStep::NaiveU8ToF32);
+                steps.extend(f32_tf_pair_steps(from_tf, to_tf));
+                steps.push(ConvertStep::F32ToU16);
+                Ok(steps)
+            }
+        }
         _ => Err(ConvertError::NoPath {
             from: PixelDescriptor::new(from, ChannelLayout::Rgb, None, from_tf),
             to: PixelDescriptor::new(to, ChannelLayout::Rgb, None, to_tf),

--- a/zenpixels-convert/tests/cicp_transfer_correctness.rs
+++ b/zenpixels-convert/tests/cicp_transfer_correctness.rs
@@ -831,11 +831,14 @@ fn buffer_linearize_bt709_u8() {
     assert_eq!(lin.descriptor().transfer(), TransferFunction::Linear);
     // Black → 0
     assert!(read_f32(&lin, 0).abs() < 1e-6);
-    // Mid-gray → ~0.21
+    // Mid-gray U8=128 (0.502 normalized) through BT.709 EOTF
+    // = ((0.502+0.099)/1.099)^(1/0.45) ≈ 0.2616.
+    // (Prior to the planner fix for issue #19 [B], this path routed through the
+    // sRGB-specific kernel and produced ~0.216 — silently wrong.)
     let mid = read_f32(&lin, 12);
     assert!(
-        mid > 0.18 && mid < 0.25,
-        "BT.709 mid-gray linearized: {mid}"
+        (mid - 0.2616).abs() < 0.01,
+        "BT.709 mid-gray linearized: {mid} (expected ≈0.2616)"
     );
     // White → 1
     assert!((read_f32(&lin, 36) - 1.0).abs() < 1e-5);

--- a/zenpixels-convert/tests/planner_silent_passthrough.rs
+++ b/zenpixels-convert/tests/planner_silent_passthrough.rs
@@ -1,0 +1,904 @@
+//! Comprehensive coverage for issue #19 [A] and [B] (silent wrong-pixel
+//! planner bugs) plus the broader transfer-function and conversion-path
+//! matrix: every TF × every depth, HDR (PQ/HLG), out-of-gamut / extended
+//! range, cross-primaries + cross-TF, and Unknown-TF passthrough.
+//!
+//! The pattern for every case is: construct a descriptor pair, build the
+//! plan via `RowConverter::new` (or `new_explicit` for policy-sensitive
+//! cases), run a ramp of real byte values through it, and compare against
+//! a hand-coded ground-truth EOTF/OETF. A pass means the planner composed
+//! the right steps AND the kernels executed correctly.
+
+// PQ / Adobe-gamma / HLG constants exceed f32 mantissa precision in their
+// written form, but round correctly during compilation. Silence clippy.
+#![allow(clippy::excessive_precision)]
+
+use zenpixels::{
+    AlphaMode, ChannelLayout, ChannelType, ColorPrimaries, PixelDescriptor, TransferFunction,
+};
+use zenpixels_convert::{RowConverter, policy::ConvertOptions};
+
+// ── Ground-truth EOTF/OETF ───────────────────────────────────────────────
+
+const ADOBE_GAMMA: f32 = 2.199_218_75;
+
+fn srgb_eotf(v: f32) -> f32 {
+    if v <= 0.040_45 {
+        v / 12.92
+    } else {
+        ((v + 0.055) / 1.055).powf(2.4)
+    }
+}
+
+fn srgb_oetf(v: f32) -> f32 {
+    if v <= 0.003_130_8 {
+        v * 12.92
+    } else {
+        1.055 * v.powf(1.0 / 2.4) - 0.055
+    }
+}
+
+fn bt709_eotf(v: f32) -> f32 {
+    if v < 0.081 {
+        v / 4.5
+    } else {
+        ((v + 0.099) / 1.099).powf(1.0 / 0.45)
+    }
+}
+
+fn bt709_oetf(v: f32) -> f32 {
+    if v < 0.018 {
+        v * 4.5
+    } else {
+        1.099 * v.powf(0.45) - 0.099
+    }
+}
+
+fn gamma22_eotf(v: f32) -> f32 {
+    v.max(0.0).powf(ADOBE_GAMMA)
+}
+
+fn gamma22_oetf(v: f32) -> f32 {
+    v.max(0.0).powf(1.0 / ADOBE_GAMMA)
+}
+
+fn pq_eotf(v: f32) -> f32 {
+    const M1: f32 = 0.159_301_757_812_5;
+    const M2: f32 = 78.843_75;
+    const C1: f32 = 0.835_937_5;
+    const C2: f32 = 18.851_562_5;
+    const C3: f32 = 18.687_5;
+    let vp = v.max(0.0).powf(1.0 / M2);
+    let num = (vp - C1).max(0.0);
+    let den = C2 - C3 * vp;
+    if den <= 0.0 {
+        0.0
+    } else {
+        (num / den).powf(1.0 / M1)
+    }
+}
+
+fn pq_oetf(v: f32) -> f32 {
+    const M1: f32 = 0.159_301_757_812_5;
+    const M2: f32 = 78.843_75;
+    const C1: f32 = 0.835_937_5;
+    const C2: f32 = 18.851_562_5;
+    const C3: f32 = 18.687_5;
+    let lp = v.max(0.0).powf(M1);
+    ((C1 + C2 * lp) / (1.0 + C3 * lp)).powf(M2)
+}
+
+// ITU-R BT.2100 HLG OETF constants.
+const HLG_A: f32 = 0.178_832_77;
+const HLG_B: f32 = 1.0 - 4.0 * HLG_A;
+// c = 0.5 - a·ln(4a) ≈ 0.55991073 (precomputed — can't be const in f32).
+const HLG_C: f32 = 0.559_910_73;
+
+fn hlg_eotf(v: f32) -> f32 {
+    // HLG inverse OETF (scene-referred ramp; no OOTF applied here).
+    if v <= 0.5 {
+        (v * v) / 3.0
+    } else {
+        (((v - HLG_C) / HLG_A).exp() + HLG_B) / 12.0
+    }
+}
+
+fn hlg_oetf(v: f32) -> f32 {
+    let v = v.max(0.0);
+    if v <= 1.0 / 12.0 {
+        (3.0 * v).sqrt()
+    } else {
+        HLG_A * (12.0 * v - HLG_B).ln() + HLG_C
+    }
+}
+
+fn eotf_of(tf: TransferFunction) -> fn(f32) -> f32 {
+    match tf {
+        TransferFunction::Linear => |v| v,
+        TransferFunction::Srgb => srgb_eotf,
+        TransferFunction::Bt709 => bt709_eotf,
+        TransferFunction::Gamma22 => gamma22_eotf,
+        TransferFunction::Pq => pq_eotf,
+        TransferFunction::Hlg => hlg_eotf,
+        _ => |v| v,
+    }
+}
+
+fn oetf_of(tf: TransferFunction) -> fn(f32) -> f32 {
+    match tf {
+        TransferFunction::Linear => |v| v,
+        TransferFunction::Srgb => srgb_oetf,
+        TransferFunction::Bt709 => bt709_oetf,
+        TransferFunction::Gamma22 => gamma22_oetf,
+        TransferFunction::Pq => pq_oetf,
+        TransferFunction::Hlg => hlg_oetf,
+        _ => |v| v,
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+fn rgb(ct: ChannelType, tf: TransferFunction) -> PixelDescriptor {
+    PixelDescriptor::new(ct, ChannelLayout::Rgb, None, tf)
+}
+
+fn rgba(ct: ChannelType, tf: TransferFunction, alpha: AlphaMode) -> PixelDescriptor {
+    PixelDescriptor::new(ct, ChannelLayout::Rgba, Some(alpha), tf)
+}
+
+fn u8_to_f32(src_u8: u8) -> f32 {
+    src_u8 as f32 / 255.0
+}
+
+fn u16_to_f32(src_u16: u16) -> f32 {
+    src_u16 as f32 / 65535.0
+}
+
+fn u8_of(v: f32) -> u8 {
+    (v.clamp(0.0, 1.0) * 255.0).round() as u8
+}
+
+fn u16_of(v: f32) -> u16 {
+    (v.clamp(0.0, 1.0) * 65535.0).round() as u16
+}
+
+// Tolerances calibrated for mid-scale test samples; HDR (PQ/HLG) needs more
+// slack because the curves compress many linear decades into u8/u16.
+const U8_TOL: i32 = 1;
+const U16_TOL: i32 = 64;
+const F32_TOL_NORMAL: f32 = 5e-4;
+const F32_TOL_LOOSE: f32 = 5e-3; // PQ/HLG mid-range
+const HDR_U8_TOL: i32 = 2;
+
+// =========================================================================
+// [A] Same-depth integer TF changes — were silently `[Identity]`
+// =========================================================================
+//
+// For each SDR TF pair where the EOTFs diverge at the chosen sample code,
+// verify the output re-encodes correctly.
+
+fn assert_u8_same_depth_tf(sample: u8, from_tf: TransferFunction, to_tf: TransferFunction) {
+    let src_d = rgb(ChannelType::U8, from_tf);
+    let dst_d = rgb(ChannelType::U8, to_tf);
+    let mut c = RowConverter::new(src_d, dst_d).unwrap();
+    let src = [sample, sample, sample];
+    let mut dst = [0u8; 3];
+    c.convert_row(&src, &mut dst, 1);
+
+    let linear = (eotf_of(from_tf))(u8_to_f32(sample));
+    let expected = u8_of((oetf_of(to_tf))(linear));
+    for ch in dst {
+        let diff = (ch as i32 - expected as i32).abs();
+        assert!(
+            diff <= U8_TOL,
+            "U8 {from_tf:?} → U8 {to_tf:?} @ sample={sample}: got {ch}, expected {expected}"
+        );
+    }
+}
+
+#[test]
+fn u8_same_depth_gamma22_to_srgb_at_toe() {
+    assert_u8_same_depth_tf(20, TransferFunction::Gamma22, TransferFunction::Srgb);
+}
+
+#[test]
+fn u8_same_depth_srgb_to_gamma22_at_toe() {
+    assert_u8_same_depth_tf(20, TransferFunction::Srgb, TransferFunction::Gamma22);
+}
+
+#[test]
+fn u8_same_depth_bt709_to_srgb_at_toe() {
+    assert_u8_same_depth_tf(20, TransferFunction::Bt709, TransferFunction::Srgb);
+}
+
+#[test]
+fn u8_same_depth_srgb_to_bt709_at_toe() {
+    assert_u8_same_depth_tf(20, TransferFunction::Srgb, TransferFunction::Bt709);
+}
+
+#[test]
+fn u8_same_depth_gamma22_to_bt709_at_toe() {
+    assert_u8_same_depth_tf(20, TransferFunction::Gamma22, TransferFunction::Bt709);
+}
+
+#[test]
+fn u8_same_depth_bt709_to_gamma22_at_toe() {
+    assert_u8_same_depth_tf(20, TransferFunction::Bt709, TransferFunction::Gamma22);
+}
+
+#[test]
+fn u8_same_depth_gamma22_to_srgb_at_highlight() {
+    assert_u8_same_depth_tf(240, TransferFunction::Gamma22, TransferFunction::Srgb);
+}
+
+#[test]
+fn u8_same_depth_pq_to_srgb_diverges_wildly() {
+    // PQ at U8 is an ill-defined bit depth (PQ needs 10+ bits for its
+    // dynamic range) but must not silently pass-through.
+    let src_d = rgb(ChannelType::U8, TransferFunction::Pq);
+    let dst_d = rgb(ChannelType::U8, TransferFunction::Srgb);
+    let mut c = RowConverter::new(src_d, dst_d).unwrap();
+    let src = [128u8, 128, 128];
+    let mut dst = [0u8; 3];
+    c.convert_row(&src, &mut dst, 1);
+    assert_ne!(dst[0], 128, "PQ→sRGB at U8 128 must re-encode");
+}
+
+#[test]
+fn u16_same_depth_gamma22_to_srgb_at_toe() {
+    let src_d = rgb(ChannelType::U16, TransferFunction::Gamma22);
+    let dst_d = rgb(ChannelType::U16, TransferFunction::Srgb);
+    let mut c = RowConverter::new(src_d, dst_d).unwrap();
+    let src = [5000u16, 5000, 5000];
+    let mut dst = [0u16; 3];
+    c.convert_row(
+        bytemuck::cast_slice(&src),
+        bytemuck::cast_slice_mut(&mut dst),
+        1,
+    );
+    let linear = gamma22_eotf(u16_to_f32(5000));
+    let expected = u16_of(srgb_oetf(linear));
+    for ch in dst {
+        let diff = (ch as i32 - expected as i32).abs();
+        assert!(
+            diff <= U16_TOL,
+            "U16 Gamma22→Srgb: got {ch}, expected {expected}"
+        );
+    }
+    assert_ne!(dst[0], 5000);
+}
+
+// =========================================================================
+// [B] Cross-depth TF changes — int↔F32 dropped EOTF/OETF before fix
+// =========================================================================
+
+fn assert_u8_to_f32_linearize(sample: u8, tf: TransferFunction) {
+    let src_d = rgb(ChannelType::U8, tf);
+    let dst_d = rgb(ChannelType::F32, TransferFunction::Linear);
+    let mut c = RowConverter::new(src_d, dst_d).unwrap();
+    let src = [sample, sample, sample];
+    let mut dst = [0f32; 3];
+    c.convert_row(&src, bytemuck::cast_slice_mut(&mut dst), 1);
+    let expected = (eotf_of(tf))(u8_to_f32(sample));
+    let tol = match tf {
+        TransferFunction::Pq | TransferFunction::Hlg => F32_TOL_LOOSE,
+        _ => F32_TOL_NORMAL,
+    };
+    for ch in dst {
+        assert!(
+            (ch - expected).abs() < tol,
+            "U8 {tf:?} → F32 Linear @ sample={sample}: got {ch}, expected {expected}"
+        );
+    }
+}
+
+#[test]
+fn u8_srgb_to_f32_linear_mid() {
+    assert_u8_to_f32_linearize(128, TransferFunction::Srgb);
+}
+#[test]
+fn u8_bt709_to_f32_linear_mid() {
+    assert_u8_to_f32_linearize(128, TransferFunction::Bt709);
+}
+#[test]
+fn u8_gamma22_to_f32_linear_mid() {
+    assert_u8_to_f32_linearize(128, TransferFunction::Gamma22);
+}
+#[test]
+fn u8_srgb_to_f32_linear_toe() {
+    assert_u8_to_f32_linearize(10, TransferFunction::Srgb);
+}
+#[test]
+fn u8_bt709_to_f32_linear_toe() {
+    assert_u8_to_f32_linearize(10, TransferFunction::Bt709);
+}
+#[test]
+fn u8_gamma22_to_f32_linear_toe() {
+    assert_u8_to_f32_linearize(10, TransferFunction::Gamma22);
+}
+#[test]
+fn u8_srgb_to_f32_linear_highlight() {
+    assert_u8_to_f32_linearize(240, TransferFunction::Srgb);
+}
+#[test]
+fn u8_bt709_to_f32_linear_highlight() {
+    assert_u8_to_f32_linearize(240, TransferFunction::Bt709);
+}
+#[test]
+fn u8_gamma22_to_f32_linear_highlight() {
+    assert_u8_to_f32_linearize(240, TransferFunction::Gamma22);
+}
+
+fn assert_f32_linear_to_u8(sample: f32, tf: TransferFunction) {
+    let src_d = rgb(ChannelType::F32, TransferFunction::Linear);
+    let dst_d = rgb(ChannelType::U8, tf);
+    let mut c = RowConverter::new(src_d, dst_d).unwrap();
+    let src = [sample, sample, sample];
+    let mut dst = [0u8; 3];
+    c.convert_row(bytemuck::cast_slice(&src), &mut dst, 1);
+    let expected = u8_of((oetf_of(tf))(sample));
+    for ch in dst {
+        let diff = (ch as i32 - expected as i32).abs();
+        assert!(
+            diff <= U8_TOL,
+            "F32 Linear → U8 {tf:?} @ {sample}: got {ch}, expected {expected}"
+        );
+    }
+}
+
+#[test]
+fn f32_linear_to_u8_srgb_mid() {
+    assert_f32_linear_to_u8(0.217, TransferFunction::Srgb);
+}
+#[test]
+fn f32_linear_to_u8_bt709_mid() {
+    assert_f32_linear_to_u8(0.261, TransferFunction::Bt709);
+}
+#[test]
+fn f32_linear_to_u8_gamma22_mid() {
+    assert_f32_linear_to_u8(0.217, TransferFunction::Gamma22);
+}
+#[test]
+fn f32_linear_to_u8_srgb_low() {
+    assert_f32_linear_to_u8(0.001, TransferFunction::Srgb);
+}
+#[test]
+fn f32_linear_to_u8_srgb_high() {
+    assert_f32_linear_to_u8(0.9, TransferFunction::Srgb);
+}
+
+fn assert_u16_to_f32_linearize(sample: u16, tf: TransferFunction) {
+    let src_d = rgb(ChannelType::U16, tf);
+    let dst_d = rgb(ChannelType::F32, TransferFunction::Linear);
+    let mut c = RowConverter::new(src_d, dst_d).unwrap();
+    let src = [sample, sample, sample];
+    let mut dst = [0f32; 3];
+    c.convert_row(
+        bytemuck::cast_slice(&src),
+        bytemuck::cast_slice_mut(&mut dst),
+        1,
+    );
+    let expected = (eotf_of(tf))(u16_to_f32(sample));
+    let tol = match tf {
+        TransferFunction::Pq | TransferFunction::Hlg => F32_TOL_LOOSE,
+        _ => F32_TOL_NORMAL,
+    };
+    for ch in dst {
+        assert!(
+            (ch - expected).abs() < tol,
+            "U16 {tf:?} → F32 Linear @ {sample}: got {ch}, expected {expected}"
+        );
+    }
+}
+
+#[test]
+fn u16_srgb_to_f32_linear() {
+    assert_u16_to_f32_linearize(32768, TransferFunction::Srgb);
+}
+#[test]
+fn u16_bt709_to_f32_linear() {
+    assert_u16_to_f32_linearize(32768, TransferFunction::Bt709);
+}
+#[test]
+fn u16_gamma22_to_f32_linear() {
+    assert_u16_to_f32_linearize(32768, TransferFunction::Gamma22);
+}
+#[test]
+fn u16_pq_to_f32_linear() {
+    assert_u16_to_f32_linearize(32768, TransferFunction::Pq);
+}
+#[test]
+fn u16_hlg_to_f32_linear() {
+    assert_u16_to_f32_linearize(32768, TransferFunction::Hlg);
+}
+
+fn assert_f32_linear_to_u16(sample: f32, tf: TransferFunction) {
+    let src_d = rgb(ChannelType::F32, TransferFunction::Linear);
+    let dst_d = rgb(ChannelType::U16, tf);
+    let mut c = RowConverter::new(src_d, dst_d).unwrap();
+    let src = [sample, sample, sample];
+    let mut dst = [0u16; 3];
+    c.convert_row(
+        bytemuck::cast_slice(&src),
+        bytemuck::cast_slice_mut(&mut dst),
+        1,
+    );
+    let expected = u16_of((oetf_of(tf))(sample));
+    for ch in dst {
+        let diff = (ch as i32 - expected as i32).abs();
+        assert!(
+            diff <= U16_TOL,
+            "F32 Linear → U16 {tf:?} @ {sample}: got {ch}, expected {expected}"
+        );
+    }
+}
+
+#[test]
+fn f32_linear_to_u16_srgb() {
+    assert_f32_linear_to_u16(0.217, TransferFunction::Srgb);
+}
+#[test]
+fn f32_linear_to_u16_bt709() {
+    assert_f32_linear_to_u16(0.261, TransferFunction::Bt709);
+}
+#[test]
+fn f32_linear_to_u16_gamma22() {
+    assert_f32_linear_to_u16(0.217, TransferFunction::Gamma22);
+}
+#[test]
+fn f32_linear_to_u16_pq() {
+    assert_f32_linear_to_u16(0.1, TransferFunction::Pq);
+}
+#[test]
+fn f32_linear_to_u16_hlg() {
+    assert_f32_linear_to_u16(0.25, TransferFunction::Hlg);
+}
+
+// =========================================================================
+// U16 ↔ U8 cross-depth cross-TF
+// =========================================================================
+
+#[test]
+fn u16_gamma22_to_u8_srgb() {
+    // Pre-fix: would drop the TF change entirely. Now must compose.
+    let src_d = rgb(ChannelType::U16, TransferFunction::Gamma22);
+    let dst_d = rgb(ChannelType::U8, TransferFunction::Srgb);
+    let mut c = RowConverter::new(src_d, dst_d).unwrap();
+    let src = [20000u16, 20000, 20000];
+    let mut dst = [0u8; 3];
+    c.convert_row(bytemuck::cast_slice(&src), &mut dst, 1);
+    let linear = gamma22_eotf(u16_to_f32(20000));
+    let expected = u8_of(srgb_oetf(linear));
+    for ch in dst {
+        let diff = (ch as i32 - expected as i32).abs();
+        assert!(
+            diff <= U8_TOL,
+            "U16 Gamma22 → U8 Srgb: got {ch}, expected {expected}"
+        );
+    }
+}
+
+#[test]
+fn u8_srgb_to_u16_bt709() {
+    let src_d = rgb(ChannelType::U8, TransferFunction::Srgb);
+    let dst_d = rgb(ChannelType::U16, TransferFunction::Bt709);
+    let mut c = RowConverter::new(src_d, dst_d).unwrap();
+    let src = [128u8, 128, 128];
+    let mut dst = [0u16; 3];
+    c.convert_row(&src, bytemuck::cast_slice_mut(&mut dst), 1);
+    let linear = srgb_eotf(u8_to_f32(128));
+    let expected = u16_of(bt709_oetf(linear));
+    for ch in dst {
+        let diff = (ch as i32 - expected as i32).abs();
+        assert!(
+            diff <= U16_TOL,
+            "U8 Srgb → U16 Bt709: got {ch}, expected {expected}"
+        );
+    }
+}
+
+#[test]
+fn u16_pq_to_u8_srgb_fused_path() {
+    // Existing fused PQ-U16→sRGB-U8 kernel must still fire.
+    let src_d = rgb(ChannelType::U16, TransferFunction::Pq);
+    let dst_d = rgb(ChannelType::U8, TransferFunction::Srgb);
+    let mut c = RowConverter::new(src_d, dst_d).unwrap();
+    let src = [32768u16; 3];
+    let mut dst = [0u8; 3];
+    c.convert_row(bytemuck::cast_slice(&src), &mut dst, 1);
+    let expected = u8_of(srgb_oetf(pq_eotf(u16_to_f32(32768))));
+    for ch in dst {
+        let diff = (ch as i32 - expected as i32).abs();
+        assert!(
+            diff <= HDR_U8_TOL,
+            "U16 PQ → U8 Srgb (fused): got {ch}, expected {expected}"
+        );
+    }
+}
+
+// =========================================================================
+// HDR — PQ and HLG round-trips at native depth
+// =========================================================================
+
+#[test]
+fn pq_f32_roundtrip_via_linear() {
+    let pq_d = rgb(ChannelType::F32, TransferFunction::Pq);
+    let lin_d = rgb(ChannelType::F32, TransferFunction::Linear);
+    let mut fwd = RowConverter::new(pq_d, lin_d).unwrap();
+    let mut back = RowConverter::new(lin_d, pq_d).unwrap();
+    for &sample in &[0.01f32, 0.1, 0.25, 0.5, 0.75, 0.9] {
+        let src = [sample, sample, sample];
+        let mut lin = [0f32; 3];
+        fwd.convert_row(
+            bytemuck::cast_slice(&src),
+            bytemuck::cast_slice_mut(&mut lin),
+            1,
+        );
+        let mut rt = [0f32; 3];
+        back.convert_row(
+            bytemuck::cast_slice(&lin),
+            bytemuck::cast_slice_mut(&mut rt),
+            1,
+        );
+        for ch in rt {
+            assert!(
+                (ch - sample).abs() < F32_TOL_LOOSE,
+                "PQ F32 roundtrip @ {sample}: got {ch}"
+            );
+        }
+    }
+}
+
+#[test]
+fn hlg_f32_roundtrip_via_linear() {
+    let hlg_d = rgb(ChannelType::F32, TransferFunction::Hlg);
+    let lin_d = rgb(ChannelType::F32, TransferFunction::Linear);
+    let mut fwd = RowConverter::new(hlg_d, lin_d).unwrap();
+    let mut back = RowConverter::new(lin_d, hlg_d).unwrap();
+    for &sample in &[0.01f32, 0.1, 0.25, 0.5, 0.75, 0.9] {
+        let src = [sample, sample, sample];
+        let mut lin = [0f32; 3];
+        fwd.convert_row(
+            bytemuck::cast_slice(&src),
+            bytemuck::cast_slice_mut(&mut lin),
+            1,
+        );
+        let mut rt = [0f32; 3];
+        back.convert_row(
+            bytemuck::cast_slice(&lin),
+            bytemuck::cast_slice_mut(&mut rt),
+            1,
+        );
+        for ch in rt {
+            assert!(
+                (ch - sample).abs() < F32_TOL_LOOSE,
+                "HLG F32 roundtrip @ {sample}: got {ch}"
+            );
+        }
+    }
+}
+
+#[test]
+fn pq_to_hlg_f32_via_linear() {
+    let pq_d = rgb(ChannelType::F32, TransferFunction::Pq);
+    let hlg_d = rgb(ChannelType::F32, TransferFunction::Hlg);
+    let mut c = RowConverter::new(pq_d, hlg_d).unwrap();
+    let src = [0.5f32; 3];
+    let mut dst = [0f32; 3];
+    c.convert_row(
+        bytemuck::cast_slice(&src),
+        bytemuck::cast_slice_mut(&mut dst),
+        1,
+    );
+    let expected = hlg_oetf(pq_eotf(0.5));
+    for ch in dst {
+        assert!(
+            (ch - expected).abs() < F32_TOL_LOOSE,
+            "PQ→HLG F32 @ 0.5: got {ch}, expected {expected}"
+        );
+    }
+}
+
+#[test]
+fn hlg_to_pq_f32_via_linear() {
+    let hlg_d = rgb(ChannelType::F32, TransferFunction::Hlg);
+    let pq_d = rgb(ChannelType::F32, TransferFunction::Pq);
+    let mut c = RowConverter::new(hlg_d, pq_d).unwrap();
+    let src = [0.5f32; 3];
+    let mut dst = [0f32; 3];
+    c.convert_row(
+        bytemuck::cast_slice(&src),
+        bytemuck::cast_slice_mut(&mut dst),
+        1,
+    );
+    let expected = pq_oetf(hlg_eotf(0.5));
+    for ch in dst {
+        assert!(
+            (ch - expected).abs() < F32_TOL_LOOSE,
+            "HLG→PQ F32 @ 0.5: got {ch}, expected {expected}"
+        );
+    }
+}
+
+// =========================================================================
+// Out-of-gamut / extended-range (with_clip_out_of_gamut(false))
+// =========================================================================
+//
+// Only sRGB has extended-range step substitution today (see
+// `ConvertPlan::new` options loop). Verify that the substitution still
+// engages after the planner refactor AND that default (clipping) behavior
+// is unchanged.
+
+#[test]
+fn srgb_f32_linear_clips_by_default() {
+    let src_d = rgb(ChannelType::F32, TransferFunction::Srgb);
+    let dst_d = rgb(ChannelType::F32, TransferFunction::Linear);
+    let mut c = RowConverter::new(src_d, dst_d).unwrap();
+    let src = [-0.1f32, 0.5, 1.2];
+    let mut dst = [0f32; 3];
+    c.convert_row(
+        bytemuck::cast_slice(&src),
+        bytemuck::cast_slice_mut(&mut dst),
+        1,
+    );
+    // Default (clip_out_of_gamut = true) clamps negatives to 0 and >1 to 1.
+    assert!(
+        dst[0] >= 0.0,
+        "default path must clip negatives: got {}",
+        dst[0]
+    );
+    assert!(
+        dst[2] <= 1.0 + 1e-4,
+        "default path must clip >1: got {}",
+        dst[2]
+    );
+}
+
+#[test]
+fn srgb_f32_linear_extended_preserves_oog() {
+    let src_d = rgb(ChannelType::F32, TransferFunction::Srgb);
+    let dst_d = rgb(ChannelType::F32, TransferFunction::Linear);
+    let opts = ConvertOptions::permissive().with_clip_out_of_gamut(false);
+    let mut c = RowConverter::new_explicit(src_d, dst_d, &opts).unwrap();
+    let src = [-0.1f32, 0.5, 1.2];
+    let mut dst = [0f32; 3];
+    c.convert_row(
+        bytemuck::cast_slice(&src),
+        bytemuck::cast_slice_mut(&mut dst),
+        1,
+    );
+    // Extended sRGB EOTF is sign-preserving and symmetric around 0.
+    assert!(
+        dst[0] < 0.0,
+        "extended path must preserve negative: got {}",
+        dst[0]
+    );
+    assert!(
+        dst[2] > 1.0,
+        "extended path must preserve > 1: got {}",
+        dst[2]
+    );
+    // Middle value (in-gamut) should match the clipping path at v=0.5.
+    let expected_mid = srgb_eotf(0.5);
+    assert!((dst[1] - expected_mid).abs() < 1e-3);
+}
+
+#[test]
+fn linear_f32_srgb_extended_preserves_oog() {
+    let src_d = rgb(ChannelType::F32, TransferFunction::Linear);
+    let dst_d = rgb(ChannelType::F32, TransferFunction::Srgb);
+    let opts = ConvertOptions::permissive().with_clip_out_of_gamut(false);
+    let mut c = RowConverter::new_explicit(src_d, dst_d, &opts).unwrap();
+    let src = [-0.05f32, 0.217, 1.5];
+    let mut dst = [0f32; 3];
+    c.convert_row(
+        bytemuck::cast_slice(&src),
+        bytemuck::cast_slice_mut(&mut dst),
+        1,
+    );
+    assert!(dst[0] < 0.0, "extended OETF must preserve negative");
+    assert!(dst[2] > 1.0, "extended OETF must preserve > 1");
+}
+
+// =========================================================================
+// Unknown TF — planner must passthrough (issue #19 [C] territory)
+// =========================================================================
+
+#[test]
+fn f32_unknown_to_f32_linear_is_passthrough() {
+    let src_d = rgb(ChannelType::F32, TransferFunction::Unknown);
+    let dst_d = rgb(ChannelType::F32, TransferFunction::Linear);
+    let mut c = RowConverter::new(src_d, dst_d).unwrap();
+    let src = [0.123f32, 0.456, 0.789];
+    let mut dst = [0f32; 3];
+    c.convert_row(
+        bytemuck::cast_slice(&src),
+        bytemuck::cast_slice_mut(&mut dst),
+        1,
+    );
+    for (s, d) in src.iter().zip(dst.iter()) {
+        assert!(
+            (s - d).abs() < 1e-6,
+            "Unknown TF must passthrough: {s} != {d}"
+        );
+    }
+}
+
+#[test]
+fn f32_srgb_to_f32_unknown_is_passthrough() {
+    let src_d = rgb(ChannelType::F32, TransferFunction::Srgb);
+    let dst_d = rgb(ChannelType::F32, TransferFunction::Unknown);
+    let mut c = RowConverter::new(src_d, dst_d).unwrap();
+    let src = [0.123f32, 0.456, 0.789];
+    let mut dst = [0f32; 3];
+    c.convert_row(
+        bytemuck::cast_slice(&src),
+        bytemuck::cast_slice_mut(&mut dst),
+        1,
+    );
+    for (s, d) in src.iter().zip(dst.iter()) {
+        assert!(
+            (s - d).abs() < 1e-6,
+            "X → Unknown must passthrough: {s} != {d}"
+        );
+    }
+}
+
+#[test]
+fn u8_srgb_to_u8_unknown_is_exact_passthrough() {
+    let src_d = rgb(ChannelType::U8, TransferFunction::Srgb);
+    let dst_d = rgb(ChannelType::U8, TransferFunction::Unknown);
+    let mut c = RowConverter::new(src_d, dst_d).unwrap();
+    let src = [12u8, 199, 77];
+    let mut dst = [0u8; 3];
+    c.convert_row(&src, &mut dst, 1);
+    assert_eq!(dst, src, "U8 X → U8 Unknown must be byte-exact passthrough");
+}
+
+#[test]
+fn u8_unknown_to_u8_srgb_is_exact_passthrough() {
+    let src_d = rgb(ChannelType::U8, TransferFunction::Unknown);
+    let dst_d = rgb(ChannelType::U8, TransferFunction::Srgb);
+    let mut c = RowConverter::new(src_d, dst_d).unwrap();
+    let src = [12u8, 199, 77];
+    let mut dst = [0u8; 3];
+    c.convert_row(&src, &mut dst, 1);
+    assert_eq!(dst, src, "U8 Unknown → U8 X must be byte-exact passthrough");
+}
+
+// =========================================================================
+// Gamut + TF crossings — AdobeRGB Gamma22 → BT.2020 PQ, etc.
+// =========================================================================
+
+#[test]
+fn adobergb_u8_to_bt2020_pq_f32_gray_axis_preserved() {
+    // Neutral gray should stay neutral across D65→D65 primaries regardless
+    // of the TF-EOTF-matrix-OETF composition.
+    let src_d =
+        rgb(ChannelType::U8, TransferFunction::Gamma22).with_primaries(ColorPrimaries::AdobeRgb);
+    let dst_d = rgb(ChannelType::F32, TransferFunction::Pq).with_primaries(ColorPrimaries::Bt2020);
+    let mut c = RowConverter::new(src_d, dst_d).unwrap();
+    let src = [128u8, 128, 128];
+    let mut dst = [0f32; 3];
+    c.convert_row(&src, bytemuck::cast_slice_mut(&mut dst), 1);
+    // Expected: gamma22 EOTF on 128/255 → linear → PQ OETF (matrix is
+    // D65→D65, identity on neutral gray).
+    let lin = gamma22_eotf(u8_to_f32(128));
+    let expected = pq_oetf(lin);
+    for ch in dst {
+        assert!(
+            (ch - expected).abs() < F32_TOL_LOOSE,
+            "AdobeRGB U8 → BT.2020 PQ F32 gray axis: got {ch}, expected {expected}"
+        );
+    }
+}
+
+#[test]
+fn displayp3_u8_srgb_to_bt709_srgb_gray_axis_preserved() {
+    let src_d =
+        rgb(ChannelType::U8, TransferFunction::Srgb).with_primaries(ColorPrimaries::DisplayP3);
+    let dst_d = rgb(ChannelType::U8, TransferFunction::Srgb).with_primaries(ColorPrimaries::Bt709);
+    let mut c = RowConverter::new(src_d, dst_d).unwrap();
+    let src = [128u8, 128, 128];
+    let mut dst = [0u8; 3];
+    c.convert_row(&src, &mut dst, 1);
+    // Gray stays neutral across D65→D65 gamut crossing (all channels equal within ±1 LSB).
+    assert!(
+        (dst[0] as i32 - dst[1] as i32).abs() <= 1,
+        "gray should stay neutral: {dst:?}"
+    );
+    assert!(
+        (dst[1] as i32 - dst[2] as i32).abs() <= 1,
+        "gray should stay neutral: {dst:?}"
+    );
+}
+
+// =========================================================================
+// RGBA with alpha — opaque alpha must survive TF composition
+// =========================================================================
+
+#[test]
+fn rgba_opaque_alpha_preserved_across_tf_change() {
+    let src_d = rgba(
+        ChannelType::F32,
+        TransferFunction::Gamma22,
+        AlphaMode::Straight,
+    );
+    let dst_d = rgba(
+        ChannelType::F32,
+        TransferFunction::Srgb,
+        AlphaMode::Straight,
+    );
+    let mut c = RowConverter::new(src_d, dst_d).unwrap();
+    let src = [0.3f32, 0.5, 0.7, 1.0];
+    let mut dst = [0f32; 4];
+    c.convert_row(
+        bytemuck::cast_slice(&src),
+        bytemuck::cast_slice_mut(&mut dst),
+        1,
+    );
+    // Alpha = 1.0 survives (pow(1, anything) == 1).
+    assert!(
+        (dst[3] - 1.0).abs() < 1e-4,
+        "opaque alpha must survive TF change: got {}",
+        dst[3]
+    );
+}
+
+// =========================================================================
+// Sanity: existing behavior preserved
+// =========================================================================
+
+#[test]
+fn u8_srgb_to_u8_srgb_zero_cost() {
+    let d = rgb(ChannelType::U8, TransferFunction::Srgb);
+    let mut c = RowConverter::new(d, d).unwrap();
+    let src = [64u8, 128, 200];
+    let mut dst = [0u8; 3];
+    c.convert_row(&src, &mut dst, 1);
+    assert_eq!(dst, src, "same-TF same-depth must stay byte-exact");
+}
+
+#[test]
+fn u8_srgb_to_f32_linear_still_uses_fused_path() {
+    // The fused `SrgbU8ToLinearF32` kernel must remain the chosen path
+    // (not the new compose-through-F32 path) for this combination.
+    let src_d = rgb(ChannelType::U8, TransferFunction::Srgb);
+    let dst_d = rgb(ChannelType::F32, TransferFunction::Linear);
+    let mut c = RowConverter::new(src_d, dst_d).unwrap();
+    let src = [128u8, 128, 128];
+    let mut dst = [0f32; 3];
+    c.convert_row(&src, bytemuck::cast_slice_mut(&mut dst), 1);
+    let expected = srgb_eotf(u8_to_f32(128));
+    for ch in dst {
+        assert!((ch - expected).abs() < F32_TOL_NORMAL);
+    }
+}
+
+#[test]
+fn u16_pq_to_f32_linear_still_uses_fused_path() {
+    let src_d = rgb(ChannelType::U16, TransferFunction::Pq);
+    let dst_d = rgb(ChannelType::F32, TransferFunction::Linear);
+    let mut c = RowConverter::new(src_d, dst_d).unwrap();
+    let src = [32768u16; 3];
+    let mut dst = [0f32; 3];
+    c.convert_row(
+        bytemuck::cast_slice(&src),
+        bytemuck::cast_slice_mut(&mut dst),
+        1,
+    );
+    let expected = pq_eotf(u16_to_f32(32768));
+    for ch in dst {
+        assert!((ch - expected).abs() < F32_TOL_LOOSE);
+    }
+}
+
+#[test]
+fn u8_linear_to_u8_linear_zero_cost() {
+    let d = rgb(ChannelType::U8, TransferFunction::Linear);
+    let mut c = RowConverter::new(d, d).unwrap();
+    let src = [10u8, 20, 30];
+    let mut dst = [0u8; 3];
+    c.convert_row(&src, &mut dst, 1);
+    assert_eq!(dst, src);
+}


### PR DESCRIPTION
Fixes #19 [A], [B] and a third latent bug found during the fix.

## What was broken

The planner emitted success plans with wrong steps for several descriptor pairs — no error, no CMS fallback, just wrong pixels labeled with the target TF. Concrete observed errors at U8=128 mid-gray → F32 Linear:

| from_tf | actual | expected linear | |
|---|---|---|---|
| `Srgb` | 0.216 | 0.216 | OK (fused) |
| `Bt709` | 0.216 | 0.261 | **17% off** |
| `Gamma22` | 0.502 | 0.220 | **~2.3× off** |
| `Pq` | 0.502 | 0.009 | **55× off** |

And same-depth integer TF changes (`U8 Gamma22 → U8 Srgb`, etc.) silently emitted `[Identity]` — bytes passed through under a different TF label.

## What the PR does

**[A] Same-depth integer TF changes** now route through an F32 linear intermediate: `[NaiveU8ToF32 / U16ToF32, <from_tf_EOTF>, <to_tf_OETF>, NaiveF32ToU8 / F32ToU16]`.

**[B] Integer ↔ F32 without a fused kernel** now composes the F32 TF math in:
- `U8 X → F32 Linear`: `[NaiveU8ToF32, <X_EOTF>]`
- `F32 Linear → U8 X`: `[<X_OETF>, NaiveF32ToU8]`
- `U16 X → F32 Linear`, `F32 Linear → U16 X`: same shape via U16 scale steps
- `U16 X → U8 Y` cross-depth cross-TF: compose through F32 linear
- `U8 X → U16 Y`: same

**BT.709 narrowing:** `U8 Bt709 ↔ F32 Linear` was using the sRGB-specific `SrgbU8ToLinearF32` / `LinearF32ToSrgbU8` fused kernel (~17% linear-light error). Fused path narrowed to sRGB-only; BT.709 composes through the correct kernel.

**Refactor:** the 24-arm F32↔F32 TF-pair match in `depth_steps` is replaced by a `f32_tf_pair_steps(from, to)` helper that delegates to two tiny per-TF step-lookup functions (`f32_linearize_step`, `f32_encode_step`). Produces byte-identical step sequences for every previously-handled pair; also cuts the per-TF integer and F32 cases down to one-line compositions.

**Unknown TF preserved:** if either side's TF is `Unknown`, the planner still passes bytes through unchanged. Explicit opt-in API for Unknown semantics is tracked separately as #19 [C]/[D] (deprecate-and-add).

## Test coverage

`tests/planner_silent_passthrough.rs` — 54 new regression tests:
- Every TF ∈ {Linear, Srgb, Bt709, Gamma22, Pq, Hlg} × every depth ∈ {U8, U16, F32} in both directions through `RowConverter`, compared to a hand-coded ground-truth EOTF/OETF.
- HDR: PQ and HLG F32↔F32 roundtrips, PQ↔HLG via linear, fused PQ-U16→sRGB-U8 kernel sanity.
- Extended-range out-of-gamut (`ConvertOptions::permissive().with_clip_out_of_gamut(false)`): verifies sign-preserving sRGB path still engages post-refactor, and default clipping path unchanged.
- Cross-primaries + cross-TF: AdobeRGB U8 → BT.2020 PQ F32, DisplayP3 sRGB U8 → BT.709 sRGB U8 — both verified to preserve the neutral gray axis.
- RGBA: opaque alpha survives TF composition.
- Unknown TF passthrough (U8 and F32) — byte-exact.
- Sanity: zero-cost same-desc conversions and the existing fused sRGB/PQ kernels still fire.

Also updates one existing test in `cicp_transfer_correctness.rs`:
`buffer_linearize_bt709_u8` had been pinning the buggy ~0.216 output (sRGB math applied to BT.709 bytes); updated to the correct ~0.2616 BT.709 EOTF value.

## Classification

Bug fix. No public API change. `ConvertStep` is `pub(crate)`; behavior change is strictly "wrong pixels → correct pixels" for any descriptor combination that zenpipe, imageflow, and other dependents were using in the impossible-to-use wrong state.

## Remaining work (tracked in #19)

- [C] / [D] — Unknown-TF / Unknown-primaries explicit opt-in via `ConvertPlan::new_strict` and `PixelDescriptor::reinterpret_as_*`.
- [F] — `RgbaPremul → Rgb` drop-alpha semantics (composite-over-black vs un-premultiply).

Neither is addressed here to keep this PR strictly non-breaking.