### PR TITLE
feat: HDR-IQA plumbing — peak_luminance_nits + Cicp::resolve_matrix

### DIFF
--- a/zenpixels-convert/src/hdr.rs
+++ b/zenpixels-convert/src/hdr.rs
@@ -56,6 +56,35 @@ impl HdrMetadata {
             mastering_display: None,
         }
     }
+
+    /// Absolute peak luminance in cd/m² for this metadata.
+    ///
+    /// **`#[doc(hidden)]`**: HDR-IQA-specific niche surface — see
+    /// `zenpixels_convert::hdr_iqa` and imazen/zenmetrics#13.
+    ///
+    /// Resolves in order:
+    /// 1. `mastering_display.max_luminance` if present (explicit signaling).
+    /// 2. `content_light_level.max_content_light_level` if present and non-zero.
+    /// 3. Default from `TransferFunction::peak_luminance_nits`.
+    ///
+    /// Used by HDR-IQA front-ends to convert linear `[0, 1]` signal to
+    /// absolute luminance before PU encoding. The result is always
+    /// `> 0`; SDR / Unknown transfers report `1.0` (relative).
+    #[doc(hidden)]
+    #[must_use]
+    pub fn peak_luminance_nits(&self) -> f32 {
+        if let Some(md) = self.mastering_display
+            && md.max_luminance > 0.0
+        {
+            return md.max_luminance;
+        }
+        if let Some(cll) = self.content_light_level
+            && cll.max_content_light_level > 0
+        {
+            return f32::from(cll.max_content_light_level);
+        }
+        self.transfer.peak_luminance_nits()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -102,6 +131,58 @@ pub fn exposure_tonemap(v: f32, exposure: f32) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn peak_luminance_prefers_mastering_display() {
+        // mastering_display.max_luminance wins when present.
+        let meta = HdrMetadata {
+            transfer: TransferFunction::Pq,
+            content_light_level: Some(ContentLightLevel::new(4_000, 400)),
+            mastering_display: Some(MasteringDisplay::HDR10_REFERENCE),
+        };
+        // HDR10_REFERENCE is 10 000 cd/m².
+        assert_eq!(meta.peak_luminance_nits(), 10_000.0);
+    }
+
+    #[test]
+    fn peak_luminance_falls_back_to_max_cll() {
+        // No mastering display → use max_content_light_level.
+        let meta = HdrMetadata {
+            transfer: TransferFunction::Pq,
+            content_light_level: Some(ContentLightLevel::new(1_400, 400)),
+            mastering_display: None,
+        };
+        assert_eq!(meta.peak_luminance_nits(), 1_400.0);
+    }
+
+    #[test]
+    fn peak_luminance_falls_back_to_transfer_default() {
+        // No mastering display, no CLL → use TransferFunction default.
+        let meta = HdrMetadata {
+            transfer: TransferFunction::Pq,
+            content_light_level: None,
+            mastering_display: None,
+        };
+        assert_eq!(meta.peak_luminance_nits(), 10_000.0);
+
+        let meta = HdrMetadata {
+            transfer: TransferFunction::Hlg,
+            content_light_level: None,
+            mastering_display: None,
+        };
+        assert_eq!(meta.peak_luminance_nits(), 1_000.0);
+    }
+
+    #[test]
+    fn peak_luminance_sdr_is_relative() {
+        // SDR metadata (no transfer hint) defaults to relative 1.0.
+        let meta = HdrMetadata {
+            transfer: TransferFunction::Srgb,
+            content_light_level: None,
+            mastering_display: None,
+        };
+        assert_eq!(meta.peak_luminance_nits(), 1.0);
+    }
 
     #[test]
     fn reinhard_boundaries() {

--- a/zenpixels-convert/src/hdr_iqa.rs
+++ b/zenpixels-convert/src/hdr_iqa.rs
@@ -1,0 +1,295 @@
+#![allow(clippy::excessive_precision)]
+//! HDR-IQA primitives — PU encoding (Mantiuk PU21) + named luma
+//! coefficients for downstream perceptual quality metrics.
+//!
+//! Niche surface: this module exists so zensim / zenmetrics /
+//! zenanalyze can score HDR image pairs through SDR-trained metrics
+//! by front-ending them with PU-encoded luminance. The whole module
+//! is `#[doc(hidden)]` because:
+//!
+//! - PU encoding is HDR-IQA-specific, not a general color-conversion
+//!   primitive (it doesn't round-trip through normal pixel pipelines).
+//! - The API contract is "experimental until validated against
+//!   AIC-HDR2025 / UPIQ" (see imazen/zenmetrics#13).
+//! - linear-srgb deliberately stays free of HDR-IQA-specific
+//!   conversions; zenpixels-convert is the higher-level layer where
+//!   perceptual converters naturally live.
+//!
+//! ## Reference
+//!
+//! Mantiuk, R. K., Azimi, M. (2021).
+//! *PU21: A novel perceptually uniform encoding for adapting existing
+//! quality metrics for HDR.* Picture Coding Symposium (PCS).
+//! Reference impl: <https://github.com/gfxdisp/pu21>.
+//!
+//! ## Output range
+//!
+//! `pu_encode(Y_cd_m2)` returns a value in roughly `[0, 530]` for
+//! `Y ∈ [0.005, 10_000]` cd/m². For downstream IQA work that wants a
+//! normalized `[0, 1]` scale, divide by [`PU_PEAK`].
+//!
+//! ## Anchor identities
+//!
+//! | Input | PU value |
+//! |---|---|
+//! | 0.005 cd/m² (sub-black) | clamped to 0 |
+//! | 1 cd/m² | ≈ 84.4 |
+//! | 10 cd/m² | ≈ 158.5 |
+//! | 80 cd/m² (legacy SDR display peak) | ≈ 250.5 |
+//! | 100 cd/m² (BT.1886 SDR peak) | ≈ 261.8 |
+//! | 203 cd/m² (BT.2408 HDR reference white) | ≈ 298.8 ([`PU_REF_WHITE_BT2408`]) |
+//! | 1 000 cd/m² (HDR10 highlight) | ≈ 388.1 |
+//! | 4 000 cd/m² | ≈ 468.5 |
+//! | 10 000 cd/m² (PQ peak) | ≈ 520.5 ([`PU_PEAK`]) |
+
+// `f32::powf` lives in `std` and behind `libm` in `no_std`. Mirror the
+// rest of the crate (see fast_gamut.rs) — std-only at the moment. If
+// no_std support is added later, gate this on `libm::Float`.
+
+// =============================================================================
+// PU21 constants (Mantiuk & Azimi 2021)
+// =============================================================================
+//
+// PU21(Y) = par[7] * (((par[1] + par[2]·Y^par[4]) / (1 + par[3]·Y^par[4]))^par[5] - par[6])
+//
+// where Y is absolute luminance in cd/m². Coefficients lifted verbatim
+// from gfxdisp/pu21 (banding_glare model — the variant tuned for IQA
+// against both subtle banding and high-luminance flare).
+
+const PU21_P1: f32 = 1.070_275_272;
+const PU21_P2: f32 = 0.408_827_393_2;
+const PU21_P3: f32 = 0.153_224_308;
+const PU21_P4: f32 = 0.252_032_616_8;
+const PU21_P5: f32 = 1.063_512_885;
+const PU21_P6: f32 = 1.141_150_47;
+const PU21_P7: f32 = 521.452_748_4;
+
+/// PU value at the HDR10 peak luminance (10 000 cd/m²).
+///
+/// Use as the normaliser when a `[0, 1]` PU output is desired.
+pub const PU_PEAK: f32 = 520.467_25;
+
+/// PU value at BT.2408 HDR reference white (203 cd/m²).
+///
+/// Anchor identity for verifying PU implementations and for downstream
+/// metric calibration.
+pub const PU_REF_WHITE_BT2408: f32 = 298.761_14;
+
+/// Lowest luminance the PU curve accepts before clamping to zero.
+///
+/// Matches gfxdisp/pu21's reference clamp.
+pub const PU_LUMINANCE_MIN_CD_M2: f32 = 0.005;
+
+/// Highest luminance the PU curve is calibrated for.
+///
+/// Coincides with the HDR10 / PQ ST 2084 peak. Inputs above this are
+/// permitted (the formula remains monotone) but extrapolate beyond the
+/// published validation range.
+pub const PU_LUMINANCE_MAX_CD_M2: f32 = 10_000.0;
+
+// =============================================================================
+// Luma coefficients
+// =============================================================================
+
+/// BT.2020 NCL (non-constant-luminance) luma coefficients.
+///
+/// Used by HDR10, PQ, BT.2100, and the HDR gain-map specs. Order is
+/// `[R, G, B]`; sums to 1.0.
+pub const BT2020_NCL_LUMA: [f32; 3] = [0.2627, 0.6780, 0.0593];
+
+/// BT.709 luma coefficients.
+///
+/// Used by sRGB-primary YCbCr at HDTV resolutions and as the default
+/// for SDR JPEG / JPEG XL on Rec.709 primaries. Order is `[R, G, B]`;
+/// sums to 1.0.
+pub const BT709_LUMA: [f32; 3] = [0.2126, 0.7152, 0.0722];
+
+/// BT.601 luma coefficients (legacy SDTV).
+///
+/// Used by SDTV YCbCr and the canonical JPEG color-space matrix when
+/// the encoder targets pre-HD content. Order is `[R, G, B]`;
+/// sums to 1.0.
+pub const BT601_LUMA: [f32; 3] = [0.299, 0.587, 0.114];
+
+// =============================================================================
+// Scalar PU
+// =============================================================================
+
+/// Encode absolute luminance (cd/m²) to PU space.
+///
+/// Inputs at or below [`PU_LUMINANCE_MIN_CD_M2`] (0.005 cd/m²) clamp to 0.
+/// The curve is monotone-increasing across its valid range and
+/// extrapolates smoothly above [`PU_LUMINANCE_MAX_CD_M2`].
+#[inline]
+pub fn pu_encode(luminance_cd_m2: f32) -> f32 {
+    if luminance_cd_m2 <= PU_LUMINANCE_MIN_CD_M2 {
+        return 0.0;
+    }
+    let yp = luminance_cd_m2.powf(PU21_P4);
+    let num = PU21_P1 + PU21_P2 * yp;
+    let den = 1.0 + PU21_P3 * yp;
+    let inner = num / den;
+    let val = PU21_P7 * (inner.powf(PU21_P5) - PU21_P6);
+    val.max(0.0)
+}
+
+/// Decode a PU value back to absolute luminance (cd/m²).
+///
+/// Inverse of [`pu_encode`]. The closed-form inverse is well-defined
+/// over the valid PU range `[0, ~530]`; inputs outside that clamp to
+/// the corresponding luminance bounds.
+#[inline]
+pub fn pu_decode(pu: f32) -> f32 {
+    if pu <= 0.0 {
+        return 0.0;
+    }
+    let inner = ((pu / PU21_P7) + PU21_P6).powf(1.0 / PU21_P5);
+    let num = inner - PU21_P1;
+    let den = PU21_P2 - PU21_P3 * inner;
+    if den <= 0.0 || num <= 0.0 {
+        return PU_LUMINANCE_MIN_CD_M2;
+    }
+    (num / den).powf(1.0 / PU21_P4)
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pu_encode_f64(y: f64) -> f64 {
+        if y <= PU_LUMINANCE_MIN_CD_M2 as f64 {
+            return 0.0;
+        }
+        let yp = y.powf(PU21_P4 as f64);
+        let num = (PU21_P1 as f64) + (PU21_P2 as f64) * yp;
+        let den = 1.0 + (PU21_P3 as f64) * yp;
+        let inner = num / den;
+        let val = (PU21_P7 as f64) * (inner.powf(PU21_P5 as f64) - (PU21_P6 as f64));
+        val.max(0.0)
+    }
+
+    #[test]
+    fn sub_black_clamps_to_zero() {
+        assert_eq!(pu_encode(-100.0), 0.0);
+        assert_eq!(pu_encode(0.0), 0.0);
+        assert_eq!(pu_encode(PU_LUMINANCE_MIN_CD_M2), 0.0);
+    }
+
+    #[test]
+    fn bt2408_reference_white_anchor() {
+        let pu = pu_encode(203.0);
+        assert!(
+            (pu - PU_REF_WHITE_BT2408).abs() < 0.05,
+            "PU(203) = {pu}, expected ≈ {PU_REF_WHITE_BT2408}"
+        );
+    }
+
+    #[test]
+    fn hdr_peak_anchor() {
+        let pu = pu_encode(PU_LUMINANCE_MAX_CD_M2);
+        assert!(
+            (pu - PU_PEAK).abs() < 0.05,
+            "PU(10000) = {pu}, expected ≈ {PU_PEAK}"
+        );
+    }
+
+    #[test]
+    fn published_curve_anchors() {
+        let cases = [
+            (1.0_f32, 84.4_f32),
+            (10.0, 158.5),
+            (80.0, 250.5),
+            (100.0, 261.8),
+            (500.0, 348.5),
+            (1_000.0, 388.1),
+            (4_000.0, 468.5),
+        ];
+        for (input, expected) in cases {
+            let pu = pu_encode(input);
+            assert!(
+                (pu - expected).abs() < 0.1,
+                "PU({input}) = {pu}, expected ≈ {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn monotone_across_decade_grid() {
+        let grid = [0.01_f32, 0.1, 1.0, 10.0, 100.0, 1_000.0, 10_000.0];
+        let mut prev = pu_encode(grid[0]);
+        for &y in &grid[1..] {
+            let pu = pu_encode(y);
+            assert!(
+                pu > prev,
+                "PU not monotone at Y = {y} (prev = {prev}, pu = {pu})"
+            );
+            prev = pu;
+        }
+    }
+
+    #[test]
+    fn round_trip_within_05_pct() {
+        for &y in &[
+            0.01_f32, 0.1, 1.0, 10.0, 80.0, 100.0, 203.0, 500.0, 1_000.0, 4_000.0, 10_000.0,
+        ] {
+            let pu = pu_encode(y);
+            let back = pu_decode(pu);
+            let rel_err = ((back - y) / y).abs();
+            assert!(
+                rel_err < 0.005,
+                "Round-trip Y = {y}: PU = {pu}, decoded = {back}, rel_err = {rel_err}"
+            );
+        }
+    }
+
+    #[test]
+    fn f32_path_matches_f64_reference() {
+        let grid: Vec<f32> = (0..1000)
+            .map(|i| {
+                let t = i as f32 / 999.0;
+                let log_min = PU_LUMINANCE_MIN_CD_M2.ln();
+                let log_max = PU_LUMINANCE_MAX_CD_M2.ln();
+                (log_min + (log_max - log_min) * t).exp()
+            })
+            .collect();
+        let mut max_err = 0.0_f32;
+        for &y in &grid {
+            let fast = pu_encode(y);
+            let slow = pu_encode_f64(y as f64) as f32;
+            let err = (fast - slow).abs();
+            if err > max_err {
+                max_err = err;
+            }
+        }
+        assert!(
+            max_err < 5e-3,
+            "f32 PU max error vs f64 = {max_err}, expected < 5e-3"
+        );
+    }
+
+    #[test]
+    fn luma_sets_sum_to_one() {
+        for (name, set) in [
+            ("BT2020_NCL", BT2020_NCL_LUMA),
+            ("BT709", BT709_LUMA),
+            ("BT601", BT601_LUMA),
+        ] {
+            let sum: f32 = set.iter().sum();
+            assert!(
+                (sum - 1.0).abs() < 1e-6,
+                "{name} luma coefficients sum to {sum}, expected 1.0"
+            );
+        }
+    }
+
+    #[test]
+    fn green_is_largest_in_every_luma_standard() {
+        for set in [BT2020_NCL_LUMA, BT709_LUMA, BT601_LUMA] {
+            assert!(set[1] > set[0] && set[1] > set[2]);
+        }
+    }
+}

--- a/zenpixels-convert/src/lib.rs
+++ b/zenpixels-convert/src/lib.rs
@@ -446,6 +446,11 @@ pub mod __bench_u16_hybrids {
 }
 pub mod gamut;
 pub mod hdr;
+/// HDR-IQA primitives (PU encoding, luma constants) for downstream
+/// quality metrics. `#[doc(hidden)]` — niche, experimental, see
+/// imazen/zenmetrics#13 for the cross-crate arc.
+#[doc(hidden)]
+pub mod hdr_iqa;
 pub mod icc_profiles;
 pub mod oklab;
 pub mod output;

--- a/zenpixels/src/cicp.rs
+++ b/zenpixels/src/cicp.rs
@@ -213,6 +213,86 @@ impl Cicp {
     }
 }
 
+impl Cicp {
+    /// Resolve unspecified (`matrix_coefficients == 2`) per ITU-T H.273.
+    ///
+    /// **`#[doc(hidden)]`**: HDR-IQA-specific niche surface — used by
+    /// downstream metric decode pipelines (zenmetrics) to disambiguate
+    /// CICP extracted from PNG cICP / AVIF nclx / JXL frame headers.
+    /// Not a general-purpose CICP API. See imazen/zenmetrics#13.
+    ///
+    /// When a container signals `MC=2`, the matrix is **not** derivable
+    /// from the primaries alone — H.273 explicitly forbids auto-deriving
+    /// BT.2020 NCL from `CP=9`, since that's a documented silent-failure
+    /// mode. The container or higher-level metadata must disambiguate.
+    ///
+    /// Behaviour:
+    /// - If `self.matrix_coefficients != 2`, returns `Ok(self)` unchanged.
+    /// - If `MC=2` and `container_hint` is `Some`, returns a copy with
+    ///   `matrix_coefficients` taken from the hint.
+    /// - If `MC=2` and `container_hint` is `None`, returns
+    ///   `Err(UnspecifiedMatrixError { primaries, transfer })` so the
+    ///   caller can decide whether to fall back, error, or warn.
+    ///
+    /// Consumers (decode pipelines that extract CICP from PNG cICP,
+    /// AVIF `nclx`, JXL frame headers) pass the codec's canonical
+    /// container default as the hint: AVIF's `nclx` defaults MC=9 when
+    /// CP=9, the JXL frame header carries an explicit matrix indication,
+    /// PNG cICP allows MC=0 only.
+    #[doc(hidden)]
+    pub const fn resolve_matrix(
+        self,
+        container_hint: Option<Cicp>,
+    ) -> Result<Cicp, UnspecifiedMatrixError> {
+        if self.matrix_coefficients != 2 {
+            return Ok(self);
+        }
+        match container_hint {
+            Some(hint) => Ok(Cicp {
+                color_primaries: self.color_primaries,
+                transfer_characteristics: self.transfer_characteristics,
+                matrix_coefficients: hint.matrix_coefficients,
+                full_range: self.full_range,
+            }),
+            None => Err(UnspecifiedMatrixError {
+                primaries: self.color_primaries,
+                transfer: self.transfer_characteristics,
+            }),
+        }
+    }
+}
+
+/// Error returned when [`Cicp::resolve_matrix`] cannot disambiguate
+/// `matrix_coefficients == 2` because no container hint was provided.
+///
+/// **`#[doc(hidden)]`**: niche surface alongside `Cicp::resolve_matrix`.
+///
+/// Per ITU-T H.273, the matrix is not derivable from primaries alone —
+/// callers must supply a hint, fall back to an explicit default, or
+/// surface the error so the codec layer can decide.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct UnspecifiedMatrixError {
+    /// CICP `color_primaries` code from the source CICP.
+    pub primaries: u8,
+    /// CICP `transfer_characteristics` code from the source CICP.
+    pub transfer: u8,
+}
+
+impl core::fmt::Display for UnspecifiedMatrixError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "CICP matrix_coefficients=2 (unspecified) with no container hint (primaries={}, transfer={})",
+            self.primaries, self.transfer,
+        )
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for UnspecifiedMatrixError {}
+
 impl core::fmt::Display for Cicp {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
@@ -389,6 +469,47 @@ mod tests {
         let desc = cicp.to_descriptor(PixelFormat::Rgb8);
         assert_eq!(desc.signal_range, SignalRange::Narrow);
         assert!(desc.alpha.is_none());
+    }
+
+    #[test]
+    fn resolve_matrix_passthrough_when_specified() {
+        // MC != 2 returns the input unchanged regardless of hint.
+        let c = Cicp::SRGB;
+        assert_eq!(c.resolve_matrix(None).unwrap(), c);
+        assert_eq!(c.resolve_matrix(Some(Cicp::BT2100_PQ)).unwrap(), c);
+    }
+
+    #[test]
+    fn resolve_matrix_uses_hint_for_unspecified() {
+        // MC=2 with a hint replaces the matrix from the hint.
+        let unspecified = Cicp::new(9, 16, 2, true);
+        let hint = Cicp::BT2100_PQ; // MC=9 (BT.2020 NCL)
+        let resolved = unspecified.resolve_matrix(Some(hint)).unwrap();
+        assert_eq!(resolved.color_primaries, 9);
+        assert_eq!(resolved.transfer_characteristics, 16);
+        assert_eq!(resolved.matrix_coefficients, 9);
+        assert!(resolved.full_range);
+    }
+
+    #[test]
+    fn resolve_matrix_errors_without_hint() {
+        // MC=2 with no hint must NOT silently derive — return the error.
+        let unspecified = Cicp::new(9, 16, 2, true);
+        let err = unspecified.resolve_matrix(None).unwrap_err();
+        assert_eq!(err.primaries, 9);
+        assert_eq!(err.transfer, 16);
+    }
+
+    #[test]
+    fn unspecified_matrix_error_display_includes_codes() {
+        let err = UnspecifiedMatrixError {
+            primaries: 9,
+            transfer: 16,
+        };
+        let s = format!("{err}");
+        assert!(s.contains("matrix_coefficients=2"));
+        assert!(s.contains("primaries=9"));
+        assert!(s.contains("transfer=16"));
     }
 
     #[test]

--- a/zenpixels/src/descriptor.rs
+++ b/zenpixels/src/descriptor.rs
@@ -329,6 +329,34 @@ impl TransferFunction {
             _ => 1.0,
         }
     }
+
+    /// Peak luminance in cd/m² that the transfer function's signal `1.0`
+    /// represents in absolute terms.
+    ///
+    /// **`#[doc(hidden)]`**: HDR-IQA-specific niche surface — used by
+    /// downstream quality metrics (zensim, zenmetrics, zenanalyze) via
+    /// `zenpixels_convert::hdr_iqa`. Not a general-purpose color-space
+    /// API. See imazen/zenmetrics#13 for the cross-crate arc.
+    ///
+    /// Used by HDR-IQA front-ends to convert linear `[0, 1]` signal to
+    /// absolute luminance before PU encoding:
+    /// `absolute_nits = linear * transfer.peak_luminance_nits()`.
+    ///
+    /// - SDR (sRGB, BT.709, Linear, Gamma22, Unknown): `1.0` (relative).
+    ///   Callers tracking SDR display peak should override.
+    /// - PQ: `10_000.0` (SMPTE ST 2084 peak).
+    /// - HLG: `1_000.0` (ITU-R BT.2100 reference HLG display peak).
+    ///   Real displays vary; callers that know the display peak should
+    ///   pass it through `HdrMetadata::peak_luminance_nits` instead.
+    #[doc(hidden)]
+    #[allow(unreachable_patterns)]
+    pub fn peak_luminance_nits(&self) -> f32 {
+        match self {
+            Self::Pq => 10_000.0,
+            Self::Hlg => 1_000.0,
+            _ => 1.0,
+        }
+    }
 }
 
 impl fmt::Display for TransferFunction {
@@ -1744,6 +1772,20 @@ mod tests {
         assert_eq!(TransferFunction::Srgb.reference_white_nits(), 1.0);
         assert_eq!(TransferFunction::Linear.reference_white_nits(), 1.0);
         assert_eq!(TransferFunction::Unknown.reference_white_nits(), 1.0);
+    }
+
+    #[test]
+    fn peak_luminance_nits_values() {
+        // PQ peak is the SMPTE ST 2084 spec maximum.
+        assert_eq!(TransferFunction::Pq.peak_luminance_nits(), 10_000.0);
+        // HLG reference display peak is BT.2100's nominal 1000 cd/m².
+        assert_eq!(TransferFunction::Hlg.peak_luminance_nits(), 1_000.0);
+        // SDR transfers report relative peak.
+        assert_eq!(TransferFunction::Srgb.peak_luminance_nits(), 1.0);
+        assert_eq!(TransferFunction::Bt709.peak_luminance_nits(), 1.0);
+        assert_eq!(TransferFunction::Linear.peak_luminance_nits(), 1.0);
+        assert_eq!(TransferFunction::Gamma22.peak_luminance_nits(), 1.0);
+        assert_eq!(TransferFunction::Unknown.peak_luminance_nits(), 1.0);
     }
 
     // --- PlaneLayout mask tests ---


### PR DESCRIPTION
Closes #34.

## Summary

Moves PU encoding + named luma constants into `zenpixels-convert::hdr_iqa` (was originally drafted for linear-srgb#26 — see closure note there), and tags every HDR-IQA-specific addition `#[doc(hidden)]` per the *\"niche enough to keep linear-srgb untouched, hidden surface in zenpixels\"* design.

## Three additions, all `#[doc(hidden)]`

### 1. `zenpixels-convert::hdr_iqa` (new module)

The cross-crate home for HDR-IQA primitives used by zensim, zenmetrics, zenanalyze, etc:

- `pu_encode(luminance_cd_m2: f32) -> f32` — Mantiuk PU21 banding-glare curve. Anchor identities verified by test (PU(203) ≈ 298.8, PU(10 000) ≈ 520.5, etc.).
- `pu_decode(pu: f32) -> f32` — closed-form inverse, ≤ 0.5 % round-trip across the valid range.
- `PU_PEAK`, `PU_REF_WHITE_BT2408`, `PU_LUMINANCE_MIN_CD_M2`, `PU_LUMINANCE_MAX_CD_M2` constants.
- `BT2020_NCL_LUMA`, `BT709_LUMA`, `BT601_LUMA` — `[f32; 3]` named luma constants.

### 2. `zenpixels::TransferFunction::peak_luminance_nits()` + `zenpixels_convert::HdrMetadata::peak_luminance_nits()`

- `TransferFunction`: PQ → 10 000, HLG → 1 000, SDR transfers → 1.0.
- `HdrMetadata`: resolves from `mastering_display.max_luminance` → `max_content_light_level` → `TransferFunction` default.

### 3. `zenpixels::Cicp::resolve_matrix(container_hint)` + `UnspecifiedMatrixError`

Handles MC=2 (unspecified) per ITU-T H.273. Returns `Err(UnspecifiedMatrixError)` rather than silently deriving BT.2020 NCL from CP=9 — that's the documented silent-failure mode.

## Why `zenpixels-convert::hdr_iqa` and not `linear-srgb`

PU encoding is HDR-IQA-specific (not a general color-conversion primitive that round-trips through normal pixel pipelines). linear-srgb is the foundational transfer-function crate broadly used across imageflow / zen / external; keeping it free of niche HDR-IQA API preserves its general-purpose scope. zenpixels-convert is the higher-level conversion layer where perceptual converters naturally live.

## Why `#[doc(hidden)]` and not `pub(crate)`

Downstream metric crates (zensim, zenmetrics, zenanalyze) need to import these from outside this workspace, so `pub(crate)` isn't enough. `#[doc(hidden)]` keeps the items out of docs.rs (signaling \"experimental / niche\") while letting external consumers reach them.

## Test plan

- [x] `cargo test --workspace` — all 521+ tests pass (271 zenpixels + 255 zenpixels-convert + sub-crate tests). 9 new hdr_iqa tests, 5 new peak_luminance_nits tests, 4 new resolve_matrix tests, 4 new HdrMetadata peak resolution tests.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (module-level `#[allow(clippy::excessive_precision)]` on `hdr_iqa.rs` for the published PU21 coefficients, matching linear-srgb's tf-module precedent).
- [x] `cargo fmt --check` — clean.

## Cross-references

- imazen/linear-srgb#25 / #26 — closed; the PU encoding moved here.
- imazen/zenmetrics#13 — consumer (uses `hdr_iqa::pu_encode` + `Cicp::resolve_matrix` + `HdrMetadata::peak_luminance_nits`).
- imazen/zensim#38 / #39 — consumer (will import `zenpixels_convert::hdr_iqa::pu_encode` for the PQ/HLG XYB front-end once trained HDR bake lands).