### PR TITLE
perf(zenpixels-convert): use garb chunk SIMD for invert_8px deinterleave

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "garb"
-version = "0.2.5"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ee8d8f5e43a45183480ea077c4e046e43ab9604928c87d6ad2080e666dc519"
+checksum = "8b968bb36272be4662f264fd123e96915e7dd51c8ca529c2d35f621817ff4207"
 dependencies = [
  "archmage",
  "bytemuck",

--- a/zenpixels-convert/Cargo.toml
+++ b/zenpixels-convert/Cargo.toml
@@ -41,7 +41,7 @@ zenpixels = { workspace = true, default-features = false, features = ["icc"] }
 linear-srgb = { version = "0.6.12", default-features = false, features = ["transfer"] }
 bytemuck = { version = "1.21", default-features = false, features = ["extern_crate_alloc", "derive"] }
 rgb = { version = "0.8", default-features = false, features = ["bytemuck"], optional = true }
-garb = { version = "0.2.5", default-features = false, features = ["experimental"] }
+garb = { version = "0.2.8", default-features = false, features = ["experimental"] }
 archmage = { version = "0.9.15", default-features = false }
 magetypes = { version = "0.9.18", default-features = false }
 paste = "1.0.15"

--- a/zenpixels-convert/src/builtin_profiles.rs
+++ b/zenpixels-convert/src/builtin_profiles.rs
@@ -333,15 +333,14 @@ mod simd {
 
     #[rite]
     fn invert_8px(token: X64V3Token, rgb_in: &[u8; 24], rgb_out: &mut [u8; 24]) {
-        // Deinterleave 8 RGB triples into three lanes of f32x8.
-        let mut r_in = [0.0f32; 8];
-        let mut g_in = [0.0f32; 8];
-        let mut b_in = [0.0f32; 8];
-        for i in 0..8 {
-            r_in[i] = rgb_in[i * 3] as f32;
-            g_in[i] = rgb_in[i * 3 + 1] as f32;
-            b_in[i] = rgb_in[i * 3 + 2] as f32;
-        }
+        // Deinterleave 8 RGB triples into three lanes of f32x8 via garb's
+        // hand-tuned `_mm_shuffle_epi8` + 256-bit AVX2 widening kernel
+        // (`vpshufb` + `vpmovzxbd` + `vcvtdq2ps`). +21-52% over LLVM
+        // autovec on the equivalent scalar loop at L1-L3 sizes per garb's
+        // `benchmarks/rgb24_chunk_vs_autovec_2026-05-07`. The kernel is
+        // `#[rite(v3)]` so it inlines into this `#[rite]` region with no
+        // dispatch boundary.
+        let (r_in, g_in, b_in) = garb::deinterleave::rgb24_chunk8_to_planes_tokenless_v3(rgb_in);
 
         // Undo the JPEG level shift (+128) applied during encode.
         let shift = mt_f32x8::splat(token, super::JPEG_LEVEL_SHIFT);


### PR DESCRIPTION
`invert_8px` (the 8-pixel SIMD kernel of `builtin_profiles::simd::convert_rgb_xyb_to_srgb_v3`) opened with a 7-line scalar loop deinterleaving 8 packed RGB u8 triples into three `[f32; 8]` planes. That loop is inside a `#[rite]` region (so autovec can use AVX2 target_feature), but for u8 stride-3 deinterleave LLVM autovec doesn't emit `_mm_shuffle_epi8` with a precomputed mask — the pattern isn't reliably inferred from generic strided indexing.

Swap that loop for `garb::deinterleave::rgb24_chunk8_to_planes_tokenless_v3` (added in garb 0.2.8). The kernel does the deinterleave with `_mm_shuffle_epi8` and the widening with real 256-bit AVX2 (`_mm256_cvtepu8_epi32` + `_mm256_cvtepi32_ps` + `_mm256_storeu_ps`). It's `#[rite(v3)]`, so it inlines into this `#[rite]` region with no dispatch boundary.

## Bench evidence

From garb's `benchmarks/rgb24_chunk_vs_autovec_2026-05-07.{log,meta}` (7950X, AVX2):

| size | scalar | autovec | chunk-SIMD | chunk vs autovec |
|------|---:|---:|---:|---:|
| 256px | 216ns | 127ns | 64ns | **+50%** |
| 4096px | 3293ns | 1218ns | 602ns | **+51%** |
| 65536px | 50.1µs | 20.1µs | 9.7µs | **+52%** |
| 1MP | 873.8µs | 591.2µs | 467.5µs | **+21%** |
| 4MP+ DRAM | (memory-bound — all tied) |

That's the deinterleave step in isolation. `invert_8px` does the deinterleave + XYB inverse + opsin matrix + linear→sRGB OETF + round-to-u8, so the wall-clock improvement on the full kernel will be smaller than 21-52%. But the deinterleave is on the hot path of every chunk and was leaving SIMD on the table.

## Diff

`Cargo.toml`: `garb = "0.2.5"` → `"0.2.8"` (caret `0.2.5` already accepted 0.2.8 transitively, but the source now uses an API only present in 0.2.8 so the manifest is now correct).

`src/builtin_profiles.rs::simd::invert_8px`:

```diff
-        let mut r_in = [0.0f32; 8];
-        let mut g_in = [0.0f32; 8];
-        let mut b_in = [0.0f32; 8];
-        for i in 0..8 {
-            r_in[i] = rgb_in[i * 3] as f32;
-            g_in[i] = rgb_in[i * 3 + 1] as f32;
-            b_in[i] = rgb_in[i * 3 + 2] as f32;
-        }
+        let (r_in, g_in, b_in) = garb::deinterleave::rgb24_chunk8_to_planes_tokenless_v3(rgb_in);
```

## What stays

The interleave-back-to-u8 step at the end of `invert_8px` (`for i in 0..8 { rgb_out[i*3] = f32_to_u8_round(sr[i]); ... }`) is unchanged. garb has no equivalent u8 round-and-pack primitive.

## Public API

Internal change only. `invert_8px` is `pub(crate)` — zenpixels-convert's public surface doesn't move.

## Test plan

- [x] `cargo build --release -p zenpixels-convert` — clean
- [x] `cargo test --release -p zenpixels-convert --lib` — 242 tests pass

## Tracking

Follows up on imazen/garb#7 / imazen/garb#8 (garb 0.2.8 release).