### PR TITLE
F16 pixel format support (Option A: descriptor-level only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,63 @@
 
 ## [Unreleased]
 
+### QUEUED BREAKING CHANGES
+
+<!-- Breaking changes that will ship together in the next major (or minor for
+     0.x) release. Add items here as you discover them. Do NOT ship these
+     piecemeal — batch them. -->
+
+- (none currently queued)
+
+### zenpixels — added
+
+- **F16 (IEEE 754 half-precision) pixel format variants and presets.**
+  `PixelFormat::RgbF16`, `RgbaF16`, `GrayF16`, `GrayAF16` on the
+  `#[non_exhaustive]` enum, plus matching `pub const` presets: `RGBF16`,
+  `RGBAF16`, `GRAYF16`, `GRAYAF16` (Unknown TF) and the Linear-TF variants
+  `RGBF16_LINEAR`, `RGBAF16_LINEAR`, `GRAYF16_LINEAR`, `GRAYAF16_LINEAR`.
+  Descriptor-level only — no new `Pixel` trait impls, no `half` crate
+  dependency in zenpixels core. Typed `impl Pixel for Rgb<f16>` etc. will
+  land when Rust stable ships the native `f16` primitive (tracked in #23).
+  Non-breaking: new variants on `#[non_exhaustive]`, new presets are
+  additive. (#23)
+
+### zenpixels-convert — added
+
+- **F16 conversion kernels.** `ConvertStep::F16ToF32` / `F32ToF16`
+  (private enum variants) with scalar `half::f16` implementations. Planner
+  routes F16 ↔ F32, F16 ↔ U8, F16 ↔ U16, and same-F16-TF-change paths
+  through F32 linear intermediate — never passes F16 bytes through
+  unchanged on TF changes. F16 arms added to all layout/swizzle kernels
+  (`swizzle_bgra_rgba`, `rgb_to_bgra`, `add_alpha`, `drop_alpha`,
+  `matte_composite`, `gray_to_rgb`, `gray_to_rgba`, `gray_alpha_to_rgba`,
+  `gray_alpha_to_rgb`, `gray_to_gray_alpha`, `gray_alpha_to_gray`,
+  `straight_to_premul`, `premul_to_straight`). SIMD dispatch for
+  F16C / AVX-512 FP16 / ARMv8.2 FP16 is a deferred optimization.
+  `half = "2.7.1"` promoted from dev-dep to dep; feature-flag-free per
+  the middleman-tax analysis in #23. 5 round-trip tests in
+  `tests/roundtrip.rs`. (#23)
+
+### zenpixels-convert — fixed
+
+- **Depth-reduction policy now catches U16 → F16.** Previous gate used
+  `ChannelType::byte_size()`, which misses U16 → F16 since both are 2
+  bytes — but U16 carries 16 bits of precision in [0,1] vs F16's ~11,
+  so U16 → F16 is a precision reduction. Switched to
+  `channel_bits()` (already used by the cost model in `negotiate.rs`)
+  so `DepthPolicy::Forbid` correctly rejects U16 → F16 and U16 → F16
+  inside RGBA → RGBA plans. No API change.
+
+### zenpixels-convert — known limitations (not new, surfaced during F16 work)
+
+- **`MatteComposite` assumes linear pixel data but the planner doesn't
+  always guarantee that.** For `F32 sRGB RGBA → F32 sRGB RGB` (or the new
+  F16 equivalent) with `AlphaPolicy::CompositeOnto`, the plan is
+  `[MatteComposite]` with no prior linearize step — the kernel blends
+  sRGB-encoded pixel data against a linearized matte, producing
+  mathematically wrong colors. Pre-existing issue inherited by the new
+  F16 arm; tracked separately (not fixed in this release).
+
 ## [0.2.10] - 2026-04-20
 
 ### zenpixels — docs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
  "zerocopy",

--- a/zenpixels-convert/Cargo.toml
+++ b/zenpixels-convert/Cargo.toml
@@ -37,12 +37,12 @@ paste = "1.0.15"
 once_cell = { version = "1.21.4", default-features = false, features = ["race", "alloc"] }
 whereat = { version = "0.1.5", default-features = false }
 moxcms = { version = "0.8.1", optional = true, features = ["options"] }
+half = { version = "2.7.1", default-features = false, features = ["bytemuck"] }
 
 [dev-dependencies]
 zenpixels = { workspace = true, features = ["planar", "imgref"] }
 zenpixels-convert = { path = ".", features = ["pipeline", "imgref", "cms-moxcms"] }
 zenbench = { version = "0.1.2"}
-half = "2"
 palette = { version = "0.7", default-features = false, features = ["std", "approx"] }
 
 [[bench]]

--- a/zenpixels-convert/src/convert.rs
+++ b/zenpixels-convert/src/convert.rs
@@ -86,6 +86,10 @@ pub(crate) enum ConvertStep {
     U16ToF32,
     /// f32 → u16 (clamp * 65535 + 0.5).
     F32ToU16,
+    /// f16 → f32 (IEEE 754 half-precision unpack, no TF).
+    F16ToF32,
+    /// f32 → f16 (round-to-nearest-even, no TF).
+    F32ToF16,
     /// PQ (SMPTE ST 2084) u16 → linear f32 (EOTF).
     PqU16ToLinearF32,
     /// Linear f32 → PQ u16 (inverse EOTF / OETF).
@@ -186,6 +190,8 @@ impl core::fmt::Debug for ConvertStep {
             Self::U8ToU16 => f.write_str("U8ToU16"),
             Self::U16ToF32 => f.write_str("U16ToF32"),
             Self::F32ToU16 => f.write_str("F32ToU16"),
+            Self::F16ToF32 => f.write_str("F16ToF32"),
+            Self::F32ToF16 => f.write_str("F32ToF16"),
             Self::PqU16ToLinearF32 => f.write_str("PqU16ToLinearF32"),
             Self::LinearF32ToPqU16 => f.write_str("LinearF32ToPqU16"),
             Self::PqF32ToLinearF32 => f.write_str("PqF32ToLinearF32"),
@@ -588,8 +594,12 @@ impl ConvertPlan {
             return Err(whereat::at!(ConvertError::AlphaRemovalForbidden));
         }
 
-        // Check depth reduction policy.
-        let reduces_depth = from.channel_type().byte_size() > to.channel_type().byte_size();
+        // Check depth reduction policy. Compare by precision bits, not byte
+        // size — F16 and U16 are both 2 bytes but F16 carries only ~11 bits of
+        // precision vs U16's 16, so a U16→F16 hop IS a precision reduction and
+        // must be policy-gated.
+        let reduces_depth = crate::negotiate::channel_bits(from.channel_type())
+            > crate::negotiate::channel_bits(to.channel_type());
         if reduces_depth && options.depth_policy == DepthPolicy::Forbid {
             return Err(whereat::at!(ConvertError::DepthReductionForbidden));
         }
@@ -944,22 +954,24 @@ fn f32_tf_pair_steps(from: TransferFunction, to: TransferFunction) -> Vec<Conver
     steps
 }
 
-/// Integer→F32 scale step for a given integer channel type. Panics for F32
-/// (caller must check); CMYK is rejected upstream by `assert_not_cmyk`.
-fn int_to_f32_step(ct: ChannelType) -> ConvertStep {
+/// Depth conversion step into F32 for any non-F32 channel type (U8, U16, F16).
+/// Panics for F32 (caller must check); CMYK is rejected upstream by `assert_not_cmyk`.
+fn to_f32_step(ct: ChannelType) -> ConvertStep {
     match ct {
         ChannelType::U8 => ConvertStep::NaiveU8ToF32,
         ChannelType::U16 => ConvertStep::U16ToF32,
-        _ => unreachable!("int_to_f32_step called with non-integer channel type"),
+        ChannelType::F16 => ConvertStep::F16ToF32,
+        _ => unreachable!("to_f32_step called with F32 or unsupported channel type"),
     }
 }
 
-/// F32→integer scale step.
-fn f32_to_int_step(ct: ChannelType) -> ConvertStep {
+/// F32→depth step for any non-F32 channel type.
+fn f32_to_depth_step(ct: ChannelType) -> ConvertStep {
     match ct {
         ChannelType::U8 => ConvertStep::NaiveF32ToU8,
         ChannelType::U16 => ConvertStep::F32ToU16,
-        _ => unreachable!("f32_to_int_step called with non-integer channel type"),
+        ChannelType::F16 => ConvertStep::F32ToF16,
+        _ => unreachable!("f32_to_depth_step called with F32 or unsupported channel type"),
     }
 }
 
@@ -985,9 +997,9 @@ fn depth_steps(
         return Ok(f32_tf_pair_steps(from_tf, to_tf));
     }
 
-    // Same depth, integer: TF change requires re-encoding. Route through F32
-    // linear intermediate — passing bytes through labeled as a different TF
-    // produces wrong pixels.
+    // Same depth, non-F32 (U8/U16/F16): TF change requires re-encoding. Route
+    // through F32 linear intermediate — passing bytes through labeled as a
+    // different TF produces wrong pixels.
     //
     // Exception: if either TF is Unknown, we don't know the correct conversion.
     // Preserve bytes exactly (no F32 round-trip — that would introduce U8/U16
@@ -998,9 +1010,9 @@ fn depth_steps(
             return Ok(Vec::new());
         }
         let mut steps = Vec::with_capacity(4);
-        steps.push(int_to_f32_step(from));
+        steps.push(to_f32_step(from));
         steps.extend(f32_tf_pair_steps(from_tf, to_tf));
-        steps.push(f32_to_int_step(to));
+        steps.push(f32_to_depth_step(to));
         return Ok(steps);
     }
 
@@ -1104,6 +1116,80 @@ fn depth_steps(
                 steps.push(ConvertStep::F32ToU16);
                 Ok(steps)
             }
+        }
+        // F16 paths route through F32. No fused TF kernels yet — these are
+        // optimization targets for a future pass.
+        (ChannelType::F16, ChannelType::F32) => {
+            let mut steps = Vec::with_capacity(3);
+            steps.push(ConvertStep::F16ToF32);
+            if from_tf != to_tf {
+                steps.extend(f32_tf_pair_steps(from_tf, to_tf));
+            }
+            Ok(steps)
+        }
+        (ChannelType::F32, ChannelType::F16) => {
+            let mut steps = Vec::with_capacity(3);
+            if from_tf != to_tf {
+                steps.extend(f32_tf_pair_steps(from_tf, to_tf));
+            }
+            steps.push(ConvertStep::F32ToF16);
+            Ok(steps)
+        }
+        (ChannelType::F16, ChannelType::U8) => {
+            let mut steps = Vec::with_capacity(4);
+            steps.push(ConvertStep::F16ToF32);
+            if from_tf == TransferFunction::Linear && to_tf == TransferFunction::Srgb {
+                steps.push(ConvertStep::LinearF32ToSrgbU8);
+            } else if from_tf == to_tf {
+                steps.push(ConvertStep::NaiveF32ToU8);
+            } else {
+                steps.extend(f32_tf_pair_steps(from_tf, to_tf));
+                steps.push(ConvertStep::NaiveF32ToU8);
+            }
+            Ok(steps)
+        }
+        (ChannelType::U8, ChannelType::F16) => {
+            let mut steps = Vec::with_capacity(4);
+            if from_tf == TransferFunction::Srgb && to_tf == TransferFunction::Linear {
+                steps.push(ConvertStep::SrgbU8ToLinearF32);
+            } else if from_tf == to_tf {
+                steps.push(ConvertStep::NaiveU8ToF32);
+            } else {
+                steps.push(ConvertStep::NaiveU8ToF32);
+                steps.extend(f32_tf_pair_steps(from_tf, to_tf));
+            }
+            steps.push(ConvertStep::F32ToF16);
+            Ok(steps)
+        }
+        (ChannelType::F16, ChannelType::U16) => {
+            let mut steps = Vec::with_capacity(4);
+            steps.push(ConvertStep::F16ToF32);
+            if from_tf == TransferFunction::Linear && to_tf == TransferFunction::Pq {
+                steps.push(ConvertStep::LinearF32ToPqU16);
+            } else if from_tf == TransferFunction::Linear && to_tf == TransferFunction::Hlg {
+                steps.push(ConvertStep::LinearF32ToHlgU16);
+            } else if from_tf == to_tf {
+                steps.push(ConvertStep::F32ToU16);
+            } else {
+                steps.extend(f32_tf_pair_steps(from_tf, to_tf));
+                steps.push(ConvertStep::F32ToU16);
+            }
+            Ok(steps)
+        }
+        (ChannelType::U16, ChannelType::F16) => {
+            let mut steps = Vec::with_capacity(4);
+            if from_tf == TransferFunction::Pq && to_tf == TransferFunction::Linear {
+                steps.push(ConvertStep::PqU16ToLinearF32);
+            } else if from_tf == TransferFunction::Hlg && to_tf == TransferFunction::Linear {
+                steps.push(ConvertStep::HlgU16ToLinearF32);
+            } else if from_tf == to_tf {
+                steps.push(ConvertStep::U16ToF32);
+            } else {
+                steps.push(ConvertStep::U16ToF32);
+                steps.extend(f32_tf_pair_steps(from_tf, to_tf));
+            }
+            steps.push(ConvertStep::F32ToF16);
+            Ok(steps)
         }
         _ => Err(ConvertError::NoPath {
             from: PixelDescriptor::new(from, ChannelLayout::Rgb, None, from_tf),
@@ -1315,6 +1401,8 @@ fn are_inverse(a: &ConvertStep, b: &ConvertStep) -> bool {
         | (ConvertStep::U16ToU8, ConvertStep::U8ToU16)
         | (ConvertStep::U16ToF32, ConvertStep::F32ToU16)
         | (ConvertStep::F32ToU16, ConvertStep::U16ToF32)
+        | (ConvertStep::F16ToF32, ConvertStep::F32ToF16)
+        | (ConvertStep::F32ToF16, ConvertStep::F16ToF32)
         // Cross-depth with transfer (near-lossless roundtrip)
         | (ConvertStep::SrgbU8ToLinearF32, ConvertStep::LinearF32ToSrgbU8)
         | (ConvertStep::LinearF32ToSrgbU8, ConvertStep::SrgbU8ToLinearF32)
@@ -1558,6 +1646,19 @@ fn intermediate_desc(current: PixelDescriptor, step: &ConvertStep) -> PixelDescr
             current.layout(),
             current.alpha(),
             TransferFunction::Srgb,
+        ),
+        // F16↔F32 depth-only steps. No TF implication: same TF on both sides.
+        ConvertStep::F16ToF32 => PixelDescriptor::new(
+            ChannelType::F32,
+            current.layout(),
+            current.alpha(),
+            current.transfer(),
+        ),
+        ConvertStep::F32ToF16 => PixelDescriptor::new(
+            ChannelType::F16,
+            current.layout(),
+            current.alpha(),
+            current.transfer(),
         ),
     }
 }

--- a/zenpixels-convert/src/convert_kernels.rs
+++ b/zenpixels-convert/src/convert_kernels.rs
@@ -11,6 +11,10 @@ use crate::{ChannelLayout, ChannelType, ColorPrimaries, PixelDescriptor};
 
 use super::ConvertStep;
 
+/// IEEE 754 half-precision encoding of 1.0: sign=0, exponent=01111 (bias 15),
+/// mantissa=0000000000 → bits 0b0_01111_0000000000 = 0x3C00.
+const F16_ONE_BITS: u16 = 0x3C00;
+
 /// Apply a single conversion step on raw byte slices.
 pub(super) fn apply_step_u8(
     step: &ConvertStep,
@@ -110,6 +114,14 @@ pub(super) fn apply_step_u8(
 
         ConvertStep::F32ToU16 => {
             f32_to_u16(src, dst, w, from.layout().channels());
+        }
+
+        ConvertStep::F16ToF32 => {
+            f16_to_f32(src, dst, w, from.layout().channels());
+        }
+
+        ConvertStep::F32ToF16 => {
+            f32_to_f16(src, dst, w, from.layout().channels());
         }
 
         ConvertStep::PqU16ToLinearF32 => {
@@ -323,6 +335,17 @@ fn swizzle_bgra_rgba(src: &[u8], dst: &mut [u8], width: usize, ch_type: ChannelT
                 dstf[s + 3] = srcf[s + 3];
             }
         }
+        ChannelType::F16 => {
+            let src16: &[u16] = bytemuck::cast_slice(&src[..width * pixel_bytes]);
+            let dst16: &mut [u16] = bytemuck::cast_slice_mut(&mut dst[..width * pixel_bytes]);
+            for i in 0..width {
+                let s = i * 4;
+                dst16[s] = src16[s + 2];
+                dst16[s + 1] = src16[s + 1];
+                dst16[s + 2] = src16[s];
+                dst16[s + 3] = src16[s + 3];
+            }
+        }
         _ => {}
     }
 }
@@ -358,6 +381,16 @@ fn rgb_to_bgra(src: &[u8], dst: &mut [u8], width: usize, ch_type: ChannelType) {
                 dstf[i * 4 + 3] = 1.0;
             }
         }
+        ChannelType::F16 => {
+            let src16: &[u16] = bytemuck::cast_slice(&src[..width * 6]);
+            let dst16: &mut [u16] = bytemuck::cast_slice_mut(&mut dst[..width * 8]);
+            for i in 0..width {
+                dst16[i * 4] = src16[i * 3 + 2]; // B
+                dst16[i * 4 + 1] = src16[i * 3 + 1]; // G
+                dst16[i * 4 + 2] = src16[i * 3]; // R
+                dst16[i * 4 + 3] = F16_ONE_BITS;
+            }
+        }
         _ => {}
     }
 }
@@ -389,6 +422,16 @@ fn add_alpha(src: &[u8], dst: &mut [u8], width: usize, ch_type: ChannelType) {
                 dstf[i * 4 + 3] = 1.0;
             }
         }
+        ChannelType::F16 => {
+            let src16: &[u16] = bytemuck::cast_slice(&src[..width * 6]);
+            let dst16: &mut [u16] = bytemuck::cast_slice_mut(&mut dst[..width * 8]);
+            for i in 0..width {
+                dst16[i * 4] = src16[i * 3];
+                dst16[i * 4 + 1] = src16[i * 3 + 1];
+                dst16[i * 4 + 2] = src16[i * 3 + 2];
+                dst16[i * 4 + 3] = F16_ONE_BITS;
+            }
+        }
         _ => {}
     }
 }
@@ -416,6 +459,15 @@ fn drop_alpha(src: &[u8], dst: &mut [u8], width: usize, ch_type: ChannelType) {
                 dstf[i * 3] = srcf[i * 4];
                 dstf[i * 3 + 1] = srcf[i * 4 + 1];
                 dstf[i * 3 + 2] = srcf[i * 4 + 2];
+            }
+        }
+        ChannelType::F16 => {
+            let src16: &[u16] = bytemuck::cast_slice(&src[..width * 8]);
+            let dst16: &mut [u16] = bytemuck::cast_slice_mut(&mut dst[..width * 6]);
+            for i in 0..width {
+                dst16[i * 3] = src16[i * 4];
+                dst16[i * 3 + 1] = src16[i * 4 + 1];
+                dst16[i * 3 + 2] = src16[i * 4 + 2];
             }
         }
         _ => {}
@@ -487,6 +539,30 @@ fn matte_composite(
                 dstf[i * 3 + 2] = srcf[i * 4 + 2] * a + mb_lin * inv_a;
             }
         }
+        ChannelType::F16 => {
+            // Same pre-existing assumption as the F32 arm: pixel data is
+            // treated as linear here, matching the matte (which is linearized
+            // from sRGB u8 above). The planner normally inserts a linearize
+            // step before MatteComposite, but for "same-TF same-depth float"
+            // (e.g. sRGB F16 → sRGB F16 with CompositeOnto) there's no such
+            // step and the blend is mathematically wrong in sRGB space. This
+            // is a known limitation inherited from the F32 path, not specific
+            // to F16. Unpack to f32 for blending, pack back to f16.
+            let src16: &[u16] = bytemuck::cast_slice(&src[..width * 8]);
+            let dst16: &mut [u16] = bytemuck::cast_slice_mut(&mut dst[..width * 6]);
+            for i in 0..width {
+                let r = half::f16::from_bits(src16[i * 4]).to_f32();
+                let g = half::f16::from_bits(src16[i * 4 + 1]).to_f32();
+                let b = half::f16::from_bits(src16[i * 4 + 2]).to_f32();
+                let a = half::f16::from_bits(src16[i * 4 + 3])
+                    .to_f32()
+                    .clamp(0.0, 1.0);
+                let inv_a = 1.0 - a;
+                dst16[i * 3] = half::f16::from_f32(r * a + mr_lin * inv_a).to_bits();
+                dst16[i * 3 + 1] = half::f16::from_f32(g * a + mg_lin * inv_a).to_bits();
+                dst16[i * 3 + 2] = half::f16::from_f32(b * a + mb_lin * inv_a).to_bits();
+            }
+        }
         _ => {
             // Fallback: just drop alpha
             drop_alpha(src, dst, width, ch_type);
@@ -521,6 +597,16 @@ fn gray_to_rgb(src: &[u8], dst: &mut [u8], width: usize, ch_type: ChannelType) {
                 dstf[i * 3 + 2] = g;
             }
         }
+        ChannelType::F16 => {
+            let src16: &[u16] = bytemuck::cast_slice(&src[..width * 2]);
+            let dst16: &mut [u16] = bytemuck::cast_slice_mut(&mut dst[..width * 6]);
+            for i in 0..width {
+                let g = src16[i];
+                dst16[i * 3] = g;
+                dst16[i * 3 + 1] = g;
+                dst16[i * 3 + 2] = g;
+            }
+        }
         _ => {}
     }
 }
@@ -552,6 +638,17 @@ fn gray_to_rgba(src: &[u8], dst: &mut [u8], width: usize, ch_type: ChannelType) 
                 dstf[i * 4 + 1] = g;
                 dstf[i * 4 + 2] = g;
                 dstf[i * 4 + 3] = 1.0;
+            }
+        }
+        ChannelType::F16 => {
+            let src16: &[u16] = bytemuck::cast_slice(&src[..width * 2]);
+            let dst16: &mut [u16] = bytemuck::cast_slice_mut(&mut dst[..width * 8]);
+            for i in 0..width {
+                let g = src16[i];
+                dst16[i * 4] = g;
+                dst16[i * 4 + 1] = g;
+                dst16[i * 4 + 2] = g;
+                dst16[i * 4 + 3] = F16_ONE_BITS;
             }
         }
         _ => {}
@@ -601,6 +698,18 @@ fn gray_alpha_to_rgba(src: &[u8], dst: &mut [u8], width: usize, ch_type: Channel
                 dstf[i * 4 + 3] = a;
             }
         }
+        ChannelType::F16 => {
+            let src16: &[u16] = bytemuck::cast_slice(&src[..width * 4]);
+            let dst16: &mut [u16] = bytemuck::cast_slice_mut(&mut dst[..width * 8]);
+            for i in 0..width {
+                let g = src16[i * 2];
+                let a = src16[i * 2 + 1];
+                dst16[i * 4] = g;
+                dst16[i * 4 + 1] = g;
+                dst16[i * 4 + 2] = g;
+                dst16[i * 4 + 3] = a;
+            }
+        }
         _ => {}
     }
 }
@@ -632,6 +741,16 @@ fn gray_alpha_to_rgb(src: &[u8], dst: &mut [u8], width: usize, ch_type: ChannelT
                 dstf[i * 3 + 2] = g;
             }
         }
+        ChannelType::F16 => {
+            let src16: &[u16] = bytemuck::cast_slice(&src[..width * 4]);
+            let dst16: &mut [u16] = bytemuck::cast_slice_mut(&mut dst[..width * 6]);
+            for i in 0..width {
+                let g = src16[i * 2];
+                dst16[i * 3] = g;
+                dst16[i * 3 + 1] = g;
+                dst16[i * 3 + 2] = g;
+            }
+        }
         _ => {}
     }
 }
@@ -659,6 +778,14 @@ fn gray_to_gray_alpha(src: &[u8], dst: &mut [u8], width: usize, ch_type: Channel
                 dstf[i * 2 + 1] = 1.0;
             }
         }
+        ChannelType::F16 => {
+            let src16: &[u16] = bytemuck::cast_slice(&src[..width * 2]);
+            let dst16: &mut [u16] = bytemuck::cast_slice_mut(&mut dst[..width * 4]);
+            for i in 0..width {
+                dst16[i * 2] = src16[i];
+                dst16[i * 2 + 1] = F16_ONE_BITS;
+            }
+        }
         _ => {}
     }
 }
@@ -682,6 +809,13 @@ fn gray_alpha_to_gray(src: &[u8], dst: &mut [u8], width: usize, ch_type: Channel
             let dstf: &mut [f32] = bytemuck::cast_slice_mut(&mut dst[..width * 4]);
             for i in 0..width {
                 dstf[i] = srcf[i * 2];
+            }
+        }
+        ChannelType::F16 => {
+            let src16: &[u16] = bytemuck::cast_slice(&src[..width * 4]);
+            let dst16: &mut [u16] = bytemuck::cast_slice_mut(&mut dst[..width * 2]);
+            for i in 0..width {
+                dst16[i] = src16[i * 2];
             }
         }
         _ => {}
@@ -746,6 +880,31 @@ fn f32_to_u16(src: &[u8], dst: &mut [u8], width: usize, channels: usize) {
     let count = width * channels;
     garb::bytes::convert_f32_to_u16(&src[..count * 4], &mut dst[..count * 2])
         .expect("pre-validated row size");
+}
+
+/// f16 → f32: IEEE 754 half-precision unpack (no TF, no scale).
+///
+/// Scalar via the `half` crate. SIMD dispatch (F16C / AVX-512 FP16 /
+/// ARMv8.2 FP16) is a future optimization — see tracking issue #23.
+fn f16_to_f32(src: &[u8], dst: &mut [u8], width: usize, channels: usize) {
+    let count = width * channels;
+    let src_bits: &[u16] = bytemuck::cast_slice(&src[..count * 2]);
+    let dst_f32: &mut [f32] = bytemuck::cast_slice_mut(&mut dst[..count * 4]);
+    for (s, d) in src_bits.iter().zip(dst_f32.iter_mut()) {
+        *d = half::f16::from_bits(*s).to_f32();
+    }
+}
+
+/// f32 → f16: IEEE 754 half-precision pack (round-to-nearest-even, no TF).
+///
+/// Values outside ±65504 are clamped to ±infinity in f16; NaNs are preserved.
+fn f32_to_f16(src: &[u8], dst: &mut [u8], width: usize, channels: usize) {
+    let count = width * channels;
+    let src_f32: &[f32] = bytemuck::cast_slice(&src[..count * 4]);
+    let dst_bits: &mut [u16] = bytemuck::cast_slice_mut(&mut dst[..count * 2]);
+    for (s, d) in src_f32.iter().zip(dst_bits.iter_mut()) {
+        *d = half::f16::from_f32(*s).to_bits();
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1107,6 +1266,31 @@ fn straight_to_premul(
                 dstf[base + alpha_idx] = a;
             }
         }
+        ChannelType::U16 => {
+            let src16: &[u16] = bytemuck::cast_slice(&src[..width * channels * 2]);
+            let dst16: &mut [u16] = bytemuck::cast_slice_mut(&mut dst[..width * channels * 2]);
+            for i in 0..width {
+                let base = i * channels;
+                let a = src16[base + alpha_idx] as u32;
+                for c in 0..alpha_idx {
+                    dst16[base + c] = ((src16[base + c] as u32 * a + 32768) / 65535) as u16;
+                }
+                dst16[base + alpha_idx] = src16[base + alpha_idx];
+            }
+        }
+        ChannelType::F16 => {
+            let src16: &[u16] = bytemuck::cast_slice(&src[..width * channels * 2]);
+            let dst16: &mut [u16] = bytemuck::cast_slice_mut(&mut dst[..width * channels * 2]);
+            for i in 0..width {
+                let base = i * channels;
+                let a = half::f16::from_bits(src16[base + alpha_idx]).to_f32();
+                for c in 0..alpha_idx {
+                    let v = half::f16::from_bits(src16[base + c]).to_f32();
+                    dst16[base + c] = half::f16::from_f32(v * a).to_bits();
+                }
+                dst16[base + alpha_idx] = src16[base + alpha_idx];
+            }
+        }
         _ => {
             // Fallback: copy.
             let len = min(src.len(), dst.len());
@@ -1170,6 +1354,46 @@ fn premul_to_straight(
                         dstf[base + c] = srcf[base + c] * inv_a;
                     }
                     dstf[base + alpha_idx] = a;
+                }
+            }
+        }
+        ChannelType::U16 => {
+            let src16: &[u16] = bytemuck::cast_slice(&src[..width * channels * 2]);
+            let dst16: &mut [u16] = bytemuck::cast_slice_mut(&mut dst[..width * channels * 2]);
+            for i in 0..width {
+                let base = i * channels;
+                let a = src16[base + alpha_idx];
+                if a == 0 {
+                    for c in 0..channels {
+                        dst16[base + c] = 0;
+                    }
+                } else {
+                    let a32 = a as u32;
+                    for c in 0..alpha_idx {
+                        dst16[base + c] =
+                            ((src16[base + c] as u32 * 65535 + a32 / 2) / a32).min(65535) as u16;
+                    }
+                    dst16[base + alpha_idx] = a;
+                }
+            }
+        }
+        ChannelType::F16 => {
+            let src16: &[u16] = bytemuck::cast_slice(&src[..width * channels * 2]);
+            let dst16: &mut [u16] = bytemuck::cast_slice_mut(&mut dst[..width * channels * 2]);
+            for i in 0..width {
+                let base = i * channels;
+                let a = half::f16::from_bits(src16[base + alpha_idx]).to_f32();
+                if a == 0.0 {
+                    for c in 0..channels {
+                        dst16[base + c] = 0;
+                    }
+                } else {
+                    let inv_a = 1.0 / a;
+                    for c in 0..alpha_idx {
+                        let v = half::f16::from_bits(src16[base + c]).to_f32();
+                        dst16[base + c] = half::f16::from_f32(v * inv_a).to_bits();
+                    }
+                    dst16[base + alpha_idx] = src16[base + alpha_idx];
                 }
             }
         }

--- a/zenpixels-convert/src/converter.rs
+++ b/zenpixels-convert/src/converter.rs
@@ -175,7 +175,9 @@ impl RowConverter {
                 if drops_alpha && options.alpha_policy == AlphaPolicy::Forbid {
                     return Err(whereat::at!(ConvertError::AlphaRemovalForbidden));
                 }
-                let reduces_depth = from.channel_type().byte_size() > to.channel_type().byte_size();
+                // Precision bits, not byte size — see convert.rs for rationale.
+                let reduces_depth = crate::negotiate::channel_bits(from.channel_type())
+                    > crate::negotiate::channel_bits(to.channel_type());
                 if reduces_depth && options.depth_policy == DepthPolicy::Forbid {
                     return Err(whereat::at!(ConvertError::DepthReductionForbidden));
                 }

--- a/zenpixels-convert/tests/roundtrip.rs
+++ b/zenpixels-convert/tests/roundtrip.rs
@@ -554,3 +554,216 @@ fn gray_to_gray_alpha_roundtrip() {
 
     assert_eq!(src, back);
 }
+
+// ---------------------------------------------------------------------------
+// F16 roundtrip tests
+// ---------------------------------------------------------------------------
+
+/// Helper: build a row of f16 pixel bytes from f32 values.
+fn f32s_to_f16_bytes(values: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(values.len() * 2);
+    for v in values {
+        out.extend_from_slice(&half::f16::from_f32(*v).to_le_bytes());
+    }
+    out
+}
+
+/// Helper: read f16 pixel bytes into f32 values.
+fn f16_bytes_to_f32s(bytes: &[u8]) -> Vec<f32> {
+    bytes
+        .chunks_exact(2)
+        .map(|c| half::f16::from_le_bytes([c[0], c[1]]).to_f32())
+        .collect()
+}
+
+/// F16 linear RGBA → F32 linear RGBA → F16 linear RGBA. Round-trip must be
+/// bit-exact because F16→F32 is lossless by IEEE 754 and F32→F16 rounds back
+/// to the same bits for any value originally representable as f16.
+#[test]
+fn f16_linear_to_f32_linear_and_back_is_exact() {
+    let width = 32u32;
+    // Sample across the full f16 SDR range including sub-normals, near-1.0,
+    // and some HDR values.
+    let f32_vals: Vec<f32> = (0..width as usize * 4)
+        .map(|i| {
+            let t = i as f32 / 16.0;
+            if i % 3 == 0 {
+                t * 0.25
+            } else if i % 3 == 1 {
+                1.0 - t * 0.01
+            } else {
+                2.0 + t * 0.1
+            }
+        })
+        .collect();
+    // Quantize to f16 first so we have exact source values.
+    let src: Vec<u8> = {
+        let mut s = Vec::with_capacity(f32_vals.len() * 2);
+        for v in &f32_vals {
+            s.extend_from_slice(&half::f16::from_f32(*v).to_le_bytes());
+        }
+        s
+    };
+
+    let from = PixelDescriptor::RGBAF16_LINEAR;
+    let to = PixelDescriptor::RGBAF32_LINEAR;
+
+    let mut up = RowConverter::new(from, to).unwrap();
+    let mut down = RowConverter::new(to, from).unwrap();
+
+    let mut f32_row = vec![0u8; width as usize * 4 * 4];
+    let mut back = vec![0u8; width as usize * 4 * 2];
+
+    up.convert_row(&src, &mut f32_row, width);
+    down.convert_row(&f32_row, &mut back, width);
+
+    assert_eq!(
+        src, back,
+        "F16 linear → F32 linear → F16 linear should be bit-exact"
+    );
+}
+
+/// F16 sRGB RGB → U8 sRGB RGB → F16 sRGB RGB. Checks the cross-depth F16 ↔ U8
+/// path routes correctly through F32 and the planner picks fused sRGB kernels.
+#[test]
+fn f16_srgb_to_u8_srgb_roundtrip_within_tolerance() {
+    let width = 16u32;
+    // sRGB-encoded f16 values representing typical 8-bit-quantizable inputs.
+    let u8_vals: Vec<u8> = (0..width as usize * 3).map(|i| (i * 7 % 256) as u8).collect();
+    let f16_vals: Vec<f32> = u8_vals.iter().map(|v| *v as f32 / 255.0).collect();
+    let src = f32s_to_f16_bytes(&f16_vals);
+
+    let f16_srgb = PixelDescriptor::new(
+        ChannelType::F16,
+        ChannelLayout::Rgb,
+        None,
+        TransferFunction::Srgb,
+    );
+    let u8_srgb = PixelDescriptor::RGB8_SRGB;
+
+    let mut to_u8 = RowConverter::new(f16_srgb, u8_srgb).unwrap();
+    let mut to_f16 = RowConverter::new(u8_srgb, f16_srgb).unwrap();
+
+    let mut u8_row = vec![0u8; width as usize * 3];
+    let mut back = vec![0u8; width as usize * 3 * 2];
+
+    to_u8.convert_row(&src, &mut u8_row, width);
+    to_f16.convert_row(&u8_row, &mut back, width);
+
+    // u8 round-trip quantizes to 1/255, but re-packing back into f16 is exact.
+    // Compare against the u8 ground truth: every round-tripped f16 must decode
+    // to the same u8 value as u8_vals.
+    for (i, (a, b)) in u8_vals.iter().zip(u8_row.iter()).enumerate() {
+        assert_eq!(a, b, "u8 mismatch at pixel {}", i);
+    }
+    let back_f32 = f16_bytes_to_f32s(&back);
+    for (i, (orig, rt)) in f16_vals.iter().zip(back_f32.iter()).enumerate() {
+        let diff = (orig - rt).abs();
+        assert!(
+            diff < 1.5 / 255.0,
+            "f16→u8→f16 roundtrip diff > 1.5/255 at pixel {}: {} vs {}",
+            i,
+            orig,
+            rt
+        );
+    }
+}
+
+/// F16 linear → U16 linear → F16 linear. U16 is more precise than F16 in [0,1]
+/// SDR, so F16 values should survive the round-trip within ~1 f16 ULP.
+#[test]
+fn f16_linear_to_u16_linear_roundtrip_within_f16_ulp() {
+    let width = 16u32;
+    let f32_vals: Vec<f32> = (0..width as usize * 3)
+        .map(|i| (i as f32 / 48.0).min(1.0))
+        .collect();
+    let src = f32s_to_f16_bytes(&f32_vals);
+
+    let f16_lin = PixelDescriptor::RGBF16_LINEAR;
+    let u16_lin = PixelDescriptor::new(
+        ChannelType::U16,
+        ChannelLayout::Rgb,
+        None,
+        TransferFunction::Linear,
+    );
+
+    let mut to_u16 = RowConverter::new(f16_lin, u16_lin).unwrap();
+    let mut to_f16 = RowConverter::new(u16_lin, f16_lin).unwrap();
+
+    let mut u16_row = vec![0u8; width as usize * 3 * 2];
+    let mut back = vec![0u8; width as usize * 3 * 2];
+
+    to_u16.convert_row(&src, &mut u16_row, width);
+    to_f16.convert_row(&u16_row, &mut back, width);
+
+    let src_f32 = f16_bytes_to_f32s(&src);
+    let back_f32 = f16_bytes_to_f32s(&back);
+    for (i, (orig, rt)) in src_f32.iter().zip(back_f32.iter()).enumerate() {
+        // f16 ULP at value near 1.0 is ~2^-11 ≈ 4.88e-4; allow 2 ULP slack.
+        let tolerance = 1e-3;
+        let diff = (orig - rt).abs();
+        assert!(
+            diff < tolerance,
+            "f16→u16→f16 roundtrip exceeded tolerance at pixel {}: {} vs {} (diff {})",
+            i,
+            orig,
+            rt,
+            diff
+        );
+    }
+}
+
+/// Depth-reduction policy catches U16 → F16 (precision loss from 16 bits to
+/// 11 effective bits) even though both are 2 bytes.
+#[test]
+fn u16_to_f16_triggers_depth_reduction_policy() {
+    use zenpixels_convert::{ConvertError, ConvertOptions, DepthPolicy, RowConverter};
+
+    let from = PixelDescriptor::new(
+        ChannelType::U16,
+        ChannelLayout::Rgb,
+        None,
+        TransferFunction::Linear,
+    );
+    let to = PixelDescriptor::RGBF16_LINEAR;
+
+    let opts = ConvertOptions::permissive().with_depth_policy(DepthPolicy::Forbid);
+
+    let result = RowConverter::new_explicit(from, to, &opts);
+    match result {
+        Err(e) => assert_eq!(*e.error(), ConvertError::DepthReductionForbidden),
+        Ok(_) => panic!("expected DepthReductionForbidden for U16 → F16 with Forbid policy"),
+    }
+}
+
+/// F16 → F16 with a TF change (sRGB → Linear) must round through F32, not
+/// pass bytes through unchanged.
+#[test]
+fn f16_srgb_to_f16_linear_changes_values() {
+    let width = 8u32;
+    // sRGB-encoded 0.5 (mid-gray) decodes to linear ~0.2140.
+    let f32_vals = vec![0.5_f32; width as usize * 3];
+    let src = f32s_to_f16_bytes(&f32_vals);
+
+    let from = PixelDescriptor::new(
+        ChannelType::F16,
+        ChannelLayout::Rgb,
+        None,
+        TransferFunction::Srgb,
+    );
+    let to = PixelDescriptor::RGBF16_LINEAR;
+
+    let mut conv = RowConverter::new(from, to).unwrap();
+    let mut out = vec![0u8; width as usize * 3 * 2];
+    conv.convert_row(&src, &mut out, width);
+
+    let out_f32 = f16_bytes_to_f32s(&out);
+    // sRGB EOTF of 0.5 ≈ 0.2140. Allow generous tolerance for F16 quantization.
+    for v in &out_f32 {
+        assert!(
+            (v - 0.2140).abs() < 0.01,
+            "expected linear ~0.2140 after sRGB F16 → Linear F16, got {}",
+            v
+        );
+    }
+}

--- a/zenpixels/src/descriptor.rs
+++ b/zenpixels/src/descriptor.rs
@@ -929,6 +929,65 @@ impl PixelDescriptor {
         Some(AlphaMode::Straight),
         TransferFunction::Unknown,
     );
+
+    // -- F16 constants --------------------------------------------------------
+
+    /// f16 RGB, transfer unknown.
+    pub const RGBF16: Self = Self::new(
+        ChannelType::F16,
+        ChannelLayout::Rgb,
+        None,
+        TransferFunction::Unknown,
+    );
+    /// f16 RGBA, transfer unknown.
+    pub const RGBAF16: Self = Self::new(
+        ChannelType::F16,
+        ChannelLayout::Rgba,
+        Some(AlphaMode::Straight),
+        TransferFunction::Unknown,
+    );
+    /// f16 grayscale, transfer unknown.
+    pub const GRAYF16: Self = Self::new(
+        ChannelType::F16,
+        ChannelLayout::Gray,
+        None,
+        TransferFunction::Unknown,
+    );
+    /// f16 grayscale with alpha, transfer unknown.
+    pub const GRAYAF16: Self = Self::new(
+        ChannelType::F16,
+        ChannelLayout::GrayAlpha,
+        Some(AlphaMode::Straight),
+        TransferFunction::Unknown,
+    );
+    /// Linear-light f16 RGB.
+    pub const RGBF16_LINEAR: Self = Self::new(
+        ChannelType::F16,
+        ChannelLayout::Rgb,
+        None,
+        TransferFunction::Linear,
+    );
+    /// Linear-light f16 RGBA with straight alpha.
+    pub const RGBAF16_LINEAR: Self = Self::new(
+        ChannelType::F16,
+        ChannelLayout::Rgba,
+        Some(AlphaMode::Straight),
+        TransferFunction::Linear,
+    );
+    /// Linear-light f16 grayscale.
+    pub const GRAYF16_LINEAR: Self = Self::new(
+        ChannelType::F16,
+        ChannelLayout::Gray,
+        None,
+        TransferFunction::Linear,
+    );
+    /// Linear-light f16 grayscale with straight alpha.
+    pub const GRAYAF16_LINEAR: Self = Self::new(
+        ChannelType::F16,
+        ChannelLayout::GrayAlpha,
+        Some(AlphaMode::Straight),
+        TransferFunction::Linear,
+    );
     /// 8-bit BGRA, transfer unknown.
     pub const BGRA8: Self = Self::new(
         ChannelType::U8,
@@ -1317,6 +1376,14 @@ pub enum PixelFormat {
     OklabaF32 = 17,
     /// 8-bit CMYK (4 bytes per pixel, no transfer function).
     Cmyk8 = 18,
+    /// f16 (IEEE 754 half-precision) RGB.
+    RgbF16 = 19,
+    /// f16 (IEEE 754 half-precision) RGBA.
+    RgbaF16 = 20,
+    /// f16 (IEEE 754 half-precision) grayscale.
+    GrayF16 = 21,
+    /// f16 (IEEE 754 half-precision) grayscale with alpha.
+    GrayAF16 = 22,
 }
 
 impl PixelFormat {
@@ -1340,6 +1407,7 @@ impl PixelFormat {
             | Self::GrayAF32
             | Self::OklabF32
             | Self::OklabaF32 => ChannelType::F32,
+            Self::RgbF16 | Self::RgbaF16 | Self::GrayF16 | Self::GrayAF16 => ChannelType::F16,
             _ => ChannelType::U8,
         }
     }
@@ -1349,10 +1417,14 @@ impl PixelFormat {
     #[allow(unreachable_patterns)]
     pub const fn layout(self) -> ChannelLayout {
         match self {
-            Self::Rgb8 | Self::Rgb16 | Self::RgbF32 => ChannelLayout::Rgb,
-            Self::Rgba8 | Self::Rgba16 | Self::RgbaF32 | Self::Rgbx8 => ChannelLayout::Rgba,
-            Self::Gray8 | Self::Gray16 | Self::GrayF32 => ChannelLayout::Gray,
-            Self::GrayA8 | Self::GrayA16 | Self::GrayAF32 => ChannelLayout::GrayAlpha,
+            Self::Rgb8 | Self::Rgb16 | Self::RgbF32 | Self::RgbF16 => ChannelLayout::Rgb,
+            Self::Rgba8 | Self::Rgba16 | Self::RgbaF32 | Self::RgbaF16 | Self::Rgbx8 => {
+                ChannelLayout::Rgba
+            }
+            Self::Gray8 | Self::Gray16 | Self::GrayF32 | Self::GrayF16 => ChannelLayout::Gray,
+            Self::GrayA8 | Self::GrayA16 | Self::GrayAF32 | Self::GrayAF16 => {
+                ChannelLayout::GrayAlpha
+            }
             Self::Bgra8 | Self::Bgrx8 => ChannelLayout::Bgra,
             Self::OklabF32 => ChannelLayout::Oklab,
             Self::OklabaF32 => ChannelLayout::OklabA,
@@ -1369,9 +1441,11 @@ impl PixelFormat {
             Self::Gray8
             | Self::Gray16
             | Self::GrayF32
+            | Self::GrayF16
             | Self::GrayA8
             | Self::GrayA16
-            | Self::GrayAF32 => ColorModel::Gray,
+            | Self::GrayAF32
+            | Self::GrayAF16 => ColorModel::Gray,
             Self::OklabF32 | Self::OklabaF32 => ColorModel::Oklab,
             Self::Cmyk8 => ColorModel::Cmyk,
             _ => ColorModel::Rgb,
@@ -1424,9 +1498,11 @@ impl PixelFormat {
             Self::Rgb8
             | Self::Rgb16
             | Self::RgbF32
+            | Self::RgbF16
             | Self::Gray8
             | Self::Gray16
             | Self::GrayF32
+            | Self::GrayF16
             | Self::OklabF32
             | Self::Cmyk8 => None,
             Self::Rgbx8 | Self::Bgrx8 => Some(AlphaMode::Undefined),
@@ -1457,6 +1533,10 @@ impl PixelFormat {
             Self::OklabF32 => "OklabF32",
             Self::OklabaF32 => "OklabaF32",
             Self::Cmyk8 => "CMYK8",
+            Self::RgbF16 => "RgbF16",
+            Self::RgbaF16 => "RgbaF16",
+            Self::GrayF16 => "GrayF16",
+            Self::GrayAF16 => "GrayAF16",
             _ => "Unknown",
         }
     }
@@ -1476,19 +1556,23 @@ impl PixelFormat {
             (ChannelType::U8, ChannelLayout::Rgb, _) => Some(Self::Rgb8),
             (ChannelType::U16, ChannelLayout::Rgb, _) => Some(Self::Rgb16),
             (ChannelType::F32, ChannelLayout::Rgb, _) => Some(Self::RgbF32),
+            (ChannelType::F16, ChannelLayout::Rgb, _) => Some(Self::RgbF16),
 
             (ChannelType::U8, ChannelLayout::Rgba, true) => Some(Self::Rgbx8),
             (ChannelType::U8, ChannelLayout::Rgba, false) => Some(Self::Rgba8),
             (ChannelType::U16, ChannelLayout::Rgba, _) => Some(Self::Rgba16),
             (ChannelType::F32, ChannelLayout::Rgba, _) => Some(Self::RgbaF32),
+            (ChannelType::F16, ChannelLayout::Rgba, _) => Some(Self::RgbaF16),
 
             (ChannelType::U8, ChannelLayout::Gray, _) => Some(Self::Gray8),
             (ChannelType::U16, ChannelLayout::Gray, _) => Some(Self::Gray16),
             (ChannelType::F32, ChannelLayout::Gray, _) => Some(Self::GrayF32),
+            (ChannelType::F16, ChannelLayout::Gray, _) => Some(Self::GrayF16),
 
             (ChannelType::U8, ChannelLayout::GrayAlpha, _) => Some(Self::GrayA8),
             (ChannelType::U16, ChannelLayout::GrayAlpha, _) => Some(Self::GrayA16),
             (ChannelType::F32, ChannelLayout::GrayAlpha, _) => Some(Self::GrayAF32),
+            (ChannelType::F16, ChannelLayout::GrayAlpha, _) => Some(Self::GrayAF16),
 
             (ChannelType::U8, ChannelLayout::Bgra, true) => Some(Self::Bgrx8),
             (ChannelType::U8, ChannelLayout::Bgra, false) => Some(Self::Bgra8),
@@ -1525,6 +1609,10 @@ impl PixelFormat {
             Self::OklabF32 => PixelDescriptor::OKLABF32,
             Self::OklabaF32 => PixelDescriptor::OKLABAF32,
             Self::Cmyk8 => PixelDescriptor::CMYK8,
+            Self::RgbF16 => PixelDescriptor::RGBF16,
+            Self::RgbaF16 => PixelDescriptor::RGBAF16,
+            Self::GrayF16 => PixelDescriptor::GRAYF16,
+            Self::GrayAF16 => PixelDescriptor::GRAYAF16,
             _ => PixelDescriptor::RGB8,
         }
     }


### PR DESCRIPTION
Implements Option A from issue #23: add descriptor-level F16 pixel support and the conversion kernels to make it real. **No `half::f16` leaks into zenpixels's public API.** Typed `impl Pixel for Rgb<f16>` etc. + a `GrayAlphaF16` struct wait for Rust stable `f16` ([rust-lang/rust#116909](https://github.com/rust-lang/rust/issues/116909), still nightly as of April 2026).

## What lands

### zenpixels (no new deps)

- `PixelFormat::RgbF16`, `RgbaF16`, `GrayF16`, `GrayAF16` on the `#[non_exhaustive]` enum
- `PixelDescriptor` `pub const` presets: `RGBF16`, `RGBAF16`, `GRAYF16`, `GRAYAF16`, `RGBF16_LINEAR`, `RGBAF16_LINEAR`, `GRAYF16_LINEAR`, `GRAYAF16_LINEAR`
- All `PixelFormat` methods (`channel_type`, `layout`, `color_model`, `default_alpha`, `name`, `from_parts`, `descriptor`) extended with F16 arms

### zenpixels-convert (`half = "2.7.1"` promoted from dev-deps to deps, internal only)

- Private `ConvertStep::F16ToF32` / `F32ToF16` (pub(crate) — not a public commitment)
- Scalar F16↔F32 kernels via `half::f16`; SIMD dispatch (F16C / AVX-512 FP16 / ARMv8.2 FP16) deferred
- Planner F16 arms in `depth_steps()` plus a rename of the depth-step helpers: `int_to_f32_step → to_f32_step`, `f32_to_int_step → f32_to_depth_step` (both extended to handle F16)
- F16 arms in all the `match ch_type` kernels: `swizzle_bgra_rgba`, `rgb_to_bgra`, `add_alpha`, `drop_alpha`, `matte_composite`, `gray_to_rgb`, `gray_to_rgba`, `gray_alpha_to_rgba`, `gray_alpha_to_rgb`, `gray_to_gray_alpha`, `gray_alpha_to_gray`, `straight_to_premul`, `premul_to_straight`
- Same-F16 TF changes route through F32 linear (never pass bytes through on a TF change)
- Peephole `cancels_cleanly` gets the `F16ToF32 ↔ F32ToF16` pair
- `intermediate_desc` handles F16↔F32 steps

### Depth-reduction policy fix (bug this PR surfaces, not creates)

`converter.rs:178` and `convert.rs:598` gated on `ChannelType::byte_size()`, so U16→F16 silently skipped the policy check (both are 2 bytes) despite being a real precision reduction from 16 effective bits to ~11. Switched to `channel_bits()` (already used by the cost model), which catches U16→F16 and leaves U16↔U8 / U8↔U16 / F32↔F16 / F16↔F32 behaving as before.

## What explicitly does NOT ship (and why)

- **No `impl Pixel for Rgb<half::f16>` / `Rgba<half::f16>` / `Gray<half::f16>`.** Would commit zenpixels's public API to the `half` crate forever or force a 0.3.0 bump when migrating to native `f16`. Wait for the native primitive.
- **No `pub struct GrayAlphaF16 { v: half::f16, a: half::f16 }` in `pixel_types.rs`.** Same reason.
- **No `OklabF16` / `OklabaF16`.** Oklab is compute-only in zen — no wire format, no codec produces or consumes it. YAGNI gate applies. Precision analysis (in issue #23) also shows iterated Oklab ops in f16 accumulate error.
- **No `f16` Cargo feature.** Middleman tax (zencodec, zenpipe, zencodecs, imageflow_core all needing forwarding) outweighs the `half` crate's cost — it's a few KB of pure Rust. CLAUDE.md's "feature flags are part of the API" rule applies.
- **No SIMD F16C / AVX-512 FP16 / ARMv8.2 FP16 dispatch.** Scalar via `half::f16` is correct; SIMD is an optimization to land after measurement.

## Time-limited asymmetry

F16 is the only depth without typed `Pixel` impls. This resolves when native `f16` stabilizes in stable Rust. The codec consumers blocked on F16 (zentiff, ultrahdr, zenjpeg Ultra HDR) all pass bytes + descriptor through `zenpixels-convert`, so the descriptor-level API covers the real use cases.

## Known limitation surfaced during this work (not fixed here)

`MatteComposite` linearizes the sRGB matte then blends against pixel data treated as linear. The planner ensures this holds for integer paths (U8/U16 kernels linearize source bytes inline) and for F32 paths that go through a depth/TF change (which inserts a linearize step). **But for same-TF same-depth float plans** — e.g. `F32 sRGB RGBA → F32 sRGB RGB` with `AlphaPolicy::CompositeOnto` — the plan is just `[MatteComposite]` with no prior linearize step, and the kernel blends sRGB-encoded pixel data against a linearized matte. Pre-existing bug, inherited by the F16 arm; flagged in kernel comment + CHANGELOG. Will file a separate issue to fix it in the planner.

## Dependent codec crates that unblock

Previously these decode f16 wire formats via `half::f16` and then force-collapse to f32 at the zenpixels boundary. They can now surface native F16 to downstream code:

- **zentiff** (TIFF `SampleFormat=IEEEFP BitsPerSample=16`)
- **zenjpeg** Ultra HDR gain maps (ISO 21496-1 APP2 f16)
- **ultrahdr** gain maps
- **image-tiff** (upstream fork)

Medium-term: heic, zenavif, zenjxl (modular f16). See issue #23 for per-crate analysis.

## Non-breaking audit

- New `PixelFormat` variants on `#[non_exhaustive]` — non-breaking
- New `pub const` presets — additive
- New `ConvertStep` variants — `pub(crate)`, not public
- New kernel functions — internal
- Depth-reduction policy fix catches precision loss previously silently allowed — tolerated behavior change per the 0.2.x policy in `CLAUDE.md`
- `cargo semver-checks --workspace` reports clean (no semver update required)

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo test --doc` passes
- [x] `cargo semver-checks --workspace` clean
- [x] 5 new F16 round-trip tests in `tests/roundtrip.rs`:
  - F16 linear → F32 linear → F16 linear: bit-exact
  - F16 sRGB → U8 sRGB → F16 sRGB: within 1.5/255 tolerance
  - F16 linear → U16 linear → F16 linear: within 2 f16 ULP
  - U16 → F16 with `DepthPolicy::Forbid`: rejected
  - F16 sRGB → F16 linear: value actually changes (not a silent passthrough)
- [ ] Maintainer spot-check of the MatteComposite F16 comment and planner F16 arms

Closes no issues; advances the checklist in #23.