### PR TITLE
feat(zenpixels): add LumaCoefficients::DisplayP3 variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@
 
 ### zenpixels — added
 
+- **`LumaCoefficients::DisplayP3` variant.** Adds the DisplayP3 luma recipe
+  (`0.2289746R + 0.6917385G + 0.0792869B`), derived from the DCI-P3 primaries
+  with a D65 whitepoint (the middle row of the DisplayP3→XYZ matrix).
+  Unlike BT.709/BT.2020 there is no ITU recommendation prescribing these —
+  they match what libultrahdr (`gainmapmath.cpp:162`) and other HDR tooling
+  use for RGB→luma on DisplayP3 content. Verified against zenpixels' own
+  `rgb_to_xyz(DisplayP3)` Y row within 1 f32 ULP. Non-breaking: new variant
+  on `#[non_exhaustive]` enum, new arm on `coefficients()`.
+
 - **`LumaCoefficients::Bt2020` variant and `coefficients()` accessor.**
   Adds the UHDTV BT.2020 luma recipe (`0.2627R + 0.6780G + 0.0593B`, same
   primaries as BT.2100 — the HDR case shares this variant). The new

--- a/zenpixels/src/policy.rs
+++ b/zenpixels/src/policy.rs
@@ -63,6 +63,15 @@ pub enum LumaCoefficients {
     /// BT.2100 (HDR) uses the same primaries as BT.2020, so this is the
     /// variant to use for both SDR BT.2020 and HDR BT.2100 content.
     Bt2020,
+    /// Display P3 (DCI-P3 primaries + D65): `0.2289746R + 0.6917385G + 0.0792869B`
+    /// (Apple wide-gamut consumer displays).
+    ///
+    /// Unlike BT.709 and BT.2020, no ITU recommendation prescribes these
+    /// weights — they are derived as the middle (Y) row of the
+    /// DisplayP3→XYZ matrix from the P3 primaries and D65 white point, and
+    /// match what libultrahdr and other HDR tooling use in practice for
+    /// RGB→luma on DisplayP3 content.
+    DisplayP3,
 }
 
 impl LumaCoefficients {
@@ -71,6 +80,7 @@ impl LumaCoefficients {
     /// - [`Bt709`](Self::Bt709): `[0.2126, 0.7152, 0.0722]`
     /// - [`Bt601`](Self::Bt601): `[0.299, 0.587, 0.114]`
     /// - [`Bt2020`](Self::Bt2020): `[0.2627, 0.6780, 0.0593]` (same as BT.2100)
+    /// - [`DisplayP3`](Self::DisplayP3): `[0.2289746, 0.6917385, 0.0792869]`
     ///
     /// The three weights always sum to exactly 1.0 in IEEE 754 double
     /// precision, but may sum to 1.0 ± 1 ULP in `f32`. Callers that need
@@ -82,6 +92,7 @@ impl LumaCoefficients {
             Self::Bt709 => [0.2126, 0.7152, 0.0722],
             Self::Bt601 => [0.299, 0.587, 0.114],
             Self::Bt2020 => [0.2627, 0.6780, 0.0593],
+            Self::DisplayP3 => [0.2289746, 0.6917385, 0.0792869],
         }
     }
 }
@@ -260,6 +271,9 @@ mod tests {
         assert_ne!(LumaCoefficients::Bt709, LumaCoefficients::Bt601);
         assert_ne!(LumaCoefficients::Bt709, LumaCoefficients::Bt2020);
         assert_ne!(LumaCoefficients::Bt601, LumaCoefficients::Bt2020);
+        assert_ne!(LumaCoefficients::Bt709, LumaCoefficients::DisplayP3);
+        assert_ne!(LumaCoefficients::Bt601, LumaCoefficients::DisplayP3);
+        assert_ne!(LumaCoefficients::Bt2020, LumaCoefficients::DisplayP3);
         let a = LumaCoefficients::Bt709;
         let b = a;
         assert_eq!(a, b);
@@ -281,6 +295,10 @@ mod tests {
             LumaCoefficients::Bt2020.coefficients(),
             [0.2627_f32, 0.6780, 0.0593],
         );
+        assert_eq!(
+            LumaCoefficients::DisplayP3.coefficients(),
+            [0.2289746_f32, 0.6917385, 0.0792869],
+        );
     }
 
     #[test]
@@ -293,6 +311,7 @@ mod tests {
             LumaCoefficients::Bt709,
             LumaCoefficients::Bt601,
             LumaCoefficients::Bt2020,
+            LumaCoefficients::DisplayP3,
         ] {
             let [r, g, b] = luma.coefficients();
             let sum = r + g + b;


### PR DESCRIPTION
## Summary

Adds `LumaCoefficients::DisplayP3` with weights `[0.2289746, 0.6917385, 0.0792869]`, derived from the DCI-P3 primaries + D65 whitepoint (the middle / Y row of the DisplayP3->XYZ matrix).

Unlike BT.709 and BT.2020, no ITU recommendation prescribes these — but they're the canonical values used by every Ultra HDR toolchain that handles P3 content, including libultrahdr ([`gainmapmath.cpp:162`](https://github.com/google/libultrahdr/blob/main/lib/src/gainmapmath.cpp#L162)). Downstream crates like ultrahdr-core need these when the base image's primaries are DisplayP3.

Follows the exact shape of #26 (which added `Bt2020`):

- New `DisplayP3` variant on `LumaCoefficients`
- New match arm in `coefficients()` returning `[0.2289746, 0.6917385, 0.0792869]`
- Extended unit tests: `luma_coefficients_variants`, `luma_coefficients_accessor_values`, `luma_coefficients_sum_to_near_unity`
- CHANGELOG entry under `[Unreleased]` -> `zenpixels -- added`

## Verification

Computed the DisplayP3 Y row from first principles using zenpixels' own chromaticities (descriptor.rs:453) and `WHITE_D65 = (0.3127, 0.3290)` (descriptor.rs:436):

```
Y row (f64 -> f32): [0.22897457, 0.69173855, 0.07928691]
Expected:            [0.2289746,  0.6917385,  0.0792869]
max delta:          5.96e-8 (< 1 f32 ULP)
sum:                1.0 exact
```

Well within the 1e-5 tolerance called out in the task scope.

## Semver

Non-breaking:
- `LumaCoefficients` is `#[non_exhaustive]`, so new variants are semver-compatible
- `coefficients()` gains a new arm but its signature is unchanged

No version bump — release manager handles that.

## Test plan

- [x] `cargo test --package zenpixels` -- 222 lib tests + 4 doctests pass
- [x] `cargo test --package zenpixels --lib policy` -- 9/9 pass (including the three new assertions in existing tests)
- [x] Coefficient values verified against computed DisplayP3->XYZ matrix within 1 f32 ULP
- [x] Coefficient values match libultrahdr's `gainmapmath.cpp:162`

Predecessor: #26