### PR TITLE
S1a (HDR #45): carry the absolute-luminance anchor (DiffuseWhite) on ColorContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,25 @@
   `zenpixels-convert::hdr::compute_content_light_level` free function).
   Negative/NaN clamp to 0, alpha ignored, strided rows handled; `None` for
   non-`RgbF32`/`RgbaF32` or non-`Linear` input.
+- **`ColorContext::diffuse_white` field + `with_diffuse_white` builder, and
+  `DiffuseWhite` re-exported at the crate root** — the absolute-luminance
+  anchor now travels on the existing `PixelBuffer.color: Arc<ColorContext>`
+  sidecar (propagated by every clone / `with_descriptor` at no per-strip cost),
+  so the HDR converter can map relative-linear light to absolute luminance for
+  PQ/HLG encode and tone-mapping. `None` = unsignaled (consumers default to
+  `DiffuseWhite::BT2408`, 203). First slice of the M×N HDR pipeline (#45).
+
+#### Changed (BREAKING, tolerated in 0.2.x)
+
+- **`ColorContext` is now `#[non_exhaustive]` and no longer derives `Eq`**
+  (`PartialEq` retained). `#[non_exhaustive]` lets the next HDR carrier fields
+  (mastering display, content light level) extend it without another break;
+  `Eq` is dropped because the new `diffuse_white` anchor wraps `f32`. Tolerated
+  per the 0.2.x policy: the only external struct-literal constructor is
+  `zencodec` (builds against published 0.2.10 — unaffected until it adopts
+  0.2.14; migration tracked as #45 S1b), and no in-tree `Eq`/`Hash` use depends
+  on `ColorContext` (verified). `cargo semver-checks` flags both as major; both
+  are tolerated-bucket items.
 
 ### Workspace — build
 

--- a/docs/public-api/zenpixels.internal.txt
+++ b/docs/public-api/zenpixels.internal.txt
@@ -9,13 +9,13 @@
 
 ## summary
 #
-#   inherent methods                           38
+#   inherent methods                           37
 #   trait roster entries (type × trait)        37
 #
 # per-module pub lines:
 #   buffer                            3
 #   cicp                              1
-#   color                             6
+#   color                             5
 #   descriptor                       10
 #   hdr                               1
 #   icc                               2
@@ -24,14 +24,13 @@
 #   planar                            7
 #   policy                            5
 
-## items (38 lines)
+## items (37 lines)
 
 pub fn buffer::Bgrx::assert_fields_are_eq(&self)
 pub fn buffer::BufferError::assert_fields_are_eq(&self)
 pub fn buffer::Rgbx::assert_fields_are_eq(&self)
 pub fn cicp::Cicp::assert_fields_are_eq(&self)
 pub fn color::ColorAuthority::assert_fields_are_eq(&self)
-pub fn color::ColorContext::assert_fields_are_eq(&self)
 pub fn color::ColorOrigin::assert_fields_are_eq(&self)
 pub fn color::ColorProfileSource<'a>::assert_fields_are_eq(&self)
 pub fn color::ColorProvenance::assert_fields_are_eq(&self)

--- a/docs/public-api/zenpixels.txt
+++ b/docs/public-api/zenpixels.txt
@@ -6,16 +6,16 @@
 # impls omitted; re-export duplicates annotated `[also: path]`.
 # DO NOT EDIT BY HAND — commit regenerated changes with the code.
 #
-# files: zenpixels.txt 806 lines (supported surface) | zenpixels.features.txt 269 added (features: icc,imgref,planar,rgb,serde,std) | zenpixels.internal.txt 75 lines (75 hidden + 0 excluded-feature)
+# files: zenpixels.txt 811 lines (supported surface) | zenpixels.features.txt 269 added (features: icc,imgref,planar,rgb,serde,std) | zenpixels.internal.txt 74 lines (74 hidden + 0 excluded-feature)
 
 ## summary
 #
 #   pub modules                                10
-#   pub types (struct/enum/trait/alias)        75
-#   pub consts/statics                        273
+#   pub types (struct/enum/trait/alias)        76
+#   pub consts/statics                        276
 #   free functions                              4
-#   inherent methods                          208
-#   struct fields                             105
+#   inherent methods                          210
+#   struct fields                             107
 #   enum variants                             208
 #   re-exports                                  4
 #   trait roster entries (type × trait)       237
@@ -23,18 +23,18 @@
 #   auto-trait exceptions                       4
 #
 # per-module pub lines:
-#   (root)                          389
+#   (root)                          393
 #   buffer                          192
 #   cicp                             27
-#   color                            57
+#   color                            60
 #   descriptor                      148
-#   hdr                              16
+#   hdr                              17
 #   icc                              13
 #   orientation                      11
 #   pixel_types                       9
 #   policy                           25
 
-## items (760 lines)
+## items (765 lines)
 
 pub mod zenpixels
 pub use At
@@ -190,6 +190,7 @@ pub const fn color::NamedProfile::from_primaries_transfer(descriptor::ColorPrima
 pub const fn color::NamedProfile::to_cicp(self) -> core::option::Option<cicp::Cicp> [also: (root)]
 pub const fn color::NamedProfile::to_primaries_transfer(self) -> (descriptor::ColorPrimaries, descriptor::TransferFunction) [also: (root)]
 pub color::ColorContext::cicp: core::option::Option<cicp::Cicp>
+pub color::ColorContext::diffuse_white: core::option::Option<hdr::DiffuseWhite>
 pub color::ColorContext::icc: core::option::Option<alloc::sync::Arc<[u8]>>
 pub fn color::ColorContext::as_profile_source(&self) -> core::option::Option<color::ColorProfileSource<'_>>
 pub fn color::ColorContext::from_cicp(cicp::Cicp) -> Self
@@ -197,6 +198,7 @@ pub fn color::ColorContext::from_icc(impl core::convert::Into<alloc::sync::Arc<[
 pub fn color::ColorContext::from_icc_and_cicp(impl core::convert::Into<alloc::sync::Arc<[u8]>>, cicp::Cicp) -> Self
 pub fn color::ColorContext::is_srgb(&self) -> bool
 pub fn color::ColorContext::transfer_function(&self) -> descriptor::TransferFunction
+pub fn color::ColorContext::with_diffuse_white(self, hdr::DiffuseWhite) -> Self
 pub color::ColorOrigin::cicp: core::option::Option<cicp::Cicp>
 pub color::ColorOrigin::color_authority: color::ColorAuthority
 pub color::ColorOrigin::icc: core::option::Option<alloc::sync::Arc<[u8]>>
@@ -375,10 +377,9 @@ pub hdr::ContentLightLevel::max_content_light_level: u16
 pub hdr::ContentLightLevel::max_frame_average_light_level: u16
 pub fn hdr::ContentLightLevel::measure(buffer::PixelSlice<'_>, hdr::DiffuseWhite) -> core::option::Option<Self>
 pub const fn hdr::ContentLightLevel::new(u16, u16) -> Self [also: (root)]
-pub struct hdr::DiffuseWhite(_)
 pub const hdr::DiffuseWhite::BT2408: Self
-pub const fn hdr::DiffuseWhite::new(f32) -> Self
-pub const fn hdr::DiffuseWhite::nits(self) -> f32
+pub const fn hdr::DiffuseWhite::new(f32) -> Self [also: (root)]
+pub const fn hdr::DiffuseWhite::nits(self) -> f32 [also: (root)]
 pub hdr::MasteringDisplay::max_luminance: f32
 pub hdr::MasteringDisplay::min_luminance: f32
 pub hdr::MasteringDisplay::primaries_xy: [[f32; 2]; 3]
@@ -611,8 +612,9 @@ pub fn cicp::Cicp::matrix_coefficients_name(u8) -> &'static str
 pub fn cicp::Cicp::to_descriptor(&self, descriptor::PixelFormat) -> descriptor::PixelDescriptor
 pub fn cicp::Cicp::transfer_characteristics_name(u8) -> &'static str
 pub fn cicp::Cicp::transfer_function_enum(&self) -> descriptor::TransferFunction
-pub struct ColorContext [also: color]
+#[non_exhaustive] pub struct ColorContext [also: color]
 pub ColorContext::cicp: core::option::Option<cicp::Cicp>
+pub ColorContext::diffuse_white: core::option::Option<hdr::DiffuseWhite>
 pub ColorContext::icc: core::option::Option<alloc::sync::Arc<[u8]>>
 pub fn color::ColorContext::as_profile_source(&self) -> core::option::Option<color::ColorProfileSource<'_>>
 pub fn color::ColorContext::from_cicp(cicp::Cicp) -> Self
@@ -620,6 +622,7 @@ pub fn color::ColorContext::from_icc(impl core::convert::Into<alloc::sync::Arc<[
 pub fn color::ColorContext::from_icc_and_cicp(impl core::convert::Into<alloc::sync::Arc<[u8]>>, cicp::Cicp) -> Self
 pub fn color::ColorContext::is_srgb(&self) -> bool
 pub fn color::ColorContext::transfer_function(&self) -> descriptor::TransferFunction
+pub fn color::ColorContext::with_diffuse_white(self, hdr::DiffuseWhite) -> Self
 #[non_exhaustive] pub struct ColorOrigin [also: color]
 pub ColorOrigin::cicp: core::option::Option<cicp::Cicp>
 pub ColorOrigin::color_authority: color::ColorAuthority
@@ -641,6 +644,8 @@ pub ConvertOptions::clip_out_of_gamut: bool
 pub ConvertOptions::depth_policy: policy::DepthPolicy
 pub ConvertOptions::gray_expand: policy::GrayExpand
 pub ConvertOptions::luma: core::option::Option<policy::LumaCoefficients>
+pub struct DiffuseWhite(_) [also: hdr]
+pub const hdr::DiffuseWhite::BT2408: Self
 #[repr(C)] pub struct GrayAlpha16 [also: pixel_types]
 pub GrayAlpha16::a: u16
 pub GrayAlpha16::v: u16
@@ -811,7 +816,7 @@ buffer::PixelSliceMut<'a>: From<buffer::PixelSliceMut<'a, P>>
 buffer::Rgbx: Clone, Copy, Debug, Default, Eq, Hash, PartialEq, buffer::Pixel, bytemuck::pod::Pod, bytemuck::zeroable::Zeroable
 cicp::Cicp: Clone, Copy, Debug, Display, Eq, Hash, PartialEq
 color::ColorAuthority: Clone, Copy, Debug, Default, Eq, Hash, PartialEq
-color::ColorContext: Clone, Debug, Eq, PartialEq
+color::ColorContext: Clone, Debug, Default, PartialEq
 color::ColorOrigin: Clone, Debug, Eq, PartialEq
 color::ColorProfileSource<'a>: Clone, Debug, Eq, PartialEq
 color::ColorProvenance: Clone, Copy, Debug, Eq, Hash, PartialEq

--- a/zenpixels/src/color.rs
+++ b/zenpixels/src/color.rs
@@ -9,6 +9,7 @@
 //! pixel descriptor itself, not as a separate enum.
 
 use crate::cicp::Cicp;
+use crate::hdr::DiffuseWhite;
 use crate::{ColorPrimaries, TransferFunction};
 use alloc::sync::Arc;
 
@@ -304,12 +305,25 @@ pub enum ColorAuthority {
 /// shareable context. Carried via `Arc` on pixel slices and pipeline
 /// sources so color metadata travels with pixel data without per-strip
 /// cloning overhead.
-#[derive(Clone, Debug, PartialEq, Eq)]
+// `Eq` dropped because `DiffuseWhite` wraps `f32` (no `Eq`); `PartialEq`
+// is retained. `#[non_exhaustive]` added so future HDR carrier fields
+// (mastering display, content light level) extend this without another break.
+// `Default` (all fields `None`) is the empty "no color signaling" context —
+// the only way to construct one now that the struct literal is sealed.
+#[derive(Clone, Debug, Default, PartialEq)]
+#[non_exhaustive]
 pub struct ColorContext {
     /// Raw ICC profile bytes.
     pub icc: Option<Arc<[u8]>>,
     /// CICP parameters (ITU-T H.273).
     pub cicp: Option<Cicp>,
+    /// Absolute-luminance anchor: the cd/m² (nits) that a relative-linear
+    /// sample value of `1.0` represents. `None` means unsignaled — consumers
+    /// default to [`DiffuseWhite::BT2408`] (203 nits, the cross-vendor
+    /// convention). Travels with the pixels so the HDR converter can map
+    /// relative-linear light to absolute luminance for PQ/HLG encode and
+    /// tone-mapping.
+    pub diffuse_white: Option<DiffuseWhite>,
 }
 
 impl ColorContext {
@@ -318,6 +332,7 @@ impl ColorContext {
         Self {
             icc: Some(icc.into()),
             cicp: None,
+            diffuse_white: None,
         }
     }
 
@@ -326,7 +341,21 @@ impl ColorContext {
         Self {
             icc: None,
             cicp: Some(cicp),
+            diffuse_white: None,
         }
+    }
+
+    /// Attach an absolute-luminance anchor — the nits that relative-linear
+    /// `1.0` represents — returning the updated context.
+    ///
+    /// Set this on an HDR working buffer (e.g. after gain-map reconstruction,
+    /// where the anchor is [`DiffuseWhite::BT2408`] = 203) so downstream
+    /// conversion can map relative-linear light to absolute cd/m² for PQ/HLG
+    /// encode and tone-mapping.
+    #[must_use]
+    pub fn with_diffuse_white(mut self, white: DiffuseWhite) -> Self {
+        self.diffuse_white = Some(white);
+        self
     }
 
     /// Create from both ICC and CICP.
@@ -342,6 +371,7 @@ impl ColorContext {
         Self {
             icc: Some(icc.into()),
             cicp: Some(cicp),
+            diffuse_white: None,
         }
     }
 
@@ -602,6 +632,7 @@ mod tests {
         let ctx = ColorContext {
             icc: None,
             cicp: None,
+            diffuse_white: None,
         };
         assert!(ctx.as_profile_source().is_none());
     }
@@ -612,6 +643,23 @@ mod tests {
             ColorContext::from_cicp(Cicp::BT2100_PQ).transfer_function(),
             TransferFunction::Pq
         );
+    }
+
+    #[test]
+    fn color_context_diffuse_white_defaults_none_and_round_trips() {
+        // Unsignaled by default — consumers fall back to BT.2408 (203).
+        assert_eq!(ColorContext::from_cicp(Cicp::BT2100_PQ).diffuse_white, None);
+        assert_eq!(ColorContext::from_icc([0u8; 4]).diffuse_white, None);
+
+        // The anchor round-trips through the builder, and is preserved by Clone.
+        let ctx = ColorContext::from_cicp(Cicp::BT2100_PQ).with_diffuse_white(DiffuseWhite::BT2408);
+        assert_eq!(ctx.diffuse_white, Some(DiffuseWhite::BT2408));
+        assert_eq!(ctx.clone().diffuse_white, Some(DiffuseWhite::BT2408));
+
+        // A custom anchor (e.g. a 100-nit SDR reference) carries through too.
+        let custom =
+            ColorContext::from_cicp(Cicp::BT2100_PQ).with_diffuse_white(DiffuseWhite::new(100.0));
+        assert_eq!(custom.diffuse_white.map(DiffuseWhite::nits), Some(100.0));
     }
 
     #[test]

--- a/zenpixels/src/lib.rs
+++ b/zenpixels/src/lib.rs
@@ -108,7 +108,7 @@ pub use color::{
 };
 
 // Re-export HDR metadata types at crate root.
-pub use hdr::{ContentLightLevel, MasteringDisplay};
+pub use hdr::{ContentLightLevel, DiffuseWhite, MasteringDisplay};
 
 // Re-export GrayAlpha pixel types at crate root.
 pub use pixel_types::{GrayAlpha8, GrayAlpha16, GrayAlphaF32};


### PR DESCRIPTION
**S1a of the M×N HDR pipeline epic (#45).** Stacked on #41 (base branch `hdr-api-cleanup`).

The HDR hub needs the absolute-luminance anchor — the nits that relative-linear `1.0` represents — to **travel with the pixels**, so the converter can map relative-linear light to absolute cd/m² for PQ/HLG encode and tone-mapping. The audit (#45) chose the home: the **existing** `PixelBuffer.color: Arc<ColorContext>` sidecar, which already propagates through every clone / `with_descriptor` at no per-strip cost — no new attachment mechanism, no `PixelDescriptor` field, no wrapper type.

## Changes (zenpixels only)
- **`ColorContext::diffuse_white: Option<DiffuseWhite>`** + **`with_diffuse_white(self, DiffuseWhite)`** builder. `None` = unsignaled (consumers default to `DiffuseWhite::BT2408`, 203).
- **`ColorContext` → `#[non_exhaustive]`** so the next HDR carrier fields (mastering display, CLL) extend it without another break.
- **`Eq` dropped** from `ColorContext` (`PartialEq` retained) — the anchor wraps `f32`.
- **`DiffuseWhite` re-exported at the crate root** (`zenpixels::DiffuseWhite`).

## Tolerated 0.2.x breaks (per zenpixels CLAUDE.md policy)
`cargo semver-checks` flags two majors — both in the tolerated bucket, documented in the CHANGELOG under `#### Changed (BREAKING, tolerated in 0.2.x)`:
1. `#[non_exhaustive]` on `ColorContext` — the only external struct-literal constructor is `zencodec` (`info.rs:353`), which builds against **published 0.2.10** and is unaffected until it adopts 0.2.14 (that migration is **S1b**).
2. `Eq` derive removed — verified **no in-tree `Eq`/`Hash` use** depends on `ColorContext`.

## Verification
- **434+ tests pass** (incl. a new `color_context_diffuse_white_*` round-trip/clone-preservation test); clippy + fmt clean; api-doc snapshots regenerated (`DiffuseWhite` now in the public surface).

## Notes
- The base #41 was force-updated to also carry an 8-line gray-CICP `icc/mod.rs` doc comment from a concurrent session (kept at the author's request); it is **not** part of this S1a diff.
- **Next — S1b:** add `diffuse_white` to `zencodec::Metadata` + `SourceColor` and populate it in the gain-map decode adapters (gated on the 0.2.14 release that ships `DiffuseWhite`).
