### PR TITLE
fix: 32-bit overflow safety in PixelBuffer constructors and crop_copy

### DIFF
--- a/zenpixels/src/buffer.rs
+++ b/zenpixels/src/buffer.rs
@@ -2252,13 +2252,22 @@ impl<P> PixelBuffer<P> {
     ///
     /// # Panics
     ///
-    /// Panics if the crop region is out of bounds.
+    /// Panics if the crop region is out of bounds, or if the destination
+    /// allocation size (`aligned_stride(w) * h + min_alignment - 1`)
+    /// overflows `usize`. On 64-bit targets the overflow case is
+    /// unreachable for `u32` dimensions; on 32-bit targets it can be
+    /// reached with adversarial inputs and panics eagerly here rather
+    /// than producing a deferred slice-bounds panic.
     pub fn crop_copy(&self, x: u32, y: u32, w: u32, h: u32) -> PixelBuffer<P> {
         let src = self.crop_view(x, y, w, h);
         let stride = self.descriptor.aligned_stride(w);
-        let total = stride * h as usize;
         let align = self.descriptor.min_alignment();
-        let alloc_size = total + align - 1;
+        let total = stride
+            .checked_mul(h as usize)
+            .expect("crop_copy: stride * height overflows usize");
+        let alloc_size = total
+            .checked_add(align - 1)
+            .expect("crop_copy: aligned allocation size overflows usize");
         let data = vec![0u8; alloc_size];
         let offset = align_offset(data.as_ptr(), align);
         let mut dst = PixelBuffer {
@@ -3018,6 +3027,79 @@ mod tests {
         let buf = PixelBuffer::new(2, 2, PixelDescriptor::RGB8_SRGB);
         let typed: Option<PixelBuffer<Rgba<u8>>> = buf.try_typed();
         assert!(typed.is_none());
+    }
+
+    // --- Security audit 2026-05-06: 32-bit overflow safety regressions ---
+    //
+    // These dimensions overflow `usize` arithmetic on 32-bit targets but are
+    // representable on 64-bit, so the tests are gated to run under `cross`
+    // or any other 32-bit build (e.g. i686-unknown-linux-gnu). On 64-bit the
+    // overflow path is unreachable for `u32 x u32 x small-const` inputs;
+    // running the suite under 32-bit exercises the actual guard.
+
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn from_vec_rejects_stride_height_overflow_32bit() {
+        // RGB8: bpp=3. stride * height overflows 32-bit usize.
+        // 0xFFFF * 3 = 0x2FFFD, * 0xFFFF heights overflows.
+        let data = alloc::vec::Vec::<u8>::new();
+        let err = PixelBuffer::from_vec(data, 0xFFFF, 0xFFFF, PixelDescriptor::RGB8_SRGB)
+            .expect_err("expected overflow to be reported");
+        assert_eq!(*err.error(), BufferError::InvalidDimensions);
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    #[cfg(feature = "rgb")]
+    fn from_pixels_rejects_width_height_overflow_32bit() {
+        use rgb::Rgb;
+        // 2^16 * 2^16 == 2^32, wraps to 0 on 32-bit. With the fix this
+        // returns InvalidDimensions instead of accepting an empty vec
+        // for a (65536, 65536) buffer.
+        let pixels: alloc::vec::Vec<Rgb<u8>> = alloc::vec::Vec::new();
+        let err = PixelBuffer::<Rgb<u8>>::from_pixels(pixels, 1 << 16, 1 << 16)
+            .expect_err("expected width*height overflow to be reported");
+        assert_eq!(*err.error(), BufferError::InvalidDimensions);
+    }
+
+    #[cfg(feature = "rgb")]
+    #[test]
+    fn from_pixels_length_mismatch_does_not_panic() {
+        // On 64-bit this is the normal length-mismatch path; on 32-bit the
+        // overflow guard activates first. Either way, we get a clean error
+        // and never index out of bounds.
+        use rgb::Rgb;
+        let pixels: alloc::vec::Vec<Rgb<u8>> = alloc::vec![Rgb { r: 0, g: 0, b: 0 }; 4];
+        // (3, 3) wants 9 pixels; we provided 4.
+        let err = PixelBuffer::<Rgb<u8>>::from_pixels(pixels, 3, 3)
+            .expect_err("length mismatch must error");
+        assert_eq!(*err.error(), BufferError::InvalidDimensions);
+    }
+
+    #[test]
+    fn from_vec_insufficient_data_clean_error() {
+        // Standard insufficient-data path -- guards offset+total before the
+        // length check post-fix. Verify the existing happy-path negative
+        // still surfaces as InsufficientData (not panic) under the new
+        // checked_add guard.
+        let data = alloc::vec::Vec::<u8>::new();
+        let err = PixelBuffer::from_vec(data, 4, 4, PixelDescriptor::RGB8_SRGB)
+            .expect_err("empty data must error for non-zero dims");
+        assert_eq!(*err.error(), BufferError::InsufficientData);
+    }
+
+    #[test]
+    fn crop_copy_round_trip_does_not_overflow() {
+        // Sanity check that crop_copy still works for normal inputs after
+        // the overflow guard was added. The H1 fix only changes overflow
+        // behavior (deferred slice OOB -> eager panic with named message);
+        // we exercise that the happy path still returns a tightly-packed
+        // buffer of the requested size.
+        let buf = PixelBuffer::new(8, 4, PixelDescriptor::RGB8_SRGB);
+        let cropped = buf.crop_copy(1, 1, 3, 2);
+        assert_eq!(cropped.width(), 3);
+        assert_eq!(cropped.height(), 2);
+        assert_eq!(cropped.stride(), 3 * 3); // tightly packed RGB8
     }
 }
 

--- a/zenpixels/src/buffer.rs
+++ b/zenpixels/src/buffer.rs
@@ -1642,7 +1642,14 @@ impl<P: Pixel> PixelBuffer<P> {
     #[track_caller]
     pub fn from_pixels(pixels: Vec<P>, width: u32, height: u32) -> Result<Self, At<BufferError>> {
         const { assert!(core::mem::size_of::<P>() == P::DESCRIPTOR.bytes_per_pixel()) }
-        let expected = width as usize * height as usize;
+        // On 32-bit targets, `width * height` (as usize) can wrap to a small
+        // value (e.g. 2^16 * 2^16 = 0), which would silently bypass the
+        // length check below and accept a buffer of any size. Use
+        // `checked_mul` so overflow is reported as `InvalidDimensions`
+        // instead of producing a misshapen `PixelBuffer`.
+        let expected = (width as usize)
+            .checked_mul(height as usize)
+            .ok_or_else(|| whereat::at!(BufferError::InvalidDimensions))?;
         if pixels.len() != expected {
             return Err(whereat::at!(BufferError::InvalidDimensions));
         }

--- a/zenpixels/src/buffer.rs
+++ b/zenpixels/src/buffer.rs
@@ -1554,7 +1554,14 @@ impl PixelBuffer {
             .ok_or_else(|| whereat::at!(BufferError::InvalidDimensions))?;
         let align = descriptor.min_alignment();
         let offset = align_offset(data.as_ptr(), align);
-        if data.len() < offset + total {
+        // `offset + total` must not overflow `usize`; on 32-bit targets this is
+        // reachable from large `width * height * bpp` even when `total` itself
+        // fit. Guard with `checked_add` to surface as `InvalidDimensions`
+        // rather than a deferred slice/index panic.
+        let required = offset
+            .checked_add(total)
+            .ok_or_else(|| whereat::at!(BufferError::InvalidDimensions))?;
+        if data.len() < required {
             return Err(whereat::at!(BufferError::InsufficientData));
         }
         Ok(Self {


### PR DESCRIPTION
## Summary

Addresses three HIGH findings from the 2026-05-06 zenpixels security audit. All three are 32-bit-only DoS-via-deferred-panic bugs in `PixelBuffer` constructors / `crop_copy` where unchecked `usize` arithmetic on `u32` width/height/bpp could wrap on 32-bit targets and bypass length checks, deferring the failure to a slice OOB or `vec![]` panic later.

On 64-bit these are unreachable from `u32 x u32 x small-const` inputs, so the impact is limited to 32-bit builds (i686, wasm32, embedded). Even there, no UB / no memory unsafety -- worst case is a deterministic panic on attacker-supplied dimensions. Fixes are mechanical: `checked_mul` / `checked_add`, surface `BufferError::InvalidDimensions` (or eager named panic for the infallible `crop_copy` signature).

## Findings & fixes

| ID | File:line | Symptom | Fix commit |
|----|-----------|---------|------------|
| H1 | `zenpixels/src/buffer.rs:2242` (`PixelBuffer::crop_copy`) | `stride * h + align - 1` unchecked, then `vec![0u8; alloc_size]` -> deferred slice OOB on row copy | `c9926c7` |
| H2 | `zenpixels/src/buffer.rs:1545` (`PixelBuffer::from_vec`) | `offset + total` unchecked after `stride*height` was checked | `fa7b0de` |
| H3 | `zenpixels/src/buffer.rs:1636` (`PixelBuffer::from_pixels`) | `width as usize * height as usize` unchecked; on 32-bit `2^16 * 2^16` wraps to 0 and bypasses the length-mismatch guard | `0b27ac4` |

`crop_copy` keeps its infallible signature (per CLAUDE.md YAGNI rules: no new public `try_*` API without a concrete consumer). The overflow case now panics eagerly with `\"crop_copy: ...\"` instead of a deferred slice-bounds panic, and the doc comment documents the new panic clause.

## Tests

Added regression tests in `zenpixels/src/buffer.rs` (existing `mod tests`):

- `from_vec_rejects_stride_height_overflow_32bit` -- gated `target_pointer_width = \"32\"`
- `from_pixels_rejects_width_height_overflow_32bit` -- gated 32-bit, requires `rgb` feature
- `from_pixels_length_mismatch_does_not_panic` -- any target, `rgb` feature
- `from_vec_insufficient_data_clean_error` -- any target
- `crop_copy_round_trip_does_not_overflow` -- any target, sanity check

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p zenpixels --all-features --all-targets -- -D warnings` clean
- [x] `cargo test -p zenpixels --all-features` -- 266 passed (host x86_64, gated tests skipped)
- [x] `cargo test -p zenpixels-convert --all-features` -- still passes
- [x] `cargo doc --no-deps -p zenpixels --all-features` builds
- [x] `cross test -p zenpixels --target i686-unknown-linux-gnu --all-features` -- **268 passed**, both `target_pointer_width = \"32\"`-gated overflow regressions fire and pass on real 32-bit
- [ ] CI: confirm i686 / windows-11-arm / macOS-intel runs green