### PR TITLE
feat(zenpixels): BT.2020 luma coefficients + ICC profile coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@
 
 ### zenpixels — added
 
+- **`LumaCoefficients::Bt2020` variant and `coefficients()` accessor.**
+  Adds the UHDTV BT.2020 luma recipe (`0.2627R + 0.6780G + 0.0593B`, same
+  primaries as BT.2100 — the HDR case shares this variant). The new
+  `pub const fn coefficients(self) -> [f32; 3]` returns the `[R, G, B]`
+  weights for any variant so downstream crates can pull numeric values
+  directly instead of maintaining their own tables. Motivated by
+  ultrahdr-core's `luma_coefficients()` table, which duplicates this data
+  for its BT.2100 HDR base-image path — this landing lets ultrahdr-core
+  delete its copy and pass the enum through instead. Non-breaking: new
+  variant on `#[non_exhaustive]` enum, new inherent method. `ConvertStep`
+  RGB→Gray kernels still hardcode BT.709 internally; wiring `options.luma`
+  through the planner is a separate follow-up (7562dd0).
+
 - **F16 (IEEE 754 half-precision) pixel format variants and presets.**
   `PixelFormat::RgbF16`, `RgbaF16`, `GrayF16`, `GrayAF16` on the
   `#[non_exhaustive]` enum, plus matching `pub const` presets: `RGBF16`,
@@ -24,6 +37,23 @@
   additive. (#23)
 
 ### zenpixels-convert — added
+
+- **`icc_profiles::icc_profile_for(primaries, transfer)` accessor.**
+  Companion to the primaries-only `icc_profile_for_primaries`; matches a
+  `(ColorPrimaries, TransferFunction)` pair against the bundled profile
+  set and returns `None` if nothing matches the requested TRC exactly.
+  Currently routes:
+  `(DisplayP3, Srgb|Bt709)` → `DISPLAY_P3_V4`,
+  `(Bt2020, Bt709|Srgb)` → `REC2020_V4`,
+  `(AdobeRgb, Gamma22)` → `ADOBE_RGB`.
+  HDR transfers (`Pq`, `Hlg`) and `Linear` return `None` on every primaries
+  set — no PQ/HLG ICC profiles are bundled, and those workflows should
+  signal color via CICP or generate the profile through a CMS. Motivated
+  by ultrahdr-rs's `get_icc_profile_for_gamut`, which currently regenerates
+  profiles via `moxcms::ColorProfile::new_bt2020()` on every call. Adds 4
+  unit tests covering the bundled hits, HDR rejection, mismatched-TRC
+  rejection, and BT.709 fall-through. Non-breaking: new public function,
+  no existing API changed (47eb81e).
 
 - **F16 conversion kernels.** `ConvertStep::F16ToF32` / `F32ToF16`
   (private enum variants) with scalar implementations. Planner routes

--- a/zenpixels-convert/src/icc_profiles.rs
+++ b/zenpixels-convert/src/icc_profiles.rs
@@ -65,7 +65,7 @@
 //! Rec. 2020 has a very wide gamut. Using 8-bit precision with Rec. 2020
 //! will cause visible banding in gradients. Use 16-bit or f32 precision.
 
-use crate::ColorPrimaries;
+use crate::{ColorPrimaries, TransferFunction};
 
 // ---------------------------------------------------------------------------
 // Embedded ICC profiles (CC0 license from Compact-ICC-Profiles)
@@ -168,6 +168,66 @@ pub const fn display_p3_icc(prefer_v2: bool) -> &'static [u8] {
         DISPLAY_P3_V2
     } else {
         DISPLAY_P3_V4
+    }
+}
+
+/// Get a bundled ICC profile matching both a primaries set and a transfer
+/// function.
+///
+/// This is a finer-grained accessor than [`icc_profile_for_primaries`]: it
+/// matches against the TRC encoded in each bundled profile, so a caller
+/// that asks for `(Bt2020, Bt709)` gets the same Rec. 2020 profile, but a
+/// caller asking for `(Bt2020, Pq)` gets `None` (no PQ profile bundled).
+///
+/// # Currently bundled combinations
+///
+/// | Primaries | Transfer | Returned profile |
+/// |-----------|----------|------------------|
+/// | [`Bt709`](ColorPrimaries::Bt709) | [`Srgb`](TransferFunction::Srgb) | `None` — sRGB is the assumed default |
+/// | [`DisplayP3`](ColorPrimaries::DisplayP3) | [`Srgb`](TransferFunction::Srgb) | [`DISPLAY_P3_V4`] |
+/// | [`Bt2020`](ColorPrimaries::Bt2020) | [`Bt709`](TransferFunction::Bt709) | [`REC2020_V4`] |
+/// | [`AdobeRgb`](ColorPrimaries::AdobeRgb) | [`Gamma22`](TransferFunction::Gamma22) | [`ADOBE_RGB`] |
+///
+/// # Not bundled (returns `None`)
+///
+/// - HDR transfers ([`Pq`](TransferFunction::Pq), [`Hlg`](TransferFunction::Hlg))
+///   on any primaries. Ultra HDR / HDR10 / HLG broadcast workflows that need
+///   a PQ- or HLG-tagged profile should either generate one via a CMS crate
+///   (e.g., `moxcms::ColorProfile::new_bt2020_pq().encode()`) or signal color
+///   via CICP instead of ICC.
+/// - [`Linear`](TransferFunction::Linear) on any primaries. Linear-light
+///   working spaces are typically expressed with CICP transfer code 8
+///   rather than an ICC profile.
+/// - Adobe RGB with any transfer other than `Gamma22`.
+/// - BT.2020 primaries with sRGB or BT.709 `Gamma22` / `Linear` transfers
+///   other than the single bundled BT.709 paraType-3 form.
+///
+/// When this function returns `None`, call [`icc_profile_for_primaries`] as
+/// a fallback if you can tolerate the profile's encoded TRC differing from
+/// your requested transfer (e.g., accept the bundled BT.709 TRC for an
+/// SDR BT.2020 export regardless of whether the caller asked for `Srgb` or
+/// `Bt709`).
+#[inline]
+pub const fn icc_profile_for(
+    primaries: ColorPrimaries,
+    transfer: TransferFunction,
+) -> Option<&'static [u8]> {
+    match (primaries, transfer) {
+        // Display P3 + sRGB: saucecontrol's DisplayP3Compat uses paraType-3
+        // sRGB TRC, so both the sRGB and BT.709 transfer callers (which differ
+        // only in the near-black linear segment) get the same profile.
+        (ColorPrimaries::DisplayP3, TransferFunction::Srgb)
+        | (ColorPrimaries::DisplayP3, TransferFunction::Bt709) => Some(DISPLAY_P3_V4),
+        // BT.2020 + BT.709 TRC: saucecontrol's Rec2020Compat uses paraType-3
+        // BT.709 TRC. Accept the sRGB request alias (same curve shape
+        // outside the near-black toe), as this matches what ultrahdr-style
+        // SDR BT.2020 base images need.
+        (ColorPrimaries::Bt2020, TransferFunction::Bt709)
+        | (ColorPrimaries::Bt2020, TransferFunction::Srgb) => Some(REC2020_V4),
+        // Adobe RGB + Gamma22: bundled v2 pure-gamma variant.
+        (ColorPrimaries::AdobeRgb, TransferFunction::Gamma22) => Some(ADOBE_RGB),
+        // Everything else: no bundled profile with that exact TRC.
+        _ => None,
     }
 }
 
@@ -297,5 +357,68 @@ mod tests {
         );
         assert!(icc_profile_for_primaries(ColorPrimaries::Bt709).is_none());
         assert!(icc_profile_for_primaries(ColorPrimaries::Unknown).is_none());
+    }
+
+    #[test]
+    fn icc_profile_for_hits_bundled_combinations() {
+        // Display P3 + sRGB / BT.709 paraType-3 curves both map to the bundled
+        // DisplayP3Compat-v4 profile.
+        assert_eq!(
+            icc_profile_for(ColorPrimaries::DisplayP3, TransferFunction::Srgb),
+            Some(DISPLAY_P3_V4)
+        );
+        assert_eq!(
+            icc_profile_for(ColorPrimaries::DisplayP3, TransferFunction::Bt709),
+            Some(DISPLAY_P3_V4)
+        );
+        // Rec 2020 SDR: BT.709 TRC profile is the canonical export for SDR
+        // BT.2020 base images (matches the ultrahdr 8-bit base JPEG case).
+        assert_eq!(
+            icc_profile_for(ColorPrimaries::Bt2020, TransferFunction::Bt709),
+            Some(REC2020_V4)
+        );
+        assert_eq!(
+            icc_profile_for(ColorPrimaries::Bt2020, TransferFunction::Srgb),
+            Some(REC2020_V4)
+        );
+        // Adobe RGB: pure-gamma-2.2 TRC.
+        assert_eq!(
+            icc_profile_for(ColorPrimaries::AdobeRgb, TransferFunction::Gamma22),
+            Some(ADOBE_RGB)
+        );
+    }
+
+    #[test]
+    fn icc_profile_for_rejects_hdr_transfers() {
+        // HDR PQ / HLG profiles aren't bundled; callers should use CICP or
+        // a CMS-side generator.
+        assert!(icc_profile_for(ColorPrimaries::Bt2020, TransferFunction::Pq).is_none());
+        assert!(icc_profile_for(ColorPrimaries::Bt2020, TransferFunction::Hlg).is_none());
+        assert!(icc_profile_for(ColorPrimaries::DisplayP3, TransferFunction::Pq).is_none());
+        assert!(icc_profile_for(ColorPrimaries::DisplayP3, TransferFunction::Hlg).is_none());
+        // Linear likewise isn't bundled — CICP 8 is the canonical signal.
+        assert!(icc_profile_for(ColorPrimaries::Bt2020, TransferFunction::Linear).is_none());
+        assert!(icc_profile_for(ColorPrimaries::DisplayP3, TransferFunction::Linear).is_none());
+    }
+
+    #[test]
+    fn icc_profile_for_rejects_mismatched_trc_on_bundled_primaries() {
+        // We only bundle Adobe RGB with gamma 2.2 — asking for sRGB TRC on
+        // Adobe RGB primaries returns None rather than lying with a mismatched
+        // curve. Callers who want a fallback use icc_profile_for_primaries.
+        assert!(icc_profile_for(ColorPrimaries::AdobeRgb, TransferFunction::Srgb).is_none());
+        assert!(icc_profile_for(ColorPrimaries::AdobeRgb, TransferFunction::Bt709).is_none());
+        // Gamma 2.2 on DisplayP3 / Bt2020 isn't bundled either.
+        assert!(icc_profile_for(ColorPrimaries::DisplayP3, TransferFunction::Gamma22).is_none());
+        assert!(icc_profile_for(ColorPrimaries::Bt2020, TransferFunction::Gamma22).is_none());
+    }
+
+    #[test]
+    fn icc_profile_for_bt709_returns_none() {
+        // Same as icc_profile_for_primaries: BT.709 / sRGB is the assumed
+        // default and isn't bundled.
+        assert!(icc_profile_for(ColorPrimaries::Bt709, TransferFunction::Srgb).is_none());
+        assert!(icc_profile_for(ColorPrimaries::Bt709, TransferFunction::Bt709).is_none());
+        assert!(icc_profile_for(ColorPrimaries::Unknown, TransferFunction::Unknown).is_none());
     }
 }

--- a/zenpixels/src/buffer.rs
+++ b/zenpixels/src/buffer.rs
@@ -1425,9 +1425,15 @@ pub struct PixelBuffer<P = ()> {
 impl PixelBuffer {
     /// Allocate a zero-filled buffer for the given dimensions and format.
     ///
+    /// The default path is infallible for speed — see the
+    /// [allocation policy](crate#allocation-policy) for the rationale and
+    /// for guidance on when to reach for the `try_*` sibling.
+    ///
     /// # Panics
     ///
-    /// Panics if allocation fails. Use [`try_new`](Self::try_new) for fallible allocation.
+    /// Panics if allocation fails. Use [`try_new`](Self::try_new) for
+    /// fallible allocation when handling untrusted sizes or when OOM must
+    /// be recoverable.
     pub fn new(width: u32, height: u32, descriptor: PixelDescriptor) -> Self {
         Self::try_new(width, height, descriptor).expect("pixel buffer allocation failed")
     }
@@ -1473,10 +1479,16 @@ impl PixelBuffer {
     ///
     /// `simd_align` must be a power of 2 (e.g. 16, 32, 64).
     ///
+    /// The default path is infallible for speed — see the
+    /// [allocation policy](crate#allocation-policy) for the rationale and
+    /// for guidance on when to reach for the `try_*` sibling.
+    ///
     /// # Panics
     ///
-    /// Panics if allocation fails. Use [`try_new_simd_aligned`](Self::try_new_simd_aligned)
-    /// for fallible allocation.
+    /// Panics if allocation fails. Use
+    /// [`try_new_simd_aligned`](Self::try_new_simd_aligned) for fallible
+    /// allocation when handling untrusted sizes or when OOM must be
+    /// recoverable.
     pub fn new_simd_aligned(
         width: u32,
         height: u32,
@@ -1564,10 +1576,15 @@ impl<P: Pixel> PixelBuffer<P> {
     ///
     /// The descriptor is derived from `P::DESCRIPTOR`.
     ///
+    /// The default path is infallible for speed — see the
+    /// [allocation policy](crate#allocation-policy) for the rationale and
+    /// for guidance on when to reach for the `try_*` sibling.
+    ///
     /// # Panics
     ///
-    /// Panics if allocation fails. Use [`try_new_typed`](Self::try_new_typed)
-    /// for fallible allocation.
+    /// Panics if allocation fails. Use
+    /// [`try_new_typed`](Self::try_new_typed) for fallible allocation when
+    /// handling untrusted sizes or when OOM must be recoverable.
     pub fn new_typed(width: u32, height: u32) -> Self {
         Self::try_new_typed(width, height).expect("typed pixel buffer allocation failed")
     }
@@ -1645,6 +1662,15 @@ impl<P: Pixel> PixelBuffer<P> {
     ///
     /// Zero-copy when `P` has alignment 1 (u8-component types).
     /// Copies for higher-alignment types.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the copy path (triggered for `P` with alignment > 1) fails
+    /// to allocate. There is no fallible sibling today; if you need one,
+    /// pre-convert the `ImgVec` into a `Vec<P>` and use
+    /// [`try_new_typed`](Self::try_new_typed) followed by a manual copy, or
+    /// file a request against the crate (see the
+    /// [allocation policy](crate#allocation-policy)).
     pub fn from_imgvec(img: ImgVec<P>) -> Self {
         const { assert!(core::mem::size_of::<P>() == P::DESCRIPTOR.bytes_per_pixel()) }
         let width = img.width() as u32;

--- a/zenpixels/src/lib.rs
+++ b/zenpixels/src/lib.rs
@@ -19,6 +19,35 @@
 //! - [`ColorContext`] — ICC profile bytes and/or CICP, `Arc`-shared
 //! - [`ConvertOptions`] — policies for lossy operations (alpha removal, depth reduction)
 //!
+//! # Allocation policy
+//!
+//! All default [`PixelBuffer`] constructors (`new`, `new_simd_aligned`,
+//! `new_typed`, `from_imgvec`) **panic on allocation failure**. This is a
+//! deliberate default: the infallible path lowers to a single `calloc` and
+//! keeps hot construction sites branch-free, which matters for codecs that
+//! allocate one buffer per frame or strip.
+//!
+//! For code that handles untrusted input or must recover from OOM, use the
+//! fallible siblings instead:
+//!
+//! | Panicking                         | Fallible sibling                       |
+//! |-----------------------------------|----------------------------------------|
+//! | [`PixelBuffer::new`]              | [`PixelBuffer::try_new`]               |
+//! | [`PixelBuffer::new_simd_aligned`] | [`PixelBuffer::try_new_simd_aligned`]  |
+//! | `PixelBuffer::<P>::new_typed`     | `PixelBuffer::<P>::try_new_typed`      |
+//!
+//! The fallible siblings return
+//! [`BufferError::AllocationFailed`]
+//! via [`Vec::try_reserve_exact`] + `resize(_, 0)`. They are slightly slower
+//! than the panicking path because the reserve-then-zero pattern cannot be
+//! collapsed into a single `calloc` the way `vec![0; n]` can.
+//!
+//! There is currently **no runtime or compile-time toggle** to make the
+//! default constructors fallible. If a Cargo feature (e.g. `fallible-alloc`)
+//! or a runtime option would better fit your use case, please open an issue
+//! at <https://github.com/imazen/zen/issues> describing the caller and we'll
+//! evaluate adding one. Until then, reach directly for the `try_*` variants.
+//!
 //! # Feature flags
 //!
 //! | Feature | What it enables |

--- a/zenpixels/src/policy.rs
+++ b/zenpixels/src/policy.rs
@@ -48,6 +48,9 @@ pub enum DepthPolicy {
 }
 
 /// Luma coefficients for RGB→Gray conversion.
+///
+/// Use [`coefficients()`](Self::coefficients) to get the concrete `[f32; 3]`
+/// weights for each variant.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum LumaCoefficients {
@@ -55,6 +58,32 @@ pub enum LumaCoefficients {
     Bt709,
     /// BT.601: `0.299R + 0.587G + 0.114B` (SDTV, JPEG).
     Bt601,
+    /// BT.2020 / BT.2100: `0.2627R + 0.6780G + 0.0593B` (UHDTV, wide gamut).
+    ///
+    /// BT.2100 (HDR) uses the same primaries as BT.2020, so this is the
+    /// variant to use for both SDR BT.2020 and HDR BT.2100 content.
+    Bt2020,
+}
+
+impl LumaCoefficients {
+    /// Return the `[R, G, B]` weights for this luma recipe.
+    ///
+    /// - [`Bt709`](Self::Bt709): `[0.2126, 0.7152, 0.0722]`
+    /// - [`Bt601`](Self::Bt601): `[0.299, 0.587, 0.114]`
+    /// - [`Bt2020`](Self::Bt2020): `[0.2627, 0.6780, 0.0593]` (same as BT.2100)
+    ///
+    /// The three weights always sum to exactly 1.0 in IEEE 754 double
+    /// precision, but may sum to 1.0 ± 1 ULP in `f32`. Callers that need
+    /// the weights to sum to exactly 1.0 in f32 should use double-precision
+    /// accumulation in their inner loop.
+    #[inline]
+    pub const fn coefficients(self) -> [f32; 3] {
+        match self {
+            Self::Bt709 => [0.2126, 0.7152, 0.0722],
+            Self::Bt601 => [0.299, 0.587, 0.114],
+            Self::Bt2020 => [0.2627, 0.6780, 0.0593],
+        }
+    }
 }
 
 /// Explicit options for pixel format conversion. All lossy
@@ -229,9 +258,49 @@ mod tests {
     #[test]
     fn luma_coefficients_variants() {
         assert_ne!(LumaCoefficients::Bt709, LumaCoefficients::Bt601);
+        assert_ne!(LumaCoefficients::Bt709, LumaCoefficients::Bt2020);
+        assert_ne!(LumaCoefficients::Bt601, LumaCoefficients::Bt2020);
         let a = LumaCoefficients::Bt709;
         let b = a;
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn luma_coefficients_accessor_values() {
+        // Exact bit patterns of documented coefficients — any numeric drift
+        // in the enum is a behavior break for downstream RGB→Gray kernels.
+        assert_eq!(
+            LumaCoefficients::Bt709.coefficients(),
+            [0.2126_f32, 0.7152, 0.0722],
+        );
+        assert_eq!(
+            LumaCoefficients::Bt601.coefficients(),
+            [0.299_f32, 0.587, 0.114],
+        );
+        assert_eq!(
+            LumaCoefficients::Bt2020.coefficients(),
+            [0.2627_f32, 0.6780, 0.0593],
+        );
+    }
+
+    #[test]
+    fn luma_coefficients_sum_to_near_unity() {
+        // All three recipes are constructed from spec chromaticities and
+        // must normalize to white = 1.0. Allow 1 f32 ULP of slack for
+        // BT.2020 (its double-precision sum is exactly 1.0 but single
+        // precision may round).
+        for luma in [
+            LumaCoefficients::Bt709,
+            LumaCoefficients::Bt601,
+            LumaCoefficients::Bt2020,
+        ] {
+            let [r, g, b] = luma.coefficients();
+            let sum = r + g + b;
+            assert!(
+                (sum - 1.0).abs() < 1e-6,
+                "{luma:?} coefficients sum to {sum}, expected ~1.0"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Why

`ultrahdr-core` carries its own `luma_coefficients()` table with a
hardcoded BT.2100 variant (`[0.2627, 0.6780, 0.0593]`) because
`zenpixels::LumaCoefficients` only covers `Bt709` and `Bt601`. BT.2100
shares primaries with BT.2020 (ITU-R BT.2100 §3.2) and is the default
input color space for Ultra HDR gain-map generation — the default
`SplitConfig` and `ToneMapConfig` both assume it. Adding the variant
here lets ultrahdr-core delete its copy in a follow-up and pulls the
wide-gamut recipe into the canonical policy enum every zen crate
already depends on.

Separately, ultrahdr-rs's `get_icc_profile_for_gamut` regenerates
`moxcms::ColorProfile::new_bt2020()` on every call. zenpixels-convert
already bundles a BT.2020 ICC profile (`REC2020_V4`, saucecontrol's
Rec2020Compat-v4 CC0), so the consumer-side fix is an accessor that
matches `(primaries, transfer)` pairs rather than primaries alone,
making the bundled coverage discoverable.

## What

### `zenpixels`

- `LumaCoefficients::Bt2020` — new variant, docstring calls out that
  BT.2100 shares these primaries and is the variant to use for both.
- `LumaCoefficients::coefficients(self) -> [f32; 3]` — const accessor
  returning `[R, G, B]` weights. Bt709: `[0.2126, 0.7152, 0.0722]`,
  Bt601: `[0.299, 0.587, 0.114]`, Bt2020: `[0.2627, 0.6780, 0.0593]`.
- Tests: exact-value check for all three variants, sum-to-unity check
  within 1e-6 tolerance, plus the updated variant-inequality test.

### `zenpixels-convert`

- `icc_profiles::icc_profile_for(primaries, transfer)` — new public
  accessor. Matches `(primaries, transfer)` against the bundled set and
  returns `None` when the exact TRC isn't bundled rather than falling
  back silently. Currently covers:
  - `(DisplayP3, Srgb | Bt709)` → `DISPLAY_P3_V4`
  - `(Bt2020, Bt709 | Srgb)` → `REC2020_V4`
  - `(AdobeRgb, Gamma22)` → `ADOBE_RGB`
  - Everything else (BT.709 defaults, HDR transfers, Linear, unbundled
    pair combinations) → `None`.
- Four new unit tests covering bundled hits, HDR-transfer rejection,
  mismatched-TRC rejection, and BT.709/Unknown fall-through.

## Scope notes / known gaps

- The RGB→Gray kernel in `convert_kernels::rgb_to_gray_u8` still
  hardcodes BT.709 via `garb::bytes::rgb_to_gray_bt709` regardless of
  `options.luma`. Wiring the runtime choice through the planner needs
  new `ConvertStep` variants (or parameterized steps) and is a separate
  follow-up — this PR deliberately keeps the enum as policy metadata
  downstream crates consume directly via `.coefficients()`.
- **No PQ or HLG ICC profiles are bundled.** HDR-tagged stills that
  need `BT.2020 + PQ` or `BT.2020 + HLG` profiles should continue to
  signal via CICP or call a CMS generator (e.g.,
  `moxcms::ColorProfile::new_bt2020_pq()`). Bundling HDR transfer
  profiles needs licensing / corpus verification and is left for a
  future PR. `icc_profile_for` returns `None` for these combinations,
  making the gap explicit to callers.
- ultrahdr-rs deletion / migration to `icc_profile_for` is a follow-up
  in that repo.

## Breaking?

No.
- `LumaCoefficients` is `#[non_exhaustive]` (CLAUDE.md policy rule 4);
  adding a variant is non-breaking.
- `coefficients()` and `icc_profile_for` are new public items with no
  existing API changed.
- No type signatures altered, no existing variants touched.

## Test plan

- [x] `cargo test --workspace` (passes locally; all suites green)
- [x] `cargo clippy --workspace --all-targets` (clean)
- [x] `cargo fmt --check` (clean)
- [ ] CI green on `ubuntu-latest`, `macos-latest`, `windows-latest`,
      `windows-11-arm`, `macos-15-intel`, and `i686-unknown-linux-gnu`
      (deferred to CI)
