### PR TITLE
docs(zenpixels): clarify descriptor with_* methods as relabel-only operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### zenpixels — docs
+
+- **Clarified `PixelDescriptor::with_transfer` / `with_primaries` /
+  `with_alpha` as relabel-only operations** (docs-only). Previously the
+  doc comments said "return a copy with a different X" — literally true
+  but understated that no pixel math happens. Updated to explicitly call
+  out that these are metadata-only operations and that the way to
+  actually re-encode pixels is to pass the new descriptor as the
+  destination to `RowConverter::new`. Also notes that built-in premul
+  kernels operate in encoded byte space (Canvas 2D semantics), not
+  linear light.
+
 ### zenpixels-convert — fixed
 
 - **Planner no longer silently passes bytes through on TF changes** (fixes

--- a/zenpixels/src/descriptor.rs
+++ b/zenpixels/src/descriptor.rs
@@ -1010,21 +1010,60 @@ impl PixelDescriptor {
         matches!(self.format.byte_order(), ByteOrder::Bgr)
     }
 
-    /// Return a copy with a different transfer function.
+    /// Return a copy of this descriptor **relabeled** with a different
+    /// transfer function. Does not touch any pixel bytes.
+    ///
+    /// Use when the source data was mistagged (e.g., a codec decoded a
+    /// profile-less image and you know its true TF from another source)
+    /// or when you want to assert a particular TF for downstream planning
+    /// without round-tripping through EOTF/OETF kernels.
+    ///
+    /// **This is metadata-only.** To actually re-encode pixel bytes from
+    /// one transfer function into another, pass a source buffer and a
+    /// destination descriptor with the new TF into [`RowConverter::new`]
+    /// — that builds a plan with the appropriate EOTF/OETF kernels.
+    ///
+    /// [`RowConverter::new`]: https://docs.rs/zenpixels-convert/latest/zenpixels_convert/struct.RowConverter.html#method.new
     #[inline]
     #[must_use]
     pub const fn with_transfer(self, transfer: TransferFunction) -> Self {
         Self { transfer, ..self }
     }
 
-    /// Return a copy with different primaries.
+    /// Return a copy of this descriptor **relabeled** with different
+    /// primaries. Does not touch any pixel bytes or apply a gamut matrix.
+    ///
+    /// Use when you know the true primaries of the source data independent
+    /// of whatever upstream tagging said, or to assert a particular primary
+    /// set for downstream planning.
+    ///
+    /// **This is metadata-only.** To actually apply a gamut conversion
+    /// (e.g., BT.709 → Display P3), pass the new descriptor as the
+    /// destination to [`RowConverter::new`] — that inserts the appropriate
+    /// gamut matrix in linear light.
+    ///
+    /// [`RowConverter::new`]: https://docs.rs/zenpixels-convert/latest/zenpixels_convert/struct.RowConverter.html#method.new
     #[inline]
     #[must_use]
     pub const fn with_primaries(self, primaries: ColorPrimaries) -> Self {
         Self { primaries, ..self }
     }
 
-    /// Return a copy with a different alpha mode.
+    /// Return a copy of this descriptor **relabeled** with a different
+    /// alpha mode. Does not touch any pixel bytes or apply (un)premultiply.
+    ///
+    /// Use when the source alpha mode was mistagged or when you want to
+    /// assert straight/premultiplied without round-tripping through the
+    /// premul kernels.
+    ///
+    /// **This is metadata-only.** To actually premultiply or un-premultiply
+    /// pixel values, pass the new descriptor as the destination to
+    /// [`RowConverter::new`] — that inserts a `StraightToPremul` or
+    /// `PremulToStraight` step. (Note: the built-in premul kernels operate
+    /// in the source byte space — "encoded premul", per Canvas 2D
+    /// semantics — not in linear light.)
+    ///
+    /// [`RowConverter::new`]: https://docs.rs/zenpixels-convert/latest/zenpixels_convert/struct.RowConverter.html#method.new
     #[inline]
     #[must_use]
     pub const fn with_alpha(self, alpha: Option<AlphaMode>) -> Self {


### PR DESCRIPTION
Follow-up from issue #19 CDEF design discussion.

The existing `PixelDescriptor::with_transfer` / `with_primaries` / `with_alpha` builder methods had doc comments that were literally correct ("return a copy with a different X") but understated the important semantic: they change the descriptor without touching any pixel bytes. Easy to misread as "convert to TF X" and end up with bytes labeled as the target TF but encoded for the source — exactly the silent-wrong-pixel class that PR #20 fixed on the planner side.

## What this PR adds

Expanded doc comments on all three methods explicitly calling out:

- These are metadata-only relabel operations.
- Use when source data was mistagged or when asserting a particular TF / primaries / alpha mode for downstream planning.
- To actually re-encode pixels, pass the new descriptor as the destination to `RowConverter::new` — that inserts the appropriate EOTF/OETF or gamut-matrix steps.
- For alpha specifically: the built-in premul kernels operate in encoded byte space (Canvas 2D semantics), not linear light.

## Why docs instead of new API

Earlier design sketched adding `PixelDescriptor::reinterpret_as_transfer` / `reinterpret_as_primaries` / `reinterpret_as_alpha_mode` methods for intent-signaling. On implementation it became obvious they'd be rename-only helpers duplicating the existing public API. Per CLAUDE.md rule #8 ("if a user can synthesize in 2-3 lines with existing API, do not add a helper"), docs carry the same information with zero API surface growth.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — all green
- [x] `cargo clippy -p zenpixels --all-targets -- -D warnings` — clean
- [x] `cargo doc -p zenpixels --no-deps` — renders cleanly
- [ ] CI green on all platforms