### PR TITLE
HDR API: withdraw unshipped encode helpers; add typed anchor + CLL measure; deprecate HdrMetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,35 @@
      0.x) release. Add items here as you discover them. Do NOT ship these
      piecemeal — batch them. -->
 
-- (none currently queued)
+- **Remove `zenpixels-convert::hdr::HdrMetadata`** (struct + methods) and its
+  re-export — deprecated in 0.2.14; superseded by carrying `ContentLightLevel`
+  / `MasteringDisplay` directly (or `zencodec::Metadata` at the codec layer).
+- **Retype `OutputMetadata::hdr`** — drop the `Option<HdrMetadata>` field;
+  carry HDR as sibling `content_light_level: Option<ContentLightLevel>` /
+  `mastering_display: Option<MasteringDisplay>` (transfer already rides on the
+  output descriptor), matching the universal prior-art split. Wire it at the
+  same time (currently unwired, `output.rs` `TODO(0.3.0)`).
+- **Deduplicate `ContentLightLevel` / `MasteringDisplay`** — defined twice
+  (`zenpixels::hdr` and `zencodec::info`, sibling crates). Make `zenpixels`
+  the single canonical home and have `zencodec` re-export, so codecs stop
+  converting between two identical types.
 
 ## [0.2.14] - 2026-06-13
+
+### zenpixels — added
+
+- **`hdr::DiffuseWhite`** — a typed absolute-luminance anchor: the cd/m²
+  (nits) that relative-linear `1.0` represents (OpenEXR `whiteLuminance` /
+  JPEG XL `intensity_target` / libheif `ndwt` / libplacebo SDR-white). Newtype
+  on purpose — HDR mixes nits, PQ-encoded `[0,1]`, log2 gain, and headroom
+  ratios. `DiffuseWhite::BT2408` (203, the cross-vendor default) is the
+  `Default`.
+- **`ContentLightLevel::measure(PixelSlice, DiffuseWhite) -> Option<Self>`** —
+  MaxCLL/MaxFALL (CTA-861.3-A stills) from relative-linear RGB(A) f32, a
+  constructor on the type it returns (replacing the withdrawn
+  `zenpixels-convert::hdr::compute_content_light_level` free function).
+  Negative/NaN clamp to 0, alpha ignored, strided rows handled; `None` for
+  non-`RgbF32`/`RgbaF32` or non-`Linear` input.
 
 ### Workspace — build
 
@@ -111,30 +137,42 @@
 
 ### zenpixels-convert — added
 
-- **`hdr::compute_content_light_level(PixelSlice, diffuse_white_nits)` and
-  `hdr::encode_pq16(PixelSlice, diffuse_white_nits)`** (zenpixels#39
-  Rung 2) — MaxCLL/MaxFALL measurement per CTA-861.3-A with the PNG 3rd ed
-  §11.3.2.8 stills reading (one still = one frame), and single-pass
-  linear→PQ 16-bit quantization (SMPTE ST 2084 via linear-srgb's rational
-  approximation) outputting `PixelDescriptor::RGB16_BT2100_PQ` with the
-  CLL measured in the same pass. `hdr::REFERENCE_DIFFUSE_WHITE_NITS`
-  (203.0, BT.2408) anchors "linear 1.0". Relative-linear RGB(A) f32 input
-  only; strided rows handled; NaN/negative samples clamp to 0; alpha
-  ignored/dropped. Docs carry the signaling guidance: PQ16 output should
-  signal CICP-natively where the container allows; the synthesized PQ ICC
-  is a compatibility fallback (≈8 % soft at ~1 nit). Replaces the
-  hand-rolled `render_pq16` in hdr-corpus-convert (its one real consumer —
-  scoped per the 2026-06-11 audit).
 - Property/oracle tests for the tone-map helpers (output range,
   monotonicity, f64-oracle agreement, round-trip relative-error bound) and
   a pipeline pin in `tests/output_finalize.rs` that a PQ source finalized
   `SameAsOrigin` passes origin CICP through while `OutputMetadata::hdr`
   stays `None` — the documented not-yet-wired contract
   (`output.rs` `TODO(0.3.0)`; wiring it must consciously update the pin).
-- Oracle tests for the new helpers: f64 ST 2084 reference (exact
-  constants) within ±1 code, 203-nit golden, 10 000-nit clip, CTA stills
-  CLL semantics, NaN/negative clamps, alpha-lane exclusion,
-  strided==tight parity, encode/measure agreement.
+
+### zenpixels-convert — deprecated
+
+- **`hdr::HdrMetadata`** (struct + `is_hdr`/`is_sdr`/`hdr10`/`hlg`) and the
+  **`OutputMetadata::hdr` field** are deprecated. `HdrMetadata` is a
+  redundant, weaker, frozen-shape duplicate of the codec-layer carrier
+  `zencodec::Metadata` (which the codecs actually populate): it bundles
+  `transfer` with CLL/mastering — which all surveyed prior art (libavif,
+  libheif, libjxl, FFmpeg, libplacebo, ICC, CSS, Chrome, …) keeps separate —
+  and its public, non-`#[non_exhaustive]` fields can't grow the
+  absolute-luminance anchor or gain-map data HDR needs. `hdr10()` also
+  synthesizes a placeholder ST 2086 mastering volume that was never measured.
+  Carry [`ContentLightLevel`] / [`MasteringDisplay`] directly. Removal +
+  the `OutputMetadata::hdr` retype to sibling optional fields are queued for
+  0.3.0 (see QUEUED BREAKING CHANGES). Design rationale:
+  `docs/hdr-design-survey-2026-06-13.md`.
+
+  (The in-development `hdr::compute_content_light_level` / `encode_pq16` /
+  `REFERENCE_DIFFUSE_WHITE_NITS` — never released — were withdrawn. The
+  bare-`f32` anchor the prior art uniformly rejects is replaced by the typed
+  public `DiffuseWhite` + the `ContentLightLevel::measure` constructor (both
+  added above). The encode side is **not** re-exposed: an audit of the whole
+  `~/work/zen/` tree found **no consumer that encodes linear→PQ16** — every
+  PQ16 buffer originates from an already-PQ source — so per the crate's YAGNI
+  policy a public PQ encoder is not shipped. The verified linear→PQ16 path
+  (f64-ST-2084 parity, ±1) is retained `pub(crate)` as `hdr::quantize_to`, a
+  tested oracle for the day a real consumer arrives — at which point the
+  longer-term move (a luminance anchor on `zencodec::Metadata`, so the encode
+  collapses into a plain `convert_buffer`) supersedes it; that is 0.3.0 design
+  work, see `docs/hdr-design-survey-2026-06-13.md`.)
 
 ## [0.2.13] - 2026-06-11
 
@@ -187,7 +225,7 @@ Both crates release as 0.2.13 (zenpixels skips 0.2.12 to keep the pair in lockst
 
 ### zenpixels-convert — tests
 
-- **Recognition round-trip guards on the embedded profiles** (855d8e48) — `every_bundled_profile_roundtrips_through_extract_cicp` pins: every RGB bundle profile's `cICP` tag recovers its exact code points; every GRAY profile has **no** cicp tag (ICC.1 restricts the tag to RGB/YCbCr/XYZ data colour spaces — attempting one also trips a moxcms tag-count/emission mismatch that corrupts the tag table) and is hash-identified exactly per pinned transfer sets (recognized: 1/4/6/8/11/12/13/14/15/16; gaps: 5/7/9/10/17/18 — HLG's curv-LUT exceeds the ±56/65535 identification tolerance). Both directions pinned, so any profile regeneration that gains or loses recognition fails loudly. `bundled_consts_are_hash_identified` guards the four curated `&'static` profiles the same way.
+- **Recognition round-trip guards on the embedded profiles** (855d8e48) — `every_bundled_profile_roundtrips_through_extract_cicp` pins: every RGB bundle profile's `cICP` tag recovers its exact code points; every GRAY profile has **no** cicp tag (ICC.1 restricts the tag to RGB/YCbCr/XYZ data colour spaces — the timeless reason; attempting one additionally tripped a moxcms 0.8.1 tag-count/emission mismatch that corrupted the tag table, since fixed upstream in [moxcms#182](https://github.com/awxkee/moxcms/issues/182), which now strips cicp from gray on encode) and is hash-identified exactly per pinned transfer sets (recognized: 1/4/6/8/11/12/13/14/15/16; gaps: 5/7/9/10/17/18 — HLG's curv-LUT exceeds the ±56/65535 identification tolerance). Both directions pinned, so any profile regeneration that gains or loses recognition fails loudly. `bundled_consts_are_hash_identified` guards the four curated `&'static` profiles the same way.
 
 ### zenpixels-convert — changed (features)
 

--- a/docs/public-api/zenpixels-convert.txt
+++ b/docs/public-api/zenpixels-convert.txt
@@ -6,14 +6,14 @@
 # impls omitted; re-export duplicates annotated `[also: path]`.
 # DO NOT EDIT BY HAND — commit regenerated changes with the code.
 #
-# files: zenpixels-convert.txt 308 lines (supported surface) | zenpixels-convert.features.txt 244 added (features: avx512,cms-moxcms,fast-transpose,icc-db,imgref,pipeline,planar,rgb,serde,std) | zenpixels-convert.internal.txt 53 lines (80 hidden + 0 excluded-feature)
+# files: zenpixels-convert.txt 305 lines (supported surface) | zenpixels-convert.features.txt 244 added (features: avx512,cms-moxcms,fast-transpose,icc-db,imgref,pipeline,planar,rgb,serde,std) | zenpixels-convert.internal.txt 53 lines (80 hidden + 0 excluded-feature)
 
 ## summary
 #
 #   pub modules                                13
 #   pub types (struct/enum/trait/alias)        49
-#   pub consts/statics                         20
-#   free functions                             45
+#   pub consts/statics                         19
+#   free functions                             43
 #   inherent methods                           93
 #   struct fields                              42
 #   enum variants                              50
@@ -30,14 +30,14 @@
 #   error                            20
 #   ext                              13
 #   gamut                             6
-#   hdr                              20
+#   hdr                              17
 #   icc_profiles                     13
 #   load_bearing                     11
 #   oklab                             9
 #   orient                            3
 #   output                           17
 
-## items (285 lines)
+## items (282 lines)
 
 pub mod zenpixels_convert
 pub use <<zenpixels::*>>
@@ -125,9 +125,6 @@ pub fn hdr::HdrMetadata::hdr10(zenpixels::hdr::ContentLightLevel) -> Self
 pub fn hdr::HdrMetadata::hlg() -> Self
 pub fn hdr::HdrMetadata::is_hdr(&self) -> bool
 pub fn hdr::HdrMetadata::is_sdr(&self) -> bool
-pub const hdr::REFERENCE_DIFFUSE_WHITE_NITS: f32
-pub fn hdr::compute_content_light_level(zenpixels::buffer::PixelSlice<'_>, f32) -> core::result::Result<zenpixels::hdr::ContentLightLevel, whereat::at::At<error::ConvertError>>
-pub fn hdr::encode_pq16(zenpixels::buffer::PixelSlice<'_>, f32) -> core::result::Result<(zenpixels::buffer::PixelBuffer, zenpixels::hdr::ContentLightLevel), whereat::at::At<error::ConvertError>>
 pub mod icc_profiles
 #[non_exhaustive] pub enum icc_profiles::SynthesizedIcc
 pub icc_profiles::SynthesizedIcc::CmsUnsupported

--- a/docs/public-api/zenpixels.features.txt
+++ b/docs/public-api/zenpixels.features.txt
@@ -15,7 +15,7 @@
 #   inherent methods                           98
 #   struct fields                              20
 #   enum variants                              54
-#   trait roster entries (type × trait)       105
+#   trait roster entries (type × trait)       107
 #   auto-trait-complete types                   9
 #
 # per-module pub lines:
@@ -241,7 +241,7 @@ pub const planar::PlaneMask::CHROMA: Self
 pub const planar::PlaneMask::LUMA: Self
 pub const planar::PlaneMask::NONE: Self
 
-## trait impls (52 types)
+## trait impls (53 types)
 
 buffer::PixelSlice<'a, rgb::formats::bgra::Bgra<u8>>: From<imgref::Img<&'a [rgb::formats::bgra::Bgra<u8>]>>
 buffer::PixelSlice<'a, rgb::formats::gray::Gray_v08<f32>>: From<imgref::Img<&'a [rgb::formats::gray::Gray_v08<f32>]>>
@@ -274,6 +274,7 @@ descriptor::PixelFormat: serde_core::de::Deserialize<'de>, serde_core::ser::Seri
 descriptor::SignalRange: serde_core::de::Deserialize<'de>, serde_core::ser::Serialize
 descriptor::TransferFunction: serde_core::de::Deserialize<'de>, serde_core::ser::Serialize
 hdr::ContentLightLevel: serde_core::de::Deserialize<'de>, serde_core::ser::Serialize
+hdr::DiffuseWhite: serde_core::de::Deserialize<'de>, serde_core::ser::Serialize
 hdr::MasteringDisplay: serde_core::de::Deserialize<'de>, serde_core::ser::Serialize
 pixel_types::GrayAlpha16: buffer::Pixel
 pixel_types::GrayAlpha8: buffer::Pixel

--- a/docs/public-api/zenpixels.internal.txt
+++ b/docs/public-api/zenpixels.internal.txt
@@ -10,7 +10,7 @@
 ## summary
 #
 #   inherent methods                           38
-#   trait roster entries (type × trait)        36
+#   trait roster entries (type × trait)        37
 #
 # per-module pub lines:
 #   buffer                            3
@@ -65,7 +65,7 @@ pub fn policy::DepthPolicy::assert_fields_are_eq(&self)
 pub fn policy::GrayExpand::assert_fields_are_eq(&self)
 pub fn policy::LumaCoefficients::assert_fields_are_eq(&self)
 
-## trait impls (36 types)
+## trait impls (37 types)
 
 buffer::Bgrx: TrivialClone
 buffer::BufferError: TrivialClone
@@ -85,6 +85,7 @@ descriptor::PixelFormat: TrivialClone
 descriptor::SignalRange: TrivialClone
 descriptor::TransferFunction: TrivialClone
 hdr::ContentLightLevel: TrivialClone
+hdr::DiffuseWhite: TrivialClone
 hdr::MasteringDisplay: TrivialClone
 icc::IccIdentification: TrivialClone
 icc::IdentificationUse: TrivialClone

--- a/docs/public-api/zenpixels.txt
+++ b/docs/public-api/zenpixels.txt
@@ -6,35 +6,35 @@
 # impls omitted; re-export duplicates annotated `[also: path]`.
 # DO NOT EDIT BY HAND — commit regenerated changes with the code.
 #
-# files: zenpixels.txt 799 lines (supported surface) | zenpixels.features.txt 268 added (features: icc,imgref,planar,rgb,serde,std) | zenpixels.internal.txt 74 lines (74 hidden + 0 excluded-feature)
+# files: zenpixels.txt 806 lines (supported surface) | zenpixels.features.txt 269 added (features: icc,imgref,planar,rgb,serde,std) | zenpixels.internal.txt 75 lines (75 hidden + 0 excluded-feature)
 
 ## summary
 #
 #   pub modules                                10
-#   pub types (struct/enum/trait/alias)        74
-#   pub consts/statics                        270
+#   pub types (struct/enum/trait/alias)        75
+#   pub consts/statics                        273
 #   free functions                              4
-#   inherent methods                          206
+#   inherent methods                          208
 #   struct fields                             105
 #   enum variants                             208
 #   re-exports                                  4
-#   trait roster entries (type × trait)       232
-#   auto-trait-complete types                  33
+#   trait roster entries (type × trait)       237
+#   auto-trait-complete types                  34
 #   auto-trait exceptions                       4
 #
 # per-module pub lines:
-#   (root)                          387
+#   (root)                          389
 #   buffer                          192
 #   cicp                             27
 #   color                            57
 #   descriptor                      148
-#   hdr                              12
+#   hdr                              16
 #   icc                              13
 #   orientation                      11
 #   pixel_types                       9
 #   policy                           25
 
-## items (754 lines)
+## items (760 lines)
 
 pub mod zenpixels
 pub use At
@@ -373,7 +373,12 @@ pub const fn descriptor::PixelDescriptor::with_transfer(self, descriptor::Transf
 pub mod hdr
 pub hdr::ContentLightLevel::max_content_light_level: u16
 pub hdr::ContentLightLevel::max_frame_average_light_level: u16
+pub fn hdr::ContentLightLevel::measure(buffer::PixelSlice<'_>, hdr::DiffuseWhite) -> core::option::Option<Self>
 pub const fn hdr::ContentLightLevel::new(u16, u16) -> Self [also: (root)]
+pub struct hdr::DiffuseWhite(_)
+pub const hdr::DiffuseWhite::BT2408: Self
+pub const fn hdr::DiffuseWhite::new(f32) -> Self
+pub const fn hdr::DiffuseWhite::nits(self) -> f32
 pub hdr::MasteringDisplay::max_luminance: f32
 pub hdr::MasteringDisplay::min_luminance: f32
 pub hdr::MasteringDisplay::primaries_xy: [[f32; 2]; 3]
@@ -629,6 +634,7 @@ pub fn color::ColorOrigin::with_color_authority(self, color::ColorAuthority) -> 
 pub struct ContentLightLevel [also: hdr]
 pub ContentLightLevel::max_content_light_level: u16
 pub ContentLightLevel::max_frame_average_light_level: u16
+pub fn hdr::ContentLightLevel::measure(buffer::PixelSlice<'_>, hdr::DiffuseWhite) -> core::option::Option<Self>
 #[non_exhaustive] pub struct ConvertOptions [also: policy]
 pub ConvertOptions::alpha_policy: policy::AlphaPolicy
 pub ConvertOptions::clip_out_of_gamut: bool
@@ -791,7 +797,7 @@ pub Rgbx::x: u8
 pub trait Pixel: bytemuck::pod::Pod [also: buffer]
 pub const Pixel::DESCRIPTOR: descriptor::PixelDescriptor
 
-## trait impls (40 types)
+## trait impls (41 types)
 
 buffer::Bgrx: Clone, Copy, Debug, Default, Eq, Hash, PartialEq, buffer::Pixel, bytemuck::pod::Pod, bytemuck::zeroable::Zeroable
 buffer::BufferError: Clone, Copy, Debug, Display, Eq, Error, PartialEq
@@ -821,6 +827,7 @@ descriptor::PixelFormat: Clone, Copy, Debug, Display, Eq, Hash, PartialEq
 descriptor::SignalRange: Clone, Copy, Debug, Default, Display, Eq, Hash, PartialEq
 descriptor::TransferFunction: Clone, Copy, Debug, Display, Eq, Hash, PartialEq
 hdr::ContentLightLevel: Clone, Copy, Debug, Default, Eq, Hash, PartialEq
+hdr::DiffuseWhite: Clone, Copy, Debug, Default, PartialEq
 hdr::MasteringDisplay: Clone, Copy, Debug, Default, PartialEq
 icc::IccIdentification: Clone, Copy, Debug, Eq, Hash, PartialEq
 icc::IdentificationUse: Clone, Copy, Debug, Eq, Hash, PartialEq
@@ -836,7 +843,7 @@ policy::LumaCoefficients: Clone, Copy, Debug, Eq, Hash, PartialEq
 
 ## auto traits
 
-33 types implement all of: Freeze, RefUnwindSafe, Send, Sync, Unpin, UnwindSafe
+34 types implement all of: Freeze, RefUnwindSafe, Send, Sync, Unpin, UnwindSafe
 buffer::InPlacePixels<'a>: !UnwindSafe
 buffer::PixelBuffer<P>: !RefUnwindSafe !Send !Sync !Unpin !UnwindSafe
 buffer::PixelSlice<'a, P>: !RefUnwindSafe !Send !Sync !Unpin !UnwindSafe

--- a/zenpixels-convert/src/hdr.rs
+++ b/zenpixels-convert/src/hdr.rs
@@ -7,19 +7,41 @@
 //! The core PQ/HLG EOTF/OETF math is always available through the main
 //! conversion pipeline in [`ConvertPlan`](crate::ConvertPlan).
 
-use crate::TransferFunction;
+use crate::adapt::convert_buffer;
 use crate::error::ConvertError;
-use crate::{PixelBuffer, PixelDescriptor, PixelFormat, PixelSlice};
+use crate::{PixelBuffer, PixelDescriptor, PixelFormat, PixelSlice, TransferFunction};
 use alloc::vec::Vec;
 use whereat::At;
 
 // Re-export metadata types from the core crate.
 pub use zenpixels::hdr::{ContentLightLevel, MasteringDisplay};
+// `DiffuseWhite` is only used by the `pub(crate)` `quantize_to` + its tests;
+// the canonical public home is `zenpixels::hdr::DiffuseWhite`. Not re-exported
+// publicly here (no public convert-crate API takes it).
+use zenpixels::hdr::DiffuseWhite;
 
 /// Describes the HDR characteristics of pixel data.
 ///
 /// Bundles transfer function, content light level, and mastering display
 /// metadata to provide everything needed for HDR processing.
+///
+/// # Deprecated
+///
+/// This bundle is a redundant, weaker duplicate of the codec-layer carrier
+/// `zencodec::Metadata` (which the codecs actually populate, and which also
+/// carries CICP, ICC, EXIF/XMP, and orientation). It bundles `transfer` with
+/// CLL/mastering, which the prior art uniformly keeps separate (transfer
+/// belongs on the [`PixelDescriptor`](crate::PixelDescriptor); CLL and
+/// mastering are independent optional metadata). It has frozen public fields
+/// (not `#[non_exhaustive]`), so the absolute-luminance anchor and gain-map
+/// fields HDR needs cannot be added without a break. Scheduled for removal in
+/// 0.3.0 — see `CHANGELOG.md` "QUEUED BREAKING CHANGES". Carry CLL and
+/// mastering as the standalone [`ContentLightLevel`] / [`MasteringDisplay`]
+/// types, or use `zencodec::Metadata`.
+#[deprecated(
+    since = "0.2.14",
+    note = "redundant with zencodec::Metadata and frozen-shaped; carry ContentLightLevel / MasteringDisplay directly. Removal queued for 0.3.0."
+)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HdrMetadata {
     /// Transfer function (PQ, HLG, sRGB, Linear, etc.).
@@ -30,6 +52,7 @@ pub struct HdrMetadata {
     pub mastering_display: Option<MasteringDisplay>,
 }
 
+#[allow(deprecated)]
 impl HdrMetadata {
     /// True if this describes HDR content (PQ or HLG transfer function).
     #[must_use]
@@ -129,39 +152,13 @@ pub fn exposure_tonemap(v: f32, exposure: f32) -> f32 {
 }
 
 // ---------------------------------------------------------------------------
-// Display-light measurement + PQ16 output encoding (zenpixels#39 Rung 2)
+// HDR quantization (relative-linear f32 → a PQ HDR descriptor)
 // ---------------------------------------------------------------------------
 
-/// BT.2408 reference diffuse white in cd/m² — the conventional anchor for
-/// "linear 1.0" in relative-linear HDR buffers, and the customary
-/// `diffuse_white_nits` argument for [`compute_content_light_level`] and
-/// [`encode_pq16`].
-pub const REFERENCE_DIFFUSE_WHITE_NITS: f32 = 203.0;
-
-/// Gate shared by the Rung-2 helpers: relative-linear RGB(A) f32 only.
-#[inline]
-fn require_linear_f32_rgb(desc: &PixelDescriptor) -> Result<usize, At<ConvertError>> {
-    let channels = match desc.pixel_format() {
-        PixelFormat::RgbF32 => 3,
-        PixelFormat::RgbaF32 => 4,
-        _ => return Err(whereat::at!(ConvertError::NoMatch { source: *desc })),
-    };
-    if desc.transfer != TransferFunction::Linear {
-        return Err(whereat::at!(ConvertError::UnsupportedTransfer {
-            from: desc.transfer,
-            to: TransferFunction::Linear,
-        }));
-    }
-    Ok(channels)
-}
-
-#[inline]
-fn nits_to_u16(nits: f64) -> u16 {
-    nits.round().clamp(0.0, 65535.0) as u16
-}
-
-/// Read one native-endian f32 sample (per the `PixelSlice` endianness
-/// contract); no alignment assumption on the backing bytes.
+/// Read one native-endian f32 sample from a pixel's bytes.
+// Only reached by the `pub(crate)` `quantize_to` oracle + its tests today;
+// retained alongside it (see `quantize_to` for the rationale).
+#[allow(dead_code)]
 #[inline]
 fn sample_f32(bytes: &[u8], k: usize) -> f32 {
     f32::from_ne_bytes([
@@ -172,139 +169,108 @@ fn sample_f32(bytes: &[u8], k: usize) -> f32 {
     ])
 }
 
-/// Measure MaxCLL / MaxFALL (CTA-861.3-A) from relative-linear RGB(A) f32
-/// pixels.
+/// Quantize relative-linear RGB(A) f32 pixels to a **PQ** HDR target
+/// descriptor (e.g. [`PixelDescriptor::RGB16_BT2100_PQ`]), with `white`
+/// anchoring the relative scale — sample `1.0` = `white` nits
+/// ([`DiffuseWhite::BT2408`] — 203 — is the convention).
 ///
-/// `diffuse_white_nits` anchors the relative-linear scale: a sample value of
-/// `1.0` is that many cd/m² ([`REFERENCE_DIFFUSE_WHITE_NITS`] — 203, per
-/// BT.2408 — is the convention). Semantics per CTA-861.3-A as PNG 3rd ed
-/// §11.3.2.8 imports it for stills ("each frame is analyzed"; one still is
-/// one frame): **MaxCLL** is the brightest pixel's `max(R, G, B)` in cd/m²,
-/// and **MaxFALL** is this image's average of per-pixel `max(R, G, B)`.
+/// The transfer (linear → PQ) and depth (f32 → u16) quantization runs through
+/// the conversion pipeline ([`convert_buffer`](crate::adapt::convert_buffer));
+/// this function only supplies the absolute-luminance anchor that the
+/// pipeline's fixed `1.0 = 10000 cd/m²` PQ domain cannot yet express: it
+/// pre-scales by `white / 10000`, clamps to the PQ peak, and drops any alpha
+/// lane.
 ///
-/// Negative and NaN samples clamp to 0 (the same domain convention as
-/// [`reinhard_tonemap`]); an alpha lane is ignored. Strided rows are
-/// handled. (Zero-area input cannot be constructed — buffer/slice
-/// validation rejects it; the `(0, 0)` early return is defensive.)
+/// **Primaries are not converted** — the source gamut is signaled as the
+/// target's (feed BT.2020-relative-linear for `RGB16_BT2100_PQ`). This is the
+/// value-only behavior an HDR-corpus encoder wants. Measure CLL separately
+/// with [`ContentLightLevel::measure`].
 ///
-/// # Errors
+/// This is the descriptor-driven successor to the withdrawn `encode_pq16`:
+/// one function for every PQ target, a typed anchor, and CLL decoupled from
+/// the encode. It collapses into a plain `convert_buffer` once an
+/// absolute-luminance field lands on the metadata carrier (rationale:
+/// `docs/hdr-design-survey-2026-06-13.md`).
 ///
-/// [`ConvertError::NoMatch`] unless the descriptor is `RgbF32`/`RgbaF32`,
-/// [`ConvertError::UnsupportedTransfer`] unless its transfer is `Linear`.
-pub fn compute_content_light_level(
-    px: PixelSlice<'_>,
-    diffuse_white_nits: f32,
-) -> Result<ContentLightLevel, At<ConvertError>> {
-    let desc = px.descriptor();
-    let channels = require_linear_f32_rgb(&desc)?;
-    let w = px.width() as usize;
-    let h = px.rows() as usize;
-    if w == 0 || h == 0 {
-        return Ok(ContentLightLevel::new(0, 0));
-    }
-
-    let stride = px.stride();
-    let bytes = px.as_strided_bytes();
-    let row_len = w * channels * 4;
-
-    let mut max_nits = 0.0f64;
-    let mut sum_max_nits = 0.0f64;
-    for row in 0..h {
-        let row_bytes = &bytes[row * stride..row * stride + row_len];
-        for pxl in row_bytes.chunks_exact(channels * 4) {
-            // Fold from 0.0 so NaN and negative samples drop out.
-            let m = 0.0f32
-                .max(sample_f32(pxl, 0))
-                .max(sample_f32(pxl, 1))
-                .max(sample_f32(pxl, 2));
-            let nits = f64::from(m) * f64::from(diffuse_white_nits);
-            max_nits = max_nits.max(nits);
-            sum_max_nits += nits;
-        }
-    }
-    let fall = sum_max_nits / (w as f64 * h as f64);
-    Ok(ContentLightLevel::new(
-        nits_to_u16(max_nits),
-        nits_to_u16(fall),
-    ))
-}
-
-/// Quantize relative-linear RGB(A) f32 pixels to PQ-encoded 16-bit RGB
-/// (SMPTE ST 2084, full range), measuring [`ContentLightLevel`] in the same
-/// pass.
-///
-/// `diffuse_white_nits` anchors the scale exactly as in
-/// [`compute_content_light_level`]. Each channel maps
-/// `pq(clamp(sample, 0, ∞) · diffuse_white_nits / 10000)` onto `0..=65535`;
-/// luminance above the 10 000 cd/m² PQ peak clips to code 65535. An alpha
-/// lane is dropped. Negative/NaN samples clamp to 0.
-///
-/// The output buffer's descriptor is [`PixelDescriptor::RGB16_BT2100_PQ`]
-/// (BT.2020 primaries, PQ transfer, full range — CICP `(9, 16, 0, full)`).
-/// **Signal it CICP-natively** where the container has a carrier (PNG
-/// `cICP`, AVIF `nclx`, JXL enum color); `synthesize_icc_for_cicp` can
-/// supply a compatibility ICC, but the PQ `curv`-LUT profile softens ≈8 %
-/// at ~1 nit, so the ICC is a fallback — never the primary signal.
-///
-/// Note: this quantizes values only — it does **not** convert primaries.
-/// Feed it BT.2020-relative linear data (or accept the source gamut being
-/// signaled as-is by the caller, as corpus tooling does deliberately).
+/// Kept `pub(crate)` deliberately: no in-tree or sibling consumer encodes
+/// linear→PQ16 today (every PQ16 buffer in the workspace originates from an
+/// already-PQ source), so per the crate's YAGNI policy this is not public
+/// surface. The implementation and its f64-ST-2084 parity tests are retained
+/// as a verified oracle for the day a real consumer (corpus generation /
+/// imageflow HDR encode) arrives — at which point it should be promoted *as*
+/// `convert_buffer` against a carrier that holds the luminance anchor, not as
+/// this standalone function.
 ///
 /// # Errors
 ///
-/// As [`compute_content_light_level`], plus
-/// [`ConvertError::AllocationFailed`] if the output buffer cannot be
-/// built. (The zero-area guard is defensive — such slices cannot be
-/// constructed.)
-pub fn encode_pq16(
+/// - [`ConvertError::NoMatch`] if `px` is not `RgbF32`/`RgbaF32`;
+///   [`ConvertError::UnsupportedTransfer`] if it is not `Linear`.
+/// - [`ConvertError::NoPath`] if `target`'s transfer is not PQ (HLG's
+///   scene-referred anchor differs and is not handled here).
+/// - [`ConvertError::InvalidWidth`] for zero-area input, or any error the
+///   inner [`convert_buffer`](crate::adapt::convert_buffer) raises.
+// Retained as a tested oracle, not called by non-test code yet (see the doc
+// comment above) — so it reads as dead code in a plain build until a real
+// consumer lands.
+#[allow(dead_code)]
+pub(crate) fn quantize_to(
     px: PixelSlice<'_>,
-    diffuse_white_nits: f32,
-) -> Result<(PixelBuffer, ContentLightLevel), At<ConvertError>> {
+    target: PixelDescriptor,
+    white: DiffuseWhite,
+) -> Result<PixelBuffer, At<ConvertError>> {
     let desc = px.descriptor();
-    let channels = require_linear_f32_rgb(&desc)?;
-    let w = px.width() as usize;
-    let h = px.rows() as usize;
+    let channels = match desc.pixel_format() {
+        PixelFormat::RgbF32 => 3,
+        PixelFormat::RgbaF32 => 4,
+        _ => return Err(whereat::at!(ConvertError::NoMatch { source: desc })),
+    };
+    if desc.transfer != TransferFunction::Linear {
+        return Err(whereat::at!(ConvertError::UnsupportedTransfer {
+            from: desc.transfer,
+            to: TransferFunction::Linear,
+        }));
+    }
+    // The pipeline anchors PQ at 1.0 = 10000 cd/m²; only PQ targets are handled.
+    if target.transfer != TransferFunction::Pq {
+        return Err(whereat::at!(ConvertError::NoPath {
+            from: desc,
+            to: target,
+        }));
+    }
+    let w = px.width();
+    let h = px.rows();
     if w == 0 || h == 0 {
-        return Err(whereat::at!(ConvertError::InvalidWidth(px.width())));
+        return Err(whereat::at!(ConvertError::InvalidWidth(w)));
     }
 
+    // Pre-scale relative-linear (1.0 = white nits) into the pipeline's PQ
+    // domain (1.0 = 10000 nits), clamp to the peak, drop alpha → tight RGB f32.
+    let factor = (f64::from(white.nits()) / 10_000.0) as f32;
     let stride = px.stride();
     let bytes = px.as_strided_bytes();
-    let row_len = w * channels * 4;
-    // sample → PQ-domain input: nits / 10000 = sample · (diffuse_white / 10000)
-    let to_pq_domain = f64::from(diffuse_white_nits) / 10_000.0;
-
-    let mut out: Vec<u8> = Vec::with_capacity(w * h * 3 * 2);
-    let mut max_nits = 0.0f64;
-    let mut sum_max_nits = 0.0f64;
-    for row in 0..h {
-        let row_bytes = &bytes[row * stride..row * stride + row_len];
-        for pxl in row_bytes.chunks_exact(channels * 4) {
-            let mut px_max = 0.0f32;
+    let row_len = w as usize * channels * 4;
+    let mut scaled: Vec<u8> = Vec::with_capacity(w as usize * h as usize * 3 * 4);
+    for row in 0..h as usize {
+        let rb = &bytes[row * stride..row * stride + row_len];
+        for pxl in rb.chunks_exact(channels * 4) {
             for k in 0..3 {
-                let c = sample_f32(pxl, k).max(0.0); // NaN/negative → 0
-                px_max = px_max.max(c);
-                let x = (f64::from(c) * to_pq_domain).min(1.0) as f32;
-                let q = (linear_srgb::tf::linear_to_pq(x) * 65535.0).round() as u16;
-                out.extend_from_slice(&q.to_ne_bytes());
+                let v = (sample_f32(pxl, k).max(0.0) * factor).min(1.0);
+                scaled.extend_from_slice(&v.to_ne_bytes());
             }
-            let nits = f64::from(px_max) * f64::from(diffuse_white_nits);
-            max_nits = max_nits.max(nits);
-            sum_max_nits += nits;
         }
     }
 
-    let buffer =
-        PixelBuffer::from_vec(out, px.width(), px.rows(), PixelDescriptor::RGB16_BT2100_PQ)
-            .map_err(|_| whereat::at!(ConvertError::AllocationFailed))?;
-    let fall = sum_max_nits / (w as f64 * h as f64);
-    Ok((
-        buffer,
-        ContentLightLevel::new(nits_to_u16(max_nits), nits_to_u16(fall)),
-    ))
+    // Reuse the pipeline for linear→PQ + f32→u16. Tag the scratch with the
+    // target's primaries so no gamut step is inserted (value-only quantize).
+    let src = PixelDescriptor::RGBF32_LINEAR.with_primaries(target.primaries);
+    let out = convert_buffer(&scaled, w, h, src, target)?;
+    PixelBuffer::from_vec(out, w, h, target)
+        .map_err(|_| whereat::at!(ConvertError::AllocationFailed))
 }
 
 #[cfg(test)]
+// These tests exercise the deprecated-but-still-present HdrMetadata API.
+#[allow(deprecated)]
 mod tests {
     use super::*;
 
@@ -489,9 +455,9 @@ mod tests {
         assert_eq!(exposure_tonemap(-0.5, 0.0), 0.0);
     }
 
-    // -- Rung 2 (zenpixels#39): CLL measurement + PQ16 encoding --
+    // -- quantize_to (PQ16) parity with the f64 ST 2084 oracle --
 
-    use alloc::vec;
+    use alloc::vec::Vec;
 
     /// f64 SMPTE ST 2084 inverse-EOTF oracle (exact constants).
     fn pq_oracle(x: f64) -> f64 {
@@ -507,7 +473,7 @@ mod tests {
         ((c1 + c2 * xp) / (1.0 + c3 * xp)).powf(m2)
     }
 
-    fn rgbf32_buffer(pixels: &[[f32; 3]], w: u32, h: u32) -> PixelBuffer {
+    fn rgbf32(pixels: &[[f32; 3]], w: u32, h: u32) -> PixelBuffer {
         let mut data = Vec::with_capacity(pixels.len() * 12);
         for p in pixels {
             for c in p {
@@ -518,117 +484,40 @@ mod tests {
     }
 
     #[test]
-    fn cll_two_grays_matches_cta_stills_semantics() {
-        // MaxCLL = brightest pixel's max(R,G,B); MaxFALL = image average of
-        // per-pixel max — for [1.0, 2.0] @ 203 nits: (406, round(304.5)=305).
-        let buf = rgbf32_buffer(&[[1.0; 3], [2.0; 3]], 2, 1);
-        let cll =
-            compute_content_light_level(buf.as_slice(), REFERENCE_DIFFUSE_WHITE_NITS).unwrap();
-        assert_eq!(cll.max_content_light_level, 406);
-        assert_eq!(cll.max_frame_average_light_level, 305);
-    }
-
-    #[test]
-    fn cll_clamps_nan_and_negative_samples() {
-        let buf = rgbf32_buffer(&[[-1.0, f32::NAN, 0.5]], 1, 1);
-        let cll =
-            compute_content_light_level(buf.as_slice(), REFERENCE_DIFFUSE_WHITE_NITS).unwrap();
-        // max(R,G,B) folds from 0.0 → 0.5 · 203 = 101.5 → 102.
-        assert_eq!(cll.max_content_light_level, 102);
-        assert_eq!(cll.max_frame_average_light_level, 102);
-    }
-
-    #[test]
-    fn cll_ignores_alpha_lane() {
-        let mut data = Vec::new();
-        for c in [0.5f32, 0.5, 0.5, 7.0] {
-            data.extend_from_slice(&c.to_ne_bytes());
-        }
-        let buf = PixelBuffer::from_vec(data, 1, 1, PixelDescriptor::RGBAF32_LINEAR).unwrap();
-        let cll =
-            compute_content_light_level(buf.as_slice(), REFERENCE_DIFFUSE_WHITE_NITS).unwrap();
-        assert_eq!(cll.max_content_light_level, 102); // alpha 7.0 not a light level
-    }
-
-    #[test]
-    fn cll_strided_matches_tight() {
-        let pixels = [
-            [0.25f32, 0.5, 1.0],
-            [2.0, 0.1, 0.3],
-            [0.0, 0.0, 4.0],
-            [1.5; 3],
-        ];
-        let tight = rgbf32_buffer(&pixels, 2, 2);
-        let want =
-            compute_content_light_level(tight.as_slice(), REFERENCE_DIFFUSE_WHITE_NITS).unwrap();
-
-        // Same pixels with one whole padding pixel (12 bytes) per row —
-        // stride must be pixel-aligned. Back the slice with a Vec<f32> so
-        // the pointer satisfies the f32 alignment check in `PixelSlice::new`.
-        let stride_f32 = 2 * 3 + 3;
-        let mut padded = vec![0.0f32; stride_f32 * 2];
-        for row in 0..2 {
-            for col in 0..2 {
-                for (k, &c) in pixels[row * 2 + col].iter().enumerate() {
-                    padded[row * stride_f32 + col * 3 + k] = c;
-                }
-            }
-        }
-        let bytes: &[u8] = bytemuck::cast_slice(&padded);
-        let slice =
-            PixelSlice::new(bytes, 2, 2, stride_f32 * 4, PixelDescriptor::RGBF32_LINEAR).unwrap();
-        let got = compute_content_light_level(slice, REFERENCE_DIFFUSE_WHITE_NITS).unwrap();
-        assert_eq!(got, want);
-    }
-
-    #[test]
-    fn cll_rejects_u8_and_nonlinear() {
-        let u8buf = PixelBuffer::from_vec(vec![0u8; 3], 1, 1, PixelDescriptor::RGB8_SRGB).unwrap();
-        assert!(compute_content_light_level(u8buf.as_slice(), 203.0).is_err());
-
-        let nonlinear = PixelDescriptor::RGBF32_LINEAR.with_transfer(TransferFunction::Srgb);
-        let mut data = Vec::new();
-        for c in [0.5f32; 3] {
-            data.extend_from_slice(&c.to_ne_bytes());
-        }
-        let buf = PixelBuffer::from_vec(data, 1, 1, nonlinear).unwrap();
-        assert!(compute_content_light_level(buf.as_slice(), 203.0).is_err());
-    }
-
-    #[test]
-    fn pq16_golden_reference_white_and_peak() {
-        // 1.0 @ 203 nits → PQ(0.0203); 10000/203 → PQ(1.0) = code 65535.
-        let peak = 10_000.0 / REFERENCE_DIFFUSE_WHITE_NITS;
-        let buf = rgbf32_buffer(&[[1.0; 3], [peak; 3]], 2, 1);
-        let (out, cll) = encode_pq16(buf.as_slice(), REFERENCE_DIFFUSE_WHITE_NITS).unwrap();
-
+    fn quantize_to_pq16_white_and_peak() {
+        // 1.0 @ 203 nits → PQ(203/10000); 10000/203 → PQ(1.0) = code 65535.
+        let peak = 10_000.0 / 203.0;
+        let buf = rgbf32(&[[1.0; 3], [peak; 3]], 2, 1);
+        let out = quantize_to(
+            buf.as_slice(),
+            PixelDescriptor::RGB16_BT2100_PQ,
+            DiffuseWhite::BT2408,
+        )
+        .unwrap();
         assert_eq!(out.descriptor(), PixelDescriptor::RGB16_BT2100_PQ);
         let bytes = out.as_slice().as_strided_bytes();
         let code = |i: usize| u16::from_ne_bytes([bytes[2 * i], bytes[2 * i + 1]]);
 
         let want_white = (pq_oracle(203.0 / 10_000.0) * 65535.0).round() as i64;
-        let got_white = i64::from(code(0));
-        assert!(
-            (got_white - want_white).abs() <= 1,
-            "PQ code for 203-nit white: got {got_white}, oracle {want_white}"
-        );
-        assert_eq!(code(3), 65535, "10000-nit peak must clip to full code");
-
-        assert_eq!(cll.max_content_light_level, 10_000);
-        // Average of (203, 10000) = 5101.5 → 5102.
-        assert_eq!(cll.max_frame_average_light_level, 5102);
+        assert!((i64::from(code(0)) - want_white).abs() <= 1);
+        assert_eq!(code(3), 65535, "10000-nit peak clips to full code");
     }
 
     #[test]
-    fn pq16_matches_oracle_across_decades() {
+    fn quantize_to_pq16_matches_oracle_across_decades() {
         let values = [0.001f32, 0.01, 0.1, 0.5, 1.0, 2.0, 8.0, 20.0, 49.0];
         let pixels: Vec<[f32; 3]> = values.iter().map(|&v| [v; 3]).collect();
-        let buf = rgbf32_buffer(&pixels, values.len() as u32, 1);
-        let (out, _) = encode_pq16(buf.as_slice(), REFERENCE_DIFFUSE_WHITE_NITS).unwrap();
+        let buf = rgbf32(&pixels, values.len() as u32, 1);
+        let out = quantize_to(
+            buf.as_slice(),
+            PixelDescriptor::RGB16_BT2100_PQ,
+            DiffuseWhite::BT2408,
+        )
+        .unwrap();
         let bytes = out.as_slice().as_strided_bytes();
         for (i, &v) in values.iter().enumerate() {
             let got = i64::from(u16::from_ne_bytes([bytes[6 * i], bytes[6 * i + 1]]));
-            let x = f64::from(v) * f64::from(REFERENCE_DIFFUSE_WHITE_NITS) / 10_000.0;
+            let x = f64::from(v) * 203.0 / 10_000.0;
             let want = (pq_oracle(x) * 65535.0).round() as i64;
             assert!(
                 (got - want).abs() <= 1,
@@ -638,12 +527,30 @@ mod tests {
     }
 
     #[test]
-    fn pq16_cll_agrees_with_compute() {
-        let pixels = [[0.25f32, 0.5, 1.0], [2.0, 0.1, 0.3], [0.0; 3], [1.5; 3]];
-        let buf = rgbf32_buffer(&pixels, 2, 2);
-        let direct =
-            compute_content_light_level(buf.as_slice(), REFERENCE_DIFFUSE_WHITE_NITS).unwrap();
-        let (_, inline) = encode_pq16(buf.as_slice(), REFERENCE_DIFFUSE_WHITE_NITS).unwrap();
-        assert_eq!(direct, inline);
+    fn quantize_to_rejects_non_pq_target_and_non_linear_src() {
+        let buf = rgbf32(&[[0.5; 3]], 1, 1);
+        // HLG target → NoPath (anchor semantics differ).
+        let err = quantize_to(
+            buf.as_slice(),
+            PixelDescriptor::RGB16_BT2100_HLG,
+            DiffuseWhite::BT2408,
+        )
+        .unwrap_err();
+        assert!(matches!(*err.error(), ConvertError::NoPath { .. }));
+        // Non-linear source → UnsupportedTransfer.
+        let srgb = PixelDescriptor::RGBF32_LINEAR.with_transfer(TransferFunction::Srgb);
+        let mut d = Vec::new();
+        for c in [0.5f32; 3] {
+            d.extend_from_slice(&c.to_ne_bytes());
+        }
+        let nb = PixelBuffer::from_vec(d, 1, 1, srgb).unwrap();
+        assert!(
+            quantize_to(
+                nb.as_slice(),
+                PixelDescriptor::RGB16_BT2100_PQ,
+                DiffuseWhite::BT2408
+            )
+            .is_err()
+        );
     }
 }

--- a/zenpixels-convert/src/lib.rs
+++ b/zenpixels-convert/src/lib.rs
@@ -511,6 +511,9 @@ pub use load_bearing::{LoadBearingReport, PixelBufferLoadBearingExt, PixelSliceL
 // Re-export HDR types and tone mapping.
 #[cfg(feature = "std")]
 pub use hdr::exposure_tonemap;
+// `HdrMetadata` is re-exported but deprecated (see the `hdr` module); the
+// re-export itself names it, hence the allow.
+#[allow(deprecated)]
 pub use hdr::{
     ContentLightLevel, HdrMetadata, MasteringDisplay, reinhard_inverse, reinhard_tonemap,
 };

--- a/zenpixels-convert/src/output.rs
+++ b/zenpixels-convert/src/output.rs
@@ -85,6 +85,7 @@ use alloc::sync::Arc;
 #[allow(deprecated)]
 use crate::cms::ColorManagement;
 use crate::error::ConvertError;
+#[allow(deprecated)]
 use crate::hdr::HdrMetadata;
 use crate::{
     Cicp, ColorAuthority, ColorOrigin, ColorPrimaries, PixelBuffer, PixelDescriptor, PixelFormat,
@@ -114,12 +115,28 @@ pub enum OutputProfile {
 /// the metadata matches the pixel values.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
+// The `hdr` field references the deprecated `HdrMetadata`; suppress the
+// definition-site lint here (external uses still see the field/type
+// deprecation). The field is never wired (see TODO(0.3.0) below).
+#[allow(deprecated)]
 pub struct OutputMetadata {
     /// ICC profile bytes to embed, if any.
     pub icc: Option<Arc<[u8]>>,
     /// CICP code points to embed, if any.
     pub cicp: Option<Cicp>,
     /// HDR metadata to embed (content light level, mastering display), if any.
+    ///
+    /// **Deprecated** (never wired — see the `TODO(0.3.0)` notes in this
+    /// module): the bundled [`HdrMetadata`](crate::hdr::HdrMetadata) carrier is
+    /// being removed. At 0.3.0 this becomes sibling
+    /// `content_light_level: Option<ContentLightLevel>` /
+    /// `mastering_display: Option<MasteringDisplay>` fields (transfer already
+    /// rides on the output descriptor). See `CHANGELOG.md`
+    /// "QUEUED BREAKING CHANGES".
+    #[deprecated(
+        since = "0.2.14",
+        note = "unwired bundled HDR carrier; becomes sibling content_light_level / mastering_display fields in 0.3.0."
+    )]
     pub hdr: Option<HdrMetadata>,
 }
 
@@ -362,6 +379,7 @@ fn build_cms_transform<C: ColorManagement>(
 /// allocation fails, or a policy gate (alpha/depth/luma) forbids a
 /// required operation.
 #[track_caller]
+#[allow(deprecated)] // sets the unwired, deprecated OutputMetadata::hdr to None
 pub fn finalize_for_output_with(
     buffer: &PixelBuffer,
     origin: &ColorOrigin,

--- a/zenpixels/src/hdr.rs
+++ b/zenpixels/src/hdr.rs
@@ -6,6 +6,71 @@
 //! For tone mapping and HDR processing functions, see
 //! [`zenpixels-convert::hdr`](https://docs.rs/zenpixels-convert/latest/zenpixels_convert/hdr/).
 
+use crate::{PixelFormat, PixelSlice, TransferFunction};
+
+/// The absolute luminance, in cd/m² (nits), that a relative-linear sample
+/// value of `1.0` represents — the "diffuse white" (a.k.a. nominal diffuse
+/// white / SDR reference white) anchor that bridges relative-linear pixel
+/// data to absolute display light.
+///
+/// This is the single scalar the rest of the industry uses for that bridge:
+/// OpenEXR's `whiteLuminance` ("nits of RGB (1,1,1)"), JPEG XL's
+/// `intensity_target`, libheif's `ndwt` (nominal diffuse white), and
+/// libplacebo's SDR-white constant. The cross-vendor default is
+/// [`BT2408`](Self::BT2408) = 203 cd/m².
+///
+/// It is a *typed* anchor on purpose: HDR code mixes nits, PQ-encoded `[0,1]`,
+/// log2 gain, and headroom ratios — passing a bare `f32` invites unit
+/// confusion. Use [`DiffuseWhite::new`] / [`DiffuseWhite::nits`].
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct DiffuseWhite(f32);
+
+impl DiffuseWhite {
+    /// ITU-R BT.2408 HDR reference white: **203 cd/m²**. The cross-industry
+    /// default anchor for relative-linear HDR (matches Chrome `SDRWhiteLevel`,
+    /// Skia skcms, CSS `rec2100-linear`, and libplacebo).
+    pub const BT2408: Self = Self(203.0);
+
+    /// An anchor of `nits` cd/m² (the luminance that relative-linear `1.0`
+    /// represents).
+    #[must_use]
+    pub const fn new(nits: f32) -> Self {
+        Self(nits)
+    }
+
+    /// The anchor in cd/m² (nits).
+    #[must_use]
+    pub const fn nits(self) -> f32 {
+        self.0
+    }
+}
+
+impl Default for DiffuseWhite {
+    /// [`BT2408`](Self::BT2408) — 203 cd/m².
+    fn default() -> Self {
+        Self::BT2408
+    }
+}
+
+/// Round nits to a CTA-861.3 `u16` code (saturating).
+#[inline]
+fn nits_to_u16(nits: f64) -> u16 {
+    nits.round().clamp(0.0, 65535.0) as u16
+}
+
+/// Read one native-endian f32 sample from a pixel's bytes (no alignment
+/// assumption, per the `PixelSlice` endianness contract).
+#[inline]
+fn sample_f32(bytes: &[u8], k: usize) -> f32 {
+    f32::from_ne_bytes([
+        bytes[4 * k],
+        bytes[4 * k + 1],
+        bytes[4 * k + 2],
+        bytes[4 * k + 3],
+    ])
+}
+
 /// HDR content light level metadata (CEA-861.3 / CTA-861-H).
 ///
 /// Describes the peak brightness characteristics of HDR content.
@@ -28,6 +93,59 @@ impl ContentLightLevel {
             max_content_light_level,
             max_frame_average_light_level,
         }
+    }
+
+    /// Measure MaxCLL / MaxFALL (CTA-861.3-A) from relative-linear RGB(A) f32
+    /// pixels, with `white` anchoring the scale (sample `1.0` = `white` nits;
+    /// [`DiffuseWhite::BT2408`] — 203 — is the convention).
+    ///
+    /// Semantics per CTA-861.3-A as PNG 3rd ed §11.3.2.8 imports it for stills
+    /// (one still = one frame): **MaxCLL** is the brightest pixel's
+    /// `max(R, G, B)` in cd/m², **MaxFALL** is the image's average of per-pixel
+    /// `max(R, G, B)`. Negative/NaN samples clamp to 0; an alpha lane is
+    /// ignored; strided rows are handled.
+    ///
+    /// Returns `None` if the descriptor is not relative-linear
+    /// `RgbF32`/`RgbaF32` (the caller, having produced the linear buffer,
+    /// knows its format). Zero-area input yields `Some(0, 0)`.
+    #[must_use]
+    pub fn measure(px: PixelSlice<'_>, white: DiffuseWhite) -> Option<Self> {
+        let desc = px.descriptor();
+        let channels = match desc.pixel_format() {
+            PixelFormat::RgbF32 => 3,
+            PixelFormat::RgbaF32 => 4,
+            _ => return None,
+        };
+        if desc.transfer != TransferFunction::Linear {
+            return None;
+        }
+        let w = px.width() as usize;
+        let h = px.rows() as usize;
+        if w == 0 || h == 0 {
+            return Some(Self::new(0, 0));
+        }
+        let stride = px.stride();
+        let bytes = px.as_strided_bytes();
+        let row_len = w * channels * 4;
+        let wn = f64::from(white.nits());
+
+        let mut max_nits = 0.0f64;
+        let mut sum_max_nits = 0.0f64;
+        for row in 0..h {
+            let row_bytes = &bytes[row * stride..row * stride + row_len];
+            for pxl in row_bytes.chunks_exact(channels * 4) {
+                // Fold from 0.0 so NaN and negative samples drop out.
+                let m = 0.0f32
+                    .max(sample_f32(pxl, 0))
+                    .max(sample_f32(pxl, 1))
+                    .max(sample_f32(pxl, 2));
+                let nits = f64::from(m) * wn;
+                max_nits = max_nits.max(nits);
+                sum_max_nits += nits;
+            }
+        }
+        let fall = sum_max_nits / (w as f64 * h as f64);
+        Some(Self::new(nits_to_u16(max_nits), nits_to_u16(fall)))
     }
 }
 
@@ -85,6 +203,70 @@ impl MasteringDisplay {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{PixelBuffer, PixelDescriptor};
+    use alloc::vec::Vec;
+
+    fn rgbf32(pixels: &[[f32; 3]], w: u32, h: u32) -> PixelBuffer {
+        let mut data = Vec::with_capacity(pixels.len() * 12);
+        for p in pixels {
+            for c in p {
+                data.extend_from_slice(&c.to_ne_bytes());
+            }
+        }
+        PixelBuffer::from_vec(data, w, h, PixelDescriptor::RGBF32_LINEAR).unwrap()
+    }
+
+    #[test]
+    fn diffuse_white_defaults_to_bt2408() {
+        assert_eq!(DiffuseWhite::default(), DiffuseWhite::BT2408);
+        assert_eq!(DiffuseWhite::BT2408.nits(), 203.0);
+        assert_eq!(DiffuseWhite::new(100.0).nits(), 100.0);
+    }
+
+    #[test]
+    fn measure_two_grays_cta_stills_semantics() {
+        // [1.0, 2.0] @ 203: MaxCLL = 2·203 = 406; MaxFALL = avg(203, 406) = 304.5 → 305.
+        let buf = rgbf32(&[[1.0; 3], [2.0; 3]], 2, 1);
+        let cll = ContentLightLevel::measure(buf.as_slice(), DiffuseWhite::BT2408).unwrap();
+        assert_eq!(cll.max_content_light_level, 406);
+        assert_eq!(cll.max_frame_average_light_level, 305);
+    }
+
+    #[test]
+    fn measure_clamps_nan_and_negative() {
+        let buf = rgbf32(&[[-1.0, f32::NAN, 0.5]], 1, 1);
+        let cll = ContentLightLevel::measure(buf.as_slice(), DiffuseWhite::BT2408).unwrap();
+        // max(R,G,B) folds from 0.0 → 0.5 · 203 = 101.5 → 102.
+        assert_eq!(cll.max_content_light_level, 102);
+        assert_eq!(cll.max_frame_average_light_level, 102);
+    }
+
+    #[test]
+    fn measure_ignores_alpha_and_custom_white() {
+        let mut data = Vec::new();
+        for c in [0.5f32, 0.5, 0.5, 7.0] {
+            data.extend_from_slice(&c.to_ne_bytes());
+        }
+        let buf = PixelBuffer::from_vec(data, 1, 1, PixelDescriptor::RGBAF32_LINEAR).unwrap();
+        // alpha 7.0 ignored; custom 100-nit white: 0.5 · 100 = 50.
+        let cll = ContentLightLevel::measure(buf.as_slice(), DiffuseWhite::new(100.0)).unwrap();
+        assert_eq!(cll.max_content_light_level, 50);
+    }
+
+    #[test]
+    fn measure_rejects_non_linear_and_non_f32() {
+        let u8buf =
+            PixelBuffer::from_vec(alloc::vec![0u8; 3], 1, 1, PixelDescriptor::RGB8_SRGB).unwrap();
+        assert!(ContentLightLevel::measure(u8buf.as_slice(), DiffuseWhite::BT2408).is_none());
+
+        let nonlinear = PixelDescriptor::RGBF32_LINEAR.with_transfer(TransferFunction::Srgb);
+        let mut data = Vec::new();
+        for c in [0.5f32; 3] {
+            data.extend_from_slice(&c.to_ne_bytes());
+        }
+        let buf = PixelBuffer::from_vec(data, 1, 1, nonlinear).unwrap();
+        assert!(ContentLightLevel::measure(buf.as_slice(), DiffuseWhite::BT2408).is_none());
+    }
 
     #[test]
     fn content_light_level_new() {

--- a/zenpixels/src/icc/mod.rs
+++ b/zenpixels/src/icc/mod.rs
@@ -74,6 +74,14 @@ const ICC_HEADER_NORMALIZE_END: usize = 100;
 ///
 /// This is a lightweight operation (~100ns) that reads only the 128-byte header
 /// and tag table entries — no full profile parse required.
+///
+/// Read leniency: the tag is recovered regardless of the profile's data colour
+/// space. ICC.1 restricts `cicpTag` to RGB/YCbCr/XYZ, so a GRAY/CMYK profile
+/// carrying one is non-conformant — but a third-party encoder may still emit it,
+/// and we honor it on input rather than drop recoverable colour signaling
+/// (Postel's law). zenpixels itself never *emits* a cicp tag on a gray profile
+/// (see the GRAY-class synthesis in `zenpixels-convert`); this leniency only
+/// affects what we accept, never what we produce.
 pub fn extract_cicp(data: &[u8]) -> Option<Cicp> {
     if data.len() < ICC_MIN_SIZE {
         return None;


### PR DESCRIPTION
Replaces the AI-generated `hdr.rs` Rung-2 surface (which slipped past review) after auditing it against the published-vs-unpublished line, a **14-system survey** of production HDR software (`docs/hdr-design-survey-2026-06-13.md`), **and a full `~/work/zen/` consumer sweep**.

## Key finding from the consumer sweep
**Nothing in the tree encodes linear→PQ16.** Every PQ16 buffer originates from an *already-PQ* source:

| site | direction |
|---|---|
| `zenhdr-corpus` | decode gain-map → nits → **writes EXR** |
| `zen-metrics-cli/sweep/hdr.rs` | reads **already-PQ16 PNG** → JXL → decodes back to nits |
| `zen-metrics-cli/hdr.rs` `decode_pq_png` | reads PQ samples (corpus contract) |
| codecs (zenavif…) | own YUV/AV1 path |
| imageflow | **no HDR at all** |

The `render_pq16` consumer the CHANGELOG claimed **does not exist** — a hallucinated reference. So the new encode helpers had **zero real consumers**.

## Withdraw (new in 0.2.14, never published, zero consumers)
`hdr::encode_pq16`, `hdr::compute_content_light_level`, `hdr::REFERENCE_DIFFUSE_WHITE_NITS` — a free-function-per-format encode with a bare-`f32` luminance anchor the prior art uniformly rejects.

## Add — public (the primitives with a real latent consumer)
zenmetrics hand-rolls `max`/`mean` over nits (= MaxCLL/MaxFALL); these generalize it:
- **`zenpixels::hdr::DiffuseWhite`** — typed absolute-luminance anchor (the nits of relative-linear 1.0). The unit-typing every surveyed library uses (OpenEXR `whiteLuminance`, JXL `intensity_target`, libheif `ndwt`, libplacebo SDR-white). `::BT2408` (203) is `Default`.
- **`ContentLightLevel::measure(px, DiffuseWhite) -> Option<Self>`** — CLL as a constructor on the type it returns (the correct CTA `max(R,G,B)` form; works on nits via `DiffuseWhite::new(1.0)`).

## Retain `pub(crate)` — *not* public (per the crate's YAGNI policy)
- **`hdr::quantize_to`** — the verified linear→PQ16 path (reuses `convert_buffer`; pre-scales by `white/10000`, clamps, drops alpha; **PQ codes match the f64 ST 2084 oracle within ±1**). Kept `#[allow(dead_code)]` as a **tested oracle** for when a real consumer lands — at which point it should be promoted *as* `convert_buffer` against a metadata-carried anchor, not as a standalone fn. Not re-exported; the convert-crate `DiffuseWhite` re-export is dropped too (no public convert API takes it).

## Deprecate (published 0.2.13 → removal queued for 0.3.0)
- **`hdr::HdrMetadata`** (+ `is_hdr`/`is_sdr`/`hdr10`/`hlg`) and **`OutputMetadata::hdr`** — a redundant, weaker, **frozen** duplicate of `zencodec::Metadata` that bundles `transfer` with CLL/mastering (all surveyed prior art keeps them separate); `hdr10()` fabricates an unmeasured ST 2086 volume.

## Noted, not changed here
The pipeline's `LinearF32ToPqU16` kernel is **scalar per-element** while the f32→f32 PQ path uses the batch `linear_to_pq_slice` — a latent, **non-API** SIMD fix to land separately on main.

## Safety
- **`cargo semver-checks`: "no semver update required"** (both crates) — removed items never shipped; `DiffuseWhite` + `measure` are additive.
- **1092 tests + 11 doctests pass**; clippy + fmt clean (default + `fast-transpose`); api-doc snapshots regenerated.
- Tone-map helpers left in place per request.

## Queued for 0.3.0 (CHANGELOG)
The deprecation removals + dedup `ContentLightLevel`/`MasteringDisplay` to one canonical home + move the luminance anchor onto `zencodec::Metadata` so even the internal PQ encode collapses into a plain `convert_buffer`.
