### PR TITLE
feat(hdr): thread the absolute-luminance anchor through the PQ ConvertSteps (#45 S2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,63 @@
 
 ### zenpixels-convert — changed
 
+- **The absolute-luminance anchor now threads through the PQ `ConvertStep`s
+  themselves (#45 S2).** The PQ kernels (u16 + f32, encode + decode) take a
+  `diffuse_white / 10000` scale carried on the plan and apply it to the **RGB
+  lanes only**: encode multiplies relative-linear into PQ-absolute before the
+  OETF, decode divides after the EOTF, so a relative-linear buffer maps to PQ at
+  the right brightness with no caller pre-scale. The unsignaled default is `1.0`
+  — "linear is already PQ-absolute (1.0 = 10000 cd/m²)", the exact prior
+  behavior. HLG is intentionally excluded (scene-referred anchoring differs).
+
+- **The PQ kernels (u16 + f32, encode + decode) now use a vendored *precise*
+  SIMD exact-ST 2084 transfer**, alpha-preserving. `pq_eotf_slice` /
+  `pq_oetf_slice` evaluate the exact SMPTE ST 2084 formula in SIMD via magetypes'
+  `pow_midp_precise`. This replaces **both** the prior scalar u16 path **and** the
+  `linear_srgb::default` rational-poly slice: that fit is only valid above
+  v≈0.02 and, applied as a slice (no exact-below-threshold branch), extrapolated
+  to black and drifted the tight u16 → f32 → u16 round-trip up to **256 codes**.
+  The vendored kernel is precise across the full range (round-trip **≤1**, ST
+  2084 oracle **±1**) and stays SIMD. u16↔f32 depth scaling uses the SIMD
+  `garb::bytes` primitives; the EOTF/OETF run over every lane and the alpha lane
+  is then restored linearly (never transferred or anchored). The RGB-only anchor
+  multiply is `multiply_color_channels`, a generic `#[magetypes]` `f32x16` method
+  (with-alpha `[f,f,f,1]` pattern / without-alpha uniform).
+
+- **The no-allocation convert path honors a strided destination.**
+  `convert_into_with_anchor` (and `quantize_into`) take a `dst_stride`, writing
+  each row at the caller's stride instead of assuming packed output — so the
+  result can land in a sub-region of a larger buffer, and the `BufferSize` check
+  validates `dst_stride ≥ row` + `(rows-1)·dst_stride + row` bytes.
+
+- **`quantize_to` no longer repacks; it honors strides and preserves alpha.**
+  It hands the (possibly strided, possibly RGBA) source straight to the anchored
+  pipeline — no caller-side pre-scale or contiguous repack. Alpha follows the
+  **target**: an RGB PQ target drops it (as before), an RGBA PQ target
+  (`RGBA16.with_transfer(Pq)…`) preserves it linearly. Codes still match the f64
+  ST 2084 oracle within ±1. Internally `convert_buffer_with_anchor` is now
+  strided and split over a `convert_into_with_anchor` primitive; a `pub(crate)`
+  `quantize_into` (no-allocation — writes into a caller buffer) is staged behind
+  it, ready to promote when a concrete consumer or the §3.2 public HDR-convert
+  surface lands.
+
+- **`quantize_to` now carries the diffuse-white anchor onto its output.** The
+  result `PixelBuffer` gets a `ColorContext` with the applied `diffuse_white`
+  (the `ndwt` a downstream encoder signals) plus the target's CICP, instead of a
+  context-less buffer — the anchor is a *reference* that survives the encode, so
+  the output self-describes it rather than silently dropping it. (`quantize_into`
+  writes raw bytes, so its caller owns the envelope.)
+
+- **HLG↔PQ now refuses at plan time (`ConvertError::NoPath`)** instead of
+  emitting wrong pixels. The HLG kernels carry only the scene-referred OETF (no
+  OOTF, no `Lw`), while PQ is absolute display light — routing one to the other
+  through the shared linear intermediate conflates the two luminance domains
+  (deterministic but photometrically wrong brightness). `ConvertPlan::new` (and
+  everything above it) refuses the cross, the same posture as the signal-range
+  refusal; HLG↔SDR/linear and PQ↔SDR/linear are unaffected. Correct HLG↔PQ needs
+  the OOTF + `(diffuse_white, Lw)` threading (#45 S2). Uses the existing `NoPath`
+  variant — no new public API, no semver break.
+
 - **Signal-range crossings now refuse at plan time instead of mislabeling.**
   `ConvertPlan::new` (and everything above it: `new_explicit`,
   `RowConverter`, `convert_buffer`, `adapt_for_encode*`) returns

--- a/zenpixels-convert/Cargo.toml
+++ b/zenpixels-convert/Cargo.toml
@@ -163,6 +163,11 @@ path = "benches/bench_hlg_regress.rs"
 harness = false
 
 [[bench]]
+name = "bench_pq_anchor"
+path = "benches/bench_pq_anchor.rs"
+harness = false
+
+[[bench]]
 name = "bench_u16_encode"
 path = "benches/bench_u16_encode.rs"
 harness = false

--- a/zenpixels-convert/benches/bench_pq_anchor.rs
+++ b/zenpixels-convert/benches/bench_pq_anchor.rs
@@ -1,0 +1,80 @@
+//! Anchored PQ quantization — `quantize_to`, the public HDR encode entry.
+//!
+//! Exercises the paths added in the #45-S2 anchor work end-to-end:
+//!   * the **anchored** RGB encode (default BT.2408 = 203 nits ⇒ a non-`1.0`
+//!     scale, so the `multiply_color_channels` SIMD pass runs),
+//!   * the **alpha-preserving** RGBA path (`linear_to_pq_rgba_slice` + the
+//!     `[f,f,f,1]`-pattern multiply), and
+//!   * the `garb` SIMD depth-scale glue + the `PixelBuffer` allocation.
+//!
+//! Both go linear-`f32` → PQ-`u16`; throughput is reported over the input bytes.
+
+use zenbench::prelude::*;
+use zenpixels::{PixelBuffer, PixelDescriptor, TransferFunction};
+use zenpixels_convert::quantize_to;
+
+const SIZES: &[(&str, u32, u32)] = &[
+    ("  256px", 256, 1),
+    (" 4096px", 4096, 1),
+    ("1080p  ", 1920, 1080),
+];
+
+/// Relative-linear `f32` pixel bytes spread across `[0, ~2]` (some > 1.0 to
+/// hit the PQ peak clamp); `channels` interleaved, native-endian.
+fn linear_f32(width: u32, height: u32, channels: usize) -> Vec<u8> {
+    let n = width as usize * height as usize * channels;
+    let mut v = Vec::with_capacity(n * 4);
+    for i in 0..n {
+        let x = ((i % 97) as f32) / 48.0;
+        v.extend_from_slice(&x.to_ne_bytes());
+    }
+    v
+}
+
+fn bench_quantize(
+    suite: &mut Suite,
+    name: &str,
+    src_desc: PixelDescriptor,
+    target: PixelDescriptor,
+    channels: usize,
+) {
+    for &(label, width, height) in SIZES {
+        let data = linear_f32(width, height, channels);
+        let buf = PixelBuffer::from_vec(data, width, height, src_desc).unwrap();
+        let input_bytes = (width as usize * height as usize * channels * 4) as u64;
+        let group_name = format!("{name}  {label}");
+        suite.group(group_name, move |g| {
+            g.throughput(Throughput::Bytes(input_bytes));
+            g.bench("quantize_to", move |b| {
+                b.iter(|| {
+                    let out = quantize_to(buf.as_slice(), target).unwrap();
+                    black_box(out);
+                })
+            });
+        });
+    }
+}
+
+fn main() {
+    zenbench::run(|suite| {
+        // RGB f32 linear → RGB16 PQ — the common anchored encode (default 203).
+        bench_quantize(
+            suite,
+            "RGB f32 → PQ16 @203",
+            PixelDescriptor::RGBF32_LINEAR,
+            PixelDescriptor::RGB16_BT2100_PQ,
+            3,
+        );
+        // RGBA f32 linear → RGBA16 PQ — the alpha-preserving path.
+        let rgba_pq = PixelDescriptor::RGBA16
+            .with_transfer(TransferFunction::Pq)
+            .with_primaries(PixelDescriptor::RGB16_BT2100_PQ.primaries);
+        bench_quantize(
+            suite,
+            "RGBA f32 → PQ16 @203",
+            PixelDescriptor::RGBAF32_LINEAR,
+            rgba_pq,
+            4,
+        );
+    });
+}

--- a/zenpixels-convert/src/adapt.rs
+++ b/zenpixels-convert/src/adapt.rs
@@ -262,6 +262,110 @@ pub fn convert_buffer(
     Ok(output)
 }
 
+/// Like [`convert_buffer`] but anchors the **PQ** transfer steps to an
+/// absolute-luminance white point — the cd/m² that relative-linear `1.0`
+/// represents (e.g. [`DiffuseWhite::BT2408`](zenpixels::hdr::DiffuseWhite) =
+/// 203). The PQ kernels then scale by `anchor / 10000` across the
+/// relative-linear ↔ PQ-absolute boundary, so a relative-linear buffer encodes
+/// to PQ at the right brightness with no caller-side pre-scale. Conversions
+/// without a PQ step are identical to [`convert_buffer`].
+///
+/// Runs on the built-in plan path (so the anchored PQ steps are never bypassed
+/// by a CMS matlut fast path). Honors a **strided** source — `src_stride` is the
+/// bytes between row starts (`width * from.bytes_per_pixel()` for packed) — and
+/// converts row-by-row with no pre-pack. Returns a freshly-allocated
+/// [`PixelBuffer`] (its row stride is the buffer's own — no hand-rolled `Vec`).
+/// The plan drives any channel change (e.g. `DropAlpha` for an RGB target, or
+/// alpha-preserving passthrough for an RGBA one), so the caller hands the source
+/// straight in. Alpha, if kept, is never PQ-encoded or anchor-scaled.
+#[track_caller]
+pub(crate) fn convert_buffer_with_anchor(
+    src: &[u8],
+    width: u32,
+    rows: u32,
+    src_stride: usize,
+    from: PixelDescriptor,
+    to: PixelDescriptor,
+    anchor: zenpixels::hdr::DiffuseWhite,
+) -> Result<PixelBuffer, At<ConvertError>> {
+    // Allocate through the existing PixelBuffer machinery (start-aligned,
+    // fallible) rather than a hand-rolled `vec![0u8; …]`, and convert into its
+    // backing at the buffer's own row stride.
+    let mut buf = PixelBuffer::try_new(width, rows, to)
+        .map_err(|_| whereat::at!(ConvertError::AllocationFailed))?;
+    let dst_stride = buf.stride();
+    {
+        let mut slice = buf.as_slice_mut();
+        convert_into_with_anchor(
+            src,
+            width,
+            rows,
+            src_stride,
+            from,
+            to,
+            anchor,
+            slice.as_strided_bytes_mut(),
+            dst_stride,
+        )?;
+    }
+    Ok(buf)
+}
+
+/// Like [`convert_buffer_with_anchor`] but writes into a caller-provided `dst` —
+/// no output allocation. Honors a **strided destination**: `dst_stride` is the
+/// bytes between output row starts (pass `width * to.bytes_per_pixel()` for
+/// packed). `dst` must hold `(rows - 1) * dst_stride + width * to.bpp` bytes and
+/// `dst_stride` must be ≥ the packed row width; otherwise
+/// [`ConvertError::BufferSize`]. The same strided-source / alpha rules apply.
+#[track_caller]
+#[allow(clippy::too_many_arguments)] // mirrors convert_buffer_with_anchor + strided dst
+pub(crate) fn convert_into_with_anchor(
+    src: &[u8],
+    width: u32,
+    rows: u32,
+    src_stride: usize,
+    from: PixelDescriptor,
+    to: PixelDescriptor,
+    anchor: zenpixels::hdr::DiffuseWhite,
+    dst: &mut [u8],
+    dst_stride: usize,
+) -> Result<(), At<ConvertError>> {
+    assert_not_cmyk(&from);
+    assert_not_cmyk(&to);
+
+    let dst_row = (width as usize) * to.bytes_per_pixel();
+    if rows > 0 {
+        // A strided dst must hold each row's content without rows overlapping:
+        // `dst_stride >= dst_row`, and the last row ends at
+        // `(rows-1) * dst_stride + dst_row`.
+        let needed = (rows as usize - 1) * dst_stride + dst_row;
+        if dst_stride < dst_row || dst.len() < needed {
+            return Err(whereat::at!(ConvertError::BufferSize {
+                expected: needed.max(dst_row),
+                actual: dst.len().min(dst_stride),
+            }));
+        }
+    }
+
+    // `from == to` yields an Identity plan, whose row step copies src → dst — so
+    // the strided loop handles it too (no packed-only special case needed).
+    let plan = ConvertPlan::new(from, to).at()?.with_pq_anchor(anchor);
+    let mut converter = RowConverter::from_plan(plan);
+    let src_row = (width as usize) * from.bytes_per_pixel();
+
+    for y in 0..rows as usize {
+        let src_start = y * src_stride;
+        let dst_start = y * dst_stride;
+        converter.convert_row(
+            &src[src_start..src_start + src_row],
+            &mut dst[dst_start..dst_start + dst_row],
+            width,
+        );
+    }
+
+    Ok(())
+}
+
 /// Attempt to adapt a [`PixelBuffer`] to `target` **in place** — no
 /// allocation, no copy of the frame, and the buffer's descriptor /
 /// geometry / color context are updated **atomically** via
@@ -597,6 +701,285 @@ fn contiguous_from_strided<'a>(
             packed.extend_from_slice(&data[start..start + row_bytes]);
         }
         Cow::Owned(packed)
+    }
+}
+
+#[cfg(test)]
+mod anchor_tests {
+    //! `convert_buffer_with_anchor` — proof the absolute-luminance anchor
+    //! threads through the PQ `ConvertStep`s (not via any caller pre-scale),
+    //! that it honors a strided source, and that it preserves alpha.
+    use super::convert_buffer_with_anchor;
+    use crate::{PixelDescriptor, TransferFunction};
+    use alloc::vec;
+    use alloc::vec::Vec;
+    use zenpixels::hdr::DiffuseWhite;
+
+    /// f64 SMPTE ST 2084 inverse-EOTF (linear-light fraction → PQ code [0,1]).
+    fn pq_oetf(x: f64) -> f64 {
+        if x <= 0.0 {
+            return 0.0;
+        }
+        let m1 = 2610.0 / 16384.0;
+        let m2 = 2523.0 / 4096.0 * 128.0;
+        let c1 = 3424.0 / 4096.0;
+        let c2 = 2413.0 / 4096.0 * 32.0;
+        let c3 = 2392.0 / 4096.0 * 32.0;
+        let xp = x.powf(m1);
+        ((c1 + c2 * xp) / (1.0 + c3 * xp)).powf(m2)
+    }
+
+    /// Tight RGB f32 bytes from per-pixel gray values.
+    fn gray_rgb_f32(values: &[f32]) -> Vec<u8> {
+        let mut v = Vec::with_capacity(values.len() * 12);
+        for &g in values {
+            for _ in 0..3 {
+                v.extend_from_slice(&g.to_ne_bytes());
+            }
+        }
+        v
+    }
+
+    /// Tight RGBA f32 bytes: per-pixel gray RGB plus its alpha.
+    fn gray_rgba_f32(pixels: &[(f32, f32)]) -> Vec<u8> {
+        let mut v = Vec::with_capacity(pixels.len() * 16);
+        for &(g, a) in pixels {
+            for _ in 0..3 {
+                v.extend_from_slice(&g.to_ne_bytes());
+            }
+            v.extend_from_slice(&a.to_ne_bytes());
+        }
+        v
+    }
+
+    /// Packed bytes-per-row for `desc` at `width` pixels.
+    fn packed_stride(width: usize, desc: PixelDescriptor) -> usize {
+        width * desc.bytes_per_pixel()
+    }
+
+    fn pq16_target() -> (PixelDescriptor, PixelDescriptor) {
+        let target = PixelDescriptor::RGB16_BT2100_PQ;
+        // Tag the source gamut as the target's so no gamut step is inserted.
+        let lin = PixelDescriptor::RGBF32_LINEAR.with_primaries(target.primaries);
+        (lin, target)
+    }
+
+    #[test]
+    fn anchor_pq16_encode_matches_st2084_oracle() {
+        let values = [0.001f32, 0.1, 1.0, 2.0, 49.0];
+        let (lin, target) = pq16_target();
+        let out = convert_buffer_with_anchor(
+            &gray_rgb_f32(&values),
+            values.len() as u32,
+            1,
+            packed_stride(values.len(), lin),
+            lin,
+            target,
+            DiffuseWhite::BT2408,
+        )
+        .unwrap();
+        let codes: &[u16] = bytemuck::cast_slice(out.as_slice().as_strided_bytes());
+        for (i, &v) in values.iter().enumerate() {
+            let got = i64::from(codes[i * 3]);
+            // 1.0 of relative-linear sits at 203 / 10000 of the PQ-absolute range.
+            let want = (pq_oetf(f64::from(v) * 203.0 / 10_000.0) * 65535.0).round() as i64;
+            assert!(
+                (got - want).abs() <= 1,
+                "@203 at {v}: got {got} want {want}"
+            );
+        }
+    }
+
+    #[test]
+    fn anchor_changes_pq_output_in_kernel() {
+        let (lin, target) = pq16_target();
+        let src = gray_rgb_f32(&[1.0]);
+        let enc = |w: DiffuseWhite| {
+            let o = convert_buffer_with_anchor(&src, 1, 1, packed_stride(1, lin), lin, target, w)
+                .unwrap();
+            let ob = o.as_slice().as_strided_bytes();
+            i64::from(u16::from_ne_bytes([ob[0], ob[1]]))
+        };
+        let c100 = enc(DiffuseWhite::new(100.0));
+        let c203 = enc(DiffuseWhite::BT2408);
+        // The same relative-linear 1.0 lands at a different PQ code per anchor —
+        // i.e. the scale is applied inside the kernel, not by a caller.
+        assert_ne!(c100, c203);
+        let want100 = (pq_oetf(100.0 / 10_000.0) * 65535.0).round() as i64;
+        assert!(
+            (c100 - want100).abs() <= 1,
+            "@100: got {c100} want {want100}"
+        );
+    }
+
+    #[test]
+    fn anchor_pq16_decode_divides_and_roundtrips() {
+        // linear @ 203 → PQ16 → linear @ 203 recovers the input: the decode
+        // kernel's ÷scale is the exact inverse of the encode's ×scale.
+        let values = [0.05f32, 0.2, 1.0, 5.0];
+        let (lin, target) = pq16_target();
+        let pq = convert_buffer_with_anchor(
+            &gray_rgb_f32(&values),
+            values.len() as u32,
+            1,
+            packed_stride(values.len(), lin),
+            lin,
+            target,
+            DiffuseWhite::BT2408,
+        )
+        .unwrap();
+        let back = convert_buffer_with_anchor(
+            pq.as_slice().as_strided_bytes(),
+            values.len() as u32,
+            1,
+            pq.stride(),
+            target,
+            lin,
+            DiffuseWhite::BT2408,
+        )
+        .unwrap();
+        let backf: &[f32] = bytemuck::cast_slice(back.as_slice().as_strided_bytes());
+        for (i, &v) in values.iter().enumerate() {
+            let got = backf[i * 3];
+            let rel = ((f64::from(got) - f64::from(v)) / f64::from(v)).abs();
+            assert!(rel < 0.02, "roundtrip @203 at {v}: got {got} (rel {rel})");
+        }
+    }
+
+    #[test]
+    fn anchor_threads_through_f32_pq_slice_kernel() {
+        // RGBF32 linear → RGBF32 PQ exercises the SIMD slice kernel
+        // (LinearF32ToPqF32), a different code path than the u16 kernel.
+        let values = [0.1f32, 1.0, 4.0];
+        let target = PixelDescriptor::RGB16_BT2100_PQ;
+        let lin = PixelDescriptor::RGBF32_LINEAR.with_primaries(target.primaries);
+        let pqf32 = lin.with_transfer(TransferFunction::Pq);
+        let out = convert_buffer_with_anchor(
+            &gray_rgb_f32(&values),
+            values.len() as u32,
+            1,
+            packed_stride(values.len(), lin),
+            lin,
+            pqf32,
+            DiffuseWhite::BT2408,
+        )
+        .unwrap();
+        let encoded: &[f32] = bytemuck::cast_slice(out.as_slice().as_strided_bytes());
+        for (i, &v) in values.iter().enumerate() {
+            let got = f64::from(encoded[i * 3]);
+            let want = pq_oetf(f64::from(v) * 203.0 / 10_000.0);
+            assert!(
+                (got - want).abs() < 1e-3,
+                "f32 PQ @203 at {v}: got {got} want {want}"
+            );
+        }
+    }
+
+    #[test]
+    fn no_anchor_default_is_unscaled() {
+        // DiffuseWhite at 10000 nits ⇒ scale 1.0 ⇒ the kernel treats linear as
+        // already PQ-absolute (the prior behavior). 1.0 linear → PQ code 65535.
+        let (lin, target) = pq16_target();
+        let out = convert_buffer_with_anchor(
+            &gray_rgb_f32(&[1.0]),
+            1,
+            1,
+            packed_stride(1, lin),
+            lin,
+            target,
+            DiffuseWhite::new(10_000.0),
+        )
+        .unwrap();
+        let ob = out.as_slice().as_strided_bytes();
+        assert_eq!(u16::from_ne_bytes([ob[0], ob[1]]), 65535);
+    }
+
+    #[test]
+    fn anchor_preserves_alpha_through_rgba_pq16() {
+        // RGBA f32 linear → RGBA16 PQ: the RGB lanes take the PQ OETF + anchor;
+        // alpha rides through linearly (never PQ-encoded, never anchor-scaled) —
+        // the alpha-preserving `_rgba_slice` kernel path.
+        let rgb_pq = PixelDescriptor::RGB16_BT2100_PQ;
+        let src = PixelDescriptor::RGBAF32_LINEAR.with_primaries(rgb_pq.primaries);
+        let target = PixelDescriptor::RGBA16
+            .with_transfer(TransferFunction::Pq)
+            .with_primaries(rgb_pq.primaries);
+        let pixels = [(1.0f32, 0.5f32), (2.0, 0.25)];
+        let out = convert_buffer_with_anchor(
+            &gray_rgba_f32(&pixels),
+            pixels.len() as u32,
+            1,
+            packed_stride(pixels.len(), src),
+            src,
+            target,
+            DiffuseWhite::BT2408,
+        )
+        .unwrap();
+        let codes: &[u16] = bytemuck::cast_slice(out.as_slice().as_strided_bytes());
+        for (i, &(g, a)) in pixels.iter().enumerate() {
+            let r = i64::from(codes[i * 4]);
+            let want_rgb = (pq_oetf(f64::from(g) * 203.0 / 10_000.0) * 65535.0).round() as i64;
+            assert!(
+                (r - want_rgb).abs() <= 1,
+                "rgb @203 at {g}: got {r} want {want_rgb}"
+            );
+            // Alpha is linear → u16; PQ-encoding it would give a wildly wrong code.
+            let alpha = codes[i * 4 + 3];
+            let want_a = (f64::from(a) * 65535.0).round() as u16;
+            assert_eq!(
+                alpha, want_a,
+                "alpha must pass through linearly: got {alpha} want {want_a}"
+            );
+        }
+    }
+
+    #[test]
+    fn anchor_honors_source_stride() {
+        // A padded source stride with sentinel padding (999.0, which would clip
+        // to 65535 if it leaked) must convert identically to the packed source.
+        let (lin, target) = pq16_target();
+        let row_vals = [0.1f32, 1.0, 3.0];
+        let width = row_vals.len() as u32;
+        let rows = 2u32;
+        let row = packed_stride(row_vals.len(), lin);
+        let stride = row + 2 * 12; // two sentinel pixels of padding per row
+
+        let mut packed = gray_rgb_f32(&row_vals);
+        packed.extend_from_slice(&gray_rgb_f32(&row_vals));
+        let want = convert_buffer_with_anchor(
+            &packed,
+            width,
+            rows,
+            row,
+            lin,
+            target,
+            DiffuseWhite::BT2408,
+        )
+        .unwrap();
+
+        let mut strided = vec![0u8; stride * rows as usize];
+        for y in 0..rows as usize {
+            let s = y * stride;
+            strided[s..s + row].copy_from_slice(&gray_rgb_f32(&row_vals));
+            for b in strided[s + row..s + stride].chunks_exact_mut(4) {
+                b.copy_from_slice(&999.0f32.to_ne_bytes());
+            }
+        }
+        let got = convert_buffer_with_anchor(
+            &strided,
+            width,
+            rows,
+            stride,
+            lin,
+            target,
+            DiffuseWhite::BT2408,
+        )
+        .unwrap();
+        assert_eq!(
+            got.as_slice().as_strided_bytes(),
+            want.as_slice().as_strided_bytes(),
+            "strided source must convert identically to packed"
+        );
     }
 }
 

--- a/zenpixels-convert/src/convert.rs
+++ b/zenpixels-convert/src/convert.rs
@@ -25,6 +25,14 @@ pub struct ConvertPlan {
     pub(crate) from: PixelDescriptor,
     pub(crate) to: PixelDescriptor,
     pub(crate) steps: Vec<ConvertStep>,
+    /// Relative-linear → PQ-absolute scale = `diffuse_white_nits / 10000`,
+    /// applied by the PQ kernels (encode multiplies pre-OETF, decode divides
+    /// post-EOTF). `1.0` is the unsignaled default and means "treat linear as
+    /// already PQ-absolute (1.0 = 10000 cd/m²)" — i.e. exactly the prior
+    /// behavior, so plans built without an anchor are byte-for-byte unchanged.
+    /// Set via [`with_pq_anchor`](Self::with_pq_anchor). HLG steps ignore it
+    /// (scene-referred — different anchoring, out of scope here).
+    pub(crate) pq_anchor_scale: f32,
 }
 
 /// A single conversion step.
@@ -268,6 +276,39 @@ fn assert_not_cmyk(desc: &PixelDescriptor) {
 }
 
 impl ConvertPlan {
+    /// Assemble a plan with the default (no-anchor) PQ scale. The single place
+    /// `pq_anchor_scale` is defaulted, so every construction path starts at the
+    /// behavior-preserving `1.0`.
+    fn build(from: PixelDescriptor, to: PixelDescriptor, steps: Vec<ConvertStep>) -> Self {
+        Self {
+            from,
+            to,
+            steps,
+            pq_anchor_scale: 1.0,
+        }
+    }
+
+    /// Anchor this plan's **PQ** steps to an absolute-luminance white point —
+    /// the cd/m² that relative-linear `1.0` represents (e.g.
+    /// [`DiffuseWhite::BT2408`](zenpixels::hdr::DiffuseWhite::BT2408) = 203).
+    ///
+    /// The PQ kernels then scale by `nits / 10000` across the relative-linear ↔
+    /// PQ-absolute boundary (encode multiplies before the OETF, decode divides
+    /// after the EOTF), so a relative-linear buffer maps to PQ at the right
+    /// brightness without the caller pre-scaling. A decode+encode pair in one
+    /// plan shares the scale and round-trips exactly. The BT.2408 default (203)
+    /// reproduces the byte-parity-verified pre-scale that `quantize_to` used to
+    /// do by hand. HLG steps are unaffected (scene-referred anchoring differs).
+    #[must_use]
+    pub(crate) fn with_pq_anchor(mut self, anchor: zenpixels::hdr::DiffuseWhite) -> Self {
+        // `diffuse_white_nits` / `PQ_PEAK_NITS` makes the unit explicit: the scale
+        // is the fraction of PQ's 10000 cd/m² peak that relative-linear 1.0 sits at.
+        let diffuse_white_nits = f64::from(anchor.nits());
+        const PQ_PEAK_NITS: f64 = 10_000.0;
+        self.pq_anchor_scale = (diffuse_white_nits / PQ_PEAK_NITS) as f32;
+        self
+    }
+
     /// Create a conversion plan from `from` to `to`.
     ///
     /// Returns `Err` if no conversion path exists. A
@@ -285,11 +326,7 @@ impl ConvertPlan {
         assert_not_cmyk(&from);
         assert_not_cmyk(&to);
         if from == to {
-            return Ok(Self {
-                from,
-                to,
-                steps: vec![ConvertStep::Identity],
-            });
+            return Ok(Self::build(from, to, vec![ConvertStep::Identity]));
         }
 
         // Refuse signal-range crossings: no Narrow↔Full steps exist (no
@@ -301,6 +338,24 @@ impl ConvertPlan {
         // range is preserved verbatim or the conversion fails loudly.
         // Same-range plans (including Narrow→Narrow) are unaffected.
         if from.signal_range != to.signal_range {
+            return Err(whereat::at!(ConvertError::NoPath { from, to }));
+        }
+
+        // Refuse HLG↔PQ. HLG is scene-referred — these kernels apply only its
+        // OETF, with no OOTF and no `Lw`/peak — while PQ is absolute display
+        // light (cd/m²). Routing one to the other through the shared "linear"
+        // intermediate conflates the two luminance domains by orders of
+        // magnitude (scene-normalized [0,1] vs absolute [0,10000 cd/m²]): a
+        // deterministic but grossly **wrong** result. Until the OOTF +
+        // `(diffuse_white, Lw)` threading lands (#45 S2), fail loudly rather than
+        // emit wrong pixels — the same posture as the signal-range refusal.
+        // HLG↔SDR/linear are *not* refused here: those stay within a normalized
+        // domain (endpoint-correct), missing only the mid-tone OOTF gamma.
+        if matches!(
+            (from.transfer(), to.transfer()),
+            (TransferFunction::Hlg, TransferFunction::Pq)
+                | (TransferFunction::Pq, TransferFunction::Hlg)
+        ) {
             return Err(whereat::at!(ConvertError::NoPath { from, to }));
         }
 
@@ -509,7 +564,7 @@ impl ConvertPlan {
                         steps.push(ConvertStep::Identity);
                     }
                     fuse_matlut_patterns(&mut steps);
-                    return Ok(Self { from, to, steps });
+                    return Ok(Self::build(from, to, steps));
                 }
                 if desc.channel_type() == ChannelType::U8
                     && matches!(desc.transfer(), TransferFunction::Srgb)
@@ -525,7 +580,7 @@ impl ConvertPlan {
                         steps.push(ConvertStep::Identity);
                     }
                     fuse_matlut_patterns(&mut steps);
-                    return Ok(Self { from, to, steps });
+                    return Ok(Self::build(from, to, steps));
                 }
                 if desc.channel_type() == ChannelType::F32
                     && desc.transfer() == TransferFunction::Linear
@@ -541,7 +596,7 @@ impl ConvertPlan {
                         steps.push(ConvertStep::Identity);
                     }
                     fuse_matlut_patterns(&mut steps);
-                    return Ok(Self { from, to, steps });
+                    return Ok(Self::build(from, to, steps));
                 }
                 if desc.channel_type() != ChannelType::F32 {
                     // Use the fused sRGB u8→linear f32 if applicable.
@@ -605,7 +660,7 @@ impl ConvertPlan {
         // kernels that avoid scratch-buffer round-trips.
         fuse_matlut_patterns(&mut steps);
 
-        Ok(Self { from, to, steps })
+        Ok(Self::build(from, to, steps))
     }
 
     /// Create a conversion plan with explicit policy enforcement.
@@ -731,11 +786,7 @@ impl ConvertPlan {
     /// plan exists only for `from()`/`to()` metadata; the actual row
     /// work is driven by the external transform stored on `RowConverter`.
     pub(crate) fn identity(from: PixelDescriptor, to: PixelDescriptor) -> Self {
-        Self {
-            from,
-            to,
-            steps: vec![ConvertStep::Identity],
-        }
+        Self::build(from, to, vec![ConvertStep::Identity])
     }
 
     /// Compose two plans into one: apply `self` then `other`.
@@ -791,11 +842,10 @@ impl ConvertPlan {
             }
         }
 
-        Some(Self {
-            from: self.from,
-            to: other.to,
-            steps,
-        })
+        // Composition runs at plan-build time, before any anchor is attached
+        // (`with_pq_anchor` is applied to the finished plan), so both inputs
+        // carry the default scale; the merged plan does too.
+        Some(Self::build(self.from, other.to, steps))
     }
 
     /// True if conversion is a no-op.
@@ -1339,7 +1389,15 @@ pub fn convert_row(plan: &ConvertPlan, src: &[u8], dst: &mut [u8], width: u32) {
     }
 
     if plan.steps.len() == 1 {
-        apply_step_u8(&plan.steps[0], src, dst, width, plan.from, plan.to);
+        apply_step_u8(
+            &plan.steps[0],
+            src,
+            dst,
+            width,
+            plan.from,
+            plan.to,
+            plan.pq_anchor_scale,
+        );
         return;
     }
 
@@ -1366,7 +1424,15 @@ pub(crate) fn convert_row_buffered(
     }
 
     if plan.steps.len() == 1 {
-        apply_step_u8(&plan.steps[0], src, dst, width, plan.from, plan.to);
+        apply_step_u8(
+            &plan.steps[0],
+            src,
+            dst,
+            width,
+            plan.from,
+            plan.to,
+            plan.pq_anchor_scale,
+        );
         return;
     }
 
@@ -1396,7 +1462,15 @@ pub(crate) fn convert_row_buffered(
         if i % 2 == 0 {
             let input = if i == 0 { src } else { &buf_b[..curr_len] };
             if is_last {
-                apply_step_u8(step, input, dst, width, current_desc, next_desc);
+                apply_step_u8(
+                    step,
+                    input,
+                    dst,
+                    width,
+                    current_desc,
+                    next_desc,
+                    plan.pq_anchor_scale,
+                );
             } else {
                 apply_step_u8(
                     step,
@@ -1405,12 +1479,21 @@ pub(crate) fn convert_row_buffered(
                     width,
                     current_desc,
                     next_desc,
+                    plan.pq_anchor_scale,
                 );
             }
         } else {
             let input = &buf_a[..curr_len];
             if is_last {
-                apply_step_u8(step, input, dst, width, current_desc, next_desc);
+                apply_step_u8(
+                    step,
+                    input,
+                    dst,
+                    width,
+                    current_desc,
+                    next_desc,
+                    plan.pq_anchor_scale,
+                );
             } else {
                 apply_step_u8(
                     step,
@@ -1419,6 +1502,7 @@ pub(crate) fn convert_row_buffered(
                     width,
                     current_desc,
                     next_desc,
+                    plan.pq_anchor_scale,
                 );
             }
         }

--- a/zenpixels-convert/src/convert_kernels.rs
+++ b/zenpixels-convert/src/convert_kernels.rs
@@ -28,6 +28,9 @@ pub(super) fn apply_step_u8(
     width: u32,
     from: PixelDescriptor,
     _to: PixelDescriptor,
+    // Relative-linear → PQ-absolute scale (`diffuse_white / 10000`) carried by
+    // the plan. Only the PQ kernels read it; `1.0` is a no-op for all steps.
+    pq_scale: f32,
 ) {
     crate::__trace_ops::record_step(step);
     let w = width as usize;
@@ -131,19 +134,19 @@ pub(super) fn apply_step_u8(
         }
 
         ConvertStep::PqU16ToLinearF32 => {
-            pq_u16_to_linear_f32(src, dst, w, from.layout().channels());
+            pq_u16_to_linear_f32(src, dst, w, from.layout().channels(), pq_scale);
         }
 
         ConvertStep::LinearF32ToPqU16 => {
-            linear_f32_to_pq_u16(src, dst, w, from.layout().channels());
+            linear_f32_to_pq_u16(src, dst, w, from.layout().channels(), pq_scale);
         }
 
         ConvertStep::PqF32ToLinearF32 => {
-            pq_f32_to_linear_f32(src, dst, w, from.layout().channels());
+            pq_f32_to_linear_f32(src, dst, w, from.layout().channels(), pq_scale);
         }
 
         ConvertStep::LinearF32ToPqF32 => {
-            linear_f32_to_pq_f32(src, dst, w, from.layout().channels());
+            linear_f32_to_pq_f32(src, dst, w, from.layout().channels(), pq_scale);
         }
 
         ConvertStep::HlgU16ToLinearF32 => {
@@ -1571,77 +1574,250 @@ pub(crate) fn pq_oetf(v: f32) -> f32 {
     linear_srgb::tf::linear_to_pq(v)
 }
 
-/// PQ U16 → Linear F32 (EOTF applied during depth conversion).
-fn pq_u16_to_linear_f32(src: &[u8], dst: &mut [u8], width: usize, channels: usize) {
+/// Per-tier SIMD body for [`multiply_color_channels`]. `channels == 4` builds a
+/// `[f, f, f, 1]`-repeating multiplier so the alpha lane (every 4th) is left
+/// **untouched**; any other channel count scales every lane uniformly. The
+/// 16-lane chunk is exactly 4 RGBA pixels, so the pattern stays pixel-aligned
+/// across the whole row, and `count` being a multiple of `channels` keeps the
+/// remainder pixel-aligned too.
+#[archmage::magetypes(define(f32x16), v4(cfg(avx512)), v3, neon, wasm128, scalar)]
+fn multiply_color_channels_tier(token: Token, buf: &mut [f32], channels: usize, factor: f32) {
+    let mul = if channels == 4 {
+        f32x16::from_array(
+            token,
+            [
+                factor, factor, factor, 1.0, factor, factor, factor, 1.0, factor, factor, factor,
+                1.0, factor, factor, factor, 1.0,
+            ],
+        )
+    } else {
+        f32x16::from_array(token, [factor; 16])
+    };
+    let (chunks, remainder) = buf.as_chunks_mut::<16>();
+    for chunk in chunks {
+        let v = f32x16::from_array(token, *chunk);
+        *chunk = (v * mul).to_array();
+    }
+    if channels == 4 {
+        for px in remainder.chunks_exact_mut(4) {
+            px[0] *= factor;
+            px[1] *= factor;
+            px[2] *= factor;
+        }
+    } else {
+        for v in remainder {
+            *v *= factor;
+        }
+    }
+}
+
+/// Multiply the color channels of an interleaved `f32` buffer by `factor`,
+/// SIMD-dispatched (AVX-512/AVX2/SSE/NEON/WASM via `magetypes`).
+///
+/// **With alpha** (`channels == 4`): the R/G/B lanes are scaled and the alpha
+/// lane is preserved — alpha is not luminance, so an absolute-luminance anchor
+/// never applies to it. **Without alpha** (any other `channels`): every lane is
+/// a color channel and is scaled uniformly. `factor == 1.0` is an early-out
+/// (`x * 1.0 == x`), so the un-anchored path is bit-for-bit the plain result.
+pub(crate) fn multiply_color_channels(buf: &mut [f32], channels: usize, factor: f32) {
+    if factor == 1.0 {
+        return;
+    }
+    incant!(
+        multiply_color_channels_tier(buf, channels, factor),
+        [v4, v3, neon, wasm128, scalar]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Vendored **precise** SIMD PQ (exact SMPTE ST 2084)
+// ---------------------------------------------------------------------------
+//
+// `linear_srgb::default`'s PQ slice uses a rational-polynomial fit whose valid
+// range starts at v≈0.02 (its *scalar* path switches to an exact `powf` below
+// that); applied as a slice it extrapolates the poly all the way to 0, so the
+// tight U16 → f32 → U16 round-trip drifts up to ~256 codes near black. We vendor
+// the **exact** ST 2084 formula and evaluate it in SIMD with magetypes' precise
+// `pow`, giving full-range precision (round-trip ≤1) while staying SIMD. The
+// scalar remainder defers to `linear_srgb::tf` (exact-below-threshold). Operates
+// on every lane; the kernels restore any alpha lane afterward (alpha is linear).
+// Canonical SMPTE ST 2084 constants (m1 = 2610/16384, m2 = 2523·128/4096, etc.),
+// written in their exact rational decimal form — all are exactly f32-representable
+// even though the literals run longer than the shortest round-trip.
+#[allow(clippy::excessive_precision)]
+const PQ_M1: f32 = 0.1593017578125;
+#[allow(clippy::excessive_precision)]
+const PQ_M2: f32 = 78.84375;
+#[allow(clippy::excessive_precision)]
+const PQ_C1: f32 = 0.8359375;
+#[allow(clippy::excessive_precision)]
+const PQ_C2: f32 = 18.8515625;
+#[allow(clippy::excessive_precision)]
+const PQ_C3: f32 = 18.6875;
+
+/// PQ EOTF (signal → linear), exact, precise SIMD.
+#[archmage::magetypes(define(f32x16), v4(cfg(avx512)), v3, neon, wasm128, scalar)]
+fn pq_eotf_slice_tier(token: Token, buf: &mut [f32]) {
+    let zero = f32x16::splat(token, 0.0);
+    let c1 = f32x16::splat(token, PQ_C1);
+    let c2 = f32x16::splat(token, PQ_C2);
+    let c3 = f32x16::splat(token, PQ_C3);
+    let (chunks, rem) = buf.as_chunks_mut::<16>();
+    for chunk in chunks {
+        let v = f32x16::from_array(token, *chunk).max(zero);
+        let vp = v.pow_midp_precise(1.0 / PQ_M2);
+        let num = (vp - c1).max(zero);
+        let den = c2 - c3 * vp;
+        let lin = (num / den).pow_midp_precise(1.0 / PQ_M1);
+        *chunk = f32x16::blend(v.simd_le(zero), zero, lin).to_array();
+    }
+    for v in rem {
+        *v = linear_srgb::tf::pq_to_linear(*v);
+    }
+}
+
+/// PQ inverse-EOTF / OETF (linear → signal), exact, precise SIMD.
+#[archmage::magetypes(define(f32x16), v4(cfg(avx512)), v3, neon, wasm128, scalar)]
+fn pq_oetf_slice_tier(token: Token, buf: &mut [f32]) {
+    let zero = f32x16::splat(token, 0.0);
+    let one = f32x16::splat(token, 1.0);
+    let c1 = f32x16::splat(token, PQ_C1);
+    let c2 = f32x16::splat(token, PQ_C2);
+    let c3 = f32x16::splat(token, PQ_C3);
+    let (chunks, rem) = buf.as_chunks_mut::<16>();
+    for chunk in chunks {
+        let v = f32x16::from_array(token, *chunk).max(zero);
+        let vp = v.pow_midp_precise(PQ_M1);
+        let sig = ((c1 + c2 * vp) / (one + c3 * vp)).pow_midp_precise(PQ_M2);
+        *chunk = f32x16::blend(v.simd_le(zero), zero, sig).to_array();
+    }
+    for v in rem {
+        *v = linear_srgb::tf::linear_to_pq(*v);
+    }
+}
+
+/// PQ EOTF over an interleaved f32 slice, every lane (precise SIMD).
+pub(crate) fn pq_eotf_slice(buf: &mut [f32]) {
+    incant!(pq_eotf_slice_tier(buf), [v4, v3, neon, wasm128, scalar]);
+}
+
+/// PQ OETF over an interleaved f32 slice, every lane (precise SIMD).
+pub(crate) fn pq_oetf_slice(buf: &mut [f32]) {
+    incant!(pq_oetf_slice_tier(buf), [v4, v3, neon, wasm128, scalar]);
+}
+
+/// PQ U16 → Linear F32 (EOTF during depth conversion), alpha-preserving.
+///
+/// Widens the U16 codes (`garb` SIMD) and applies the precise SIMD PQ EOTF
+/// ([`pq_eotf_slice`]) to land relative-linear, dividing the RGB lanes by `scale`
+/// (`diffuse_white / 10000`). The EOTF runs over every lane; for `channels == 4`
+/// the alpha lane is then overwritten with its (un-transformed, un-anchored)
+/// linear value. `scale == 1.0` is the identity anchor.
+fn pq_u16_to_linear_f32(src: &[u8], dst: &mut [u8], width: usize, channels: usize, scale: f32) {
     let count = width * channels;
-    let src16: &[u16] = bytemuck::cast_slice(&src[..count * 2]);
+    garb::bytes::convert_u16_to_f32(&src[..count * 2], &mut dst[..count * 4])
+        .expect("pre-validated row size");
     let dstf: &mut [f32] = bytemuck::cast_slice_mut(&mut dst[..count * 4]);
-    pq_u16_to_linear_f32_inner(src16, dstf);
-}
-
-#[autoversion]
-fn pq_u16_to_linear_f32_inner(src: &[u16], dst: &mut [f32]) {
-    for (s, d) in src.chunks_exact(16).zip(dst.chunks_exact_mut(16)) {
-        for i in 0..16 {
-            d[i] = linear_srgb::tf::pq_to_linear(s[i] as f32 / 65535.0);
-        }
-    }
-    let rem = src.len() % 16;
-    if rem > 0 {
-        let off = src.len() - rem;
-        for i in 0..rem {
-            dst[off + i] = linear_srgb::tf::pq_to_linear(src[off + i] as f32 / 65535.0);
+    pq_eotf_slice(&mut dstf[..count]);
+    multiply_color_channels(&mut dstf[..count], channels, 1.0 / scale);
+    if channels == 4 {
+        let src16: &[u16] = bytemuck::cast_slice(&src[..count * 2]);
+        for (i, px) in dstf[..count].chunks_exact_mut(4).enumerate() {
+            px[3] = f32::from(src16[i * 4 + 3]) / 65535.0;
         }
     }
 }
 
-/// Linear F32 → PQ U16 (OETF applied during depth conversion).
-fn linear_f32_to_pq_u16(src: &[u8], dst: &mut [u8], width: usize, channels: usize) {
+/// Linear F32 → PQ U16 (OETF during depth conversion), alpha-preserving.
+///
+/// Anchors the RGB lanes (`× scale`, negatives → 0), applies the precise SIMD PQ
+/// OETF ([`pq_oetf_slice`]) in fixed stack-sized chunks (the U16 output is
+/// half-width, so it cannot host the in-place f32 transform), then narrows to U16
+/// (`garb` SIMD). For `channels == 4` the alpha lane is overwritten with its
+/// linear → U16 value (never OETF'd or anchored). `scale == 1.0` is the identity.
+fn linear_f32_to_pq_u16(src: &[u8], dst: &mut [u8], width: usize, channels: usize, scale: f32) {
     let count = width * channels;
     let srcf: &[f32] = bytemuck::cast_slice(&src[..count * 4]);
-    let dst16: &mut [u16] = bytemuck::cast_slice_mut(&mut dst[..count * 2]);
-    linear_f32_to_pq_u16_inner(srcf, dst16);
+    // CHUNK is a multiple of 16 (SIMD width) and 4 (RGBA grouping), and `count`
+    // is a multiple of `channels`, so every chunk boundary stays pixel-aligned.
+    const CHUNK: usize = 1024;
+    let mut buf = [0.0f32; CHUNK];
+    let mut off = 0;
+    while off < count {
+        let n = min(count - off, CHUNK);
+        let b = &mut buf[..n];
+        b.copy_from_slice(&srcf[off..off + n]);
+        multiply_color_channels(b, channels, scale);
+        pq_oetf_slice(b);
+        garb::bytes::convert_f32_to_u16(
+            bytemuck::cast_slice(&b[..]),
+            &mut dst[off * 2..(off + n) * 2],
+        )
+        .expect("pre-validated row size");
+        if channels == 4 {
+            let dst16: &mut [u16] = bytemuck::cast_slice_mut(&mut dst[off * 2..(off + n) * 2]);
+            for (k, px) in dst16.chunks_exact_mut(4).enumerate() {
+                let a = srcf[off + k * 4 + 3];
+                px[3] = (a.clamp(0.0, 1.0) * 65535.0 + 0.5) as u16;
+            }
+        }
+        off += n;
+    }
 }
 
-#[autoversion]
-fn linear_f32_to_pq_u16_inner(src: &[f32], dst: &mut [u16]) {
-    for (s, d) in src.chunks_exact(16).zip(dst.chunks_exact_mut(16)) {
-        for i in 0..16 {
-            let encoded = linear_srgb::tf::linear_to_pq(s[i].max(0.0));
-            d[i] = (encoded.clamp(0.0, 1.0) * 65535.0 + 0.5) as u16;
-        }
-    }
-    let rem = src.len() % 16;
-    if rem > 0 {
-        let off = src.len() - rem;
-        for i in 0..rem {
-            let encoded = linear_srgb::tf::linear_to_pq(src[off + i].max(0.0));
-            dst[off + i] = (encoded.clamp(0.0, 1.0) * 65535.0 + 0.5) as u16;
-        }
-    }
-}
-
-/// PQ F32 → Linear F32 (EOTF, same depth). SIMD-dispatched.
-fn pq_f32_to_linear_f32(src: &[u8], dst: &mut [u8], width: usize, channels: usize) {
+/// PQ F32 → Linear F32 (EOTF, same depth), alpha-preserving. Precise SIMD.
+///
+/// `scale` is the `diffuse_white / 10000` anchor (see [`pq_u16_to_linear_f32`]);
+/// the RGB lanes are divided by it after the EOTF and, for `channels == 4`, the
+/// alpha lane is restored to its (un-transformed) input. `scale == 1.0` is a
+/// no-op so the un-anchored result depends only on [`pq_eotf_slice`].
+fn pq_f32_to_linear_f32(src: &[u8], dst: &mut [u8], width: usize, channels: usize, scale: f32) {
     let count = width * channels;
     let srcf: &[f32] = bytemuck::cast_slice(&src[..count * 4]);
     let dstf: &mut [f32] = bytemuck::cast_slice_mut(&mut dst[..count * 4]);
     dstf[..count].copy_from_slice(&srcf[..count]);
-    linear_srgb::default::pq_to_linear_slice(&mut dstf[..count]);
+    pq_eotf_slice(&mut dstf[..count]);
+    multiply_color_channels(&mut dstf[..count], channels, 1.0 / scale);
+    if channels == 4 {
+        for (i, px) in dstf[..count].chunks_exact_mut(4).enumerate() {
+            px[3] = srcf[i * 4 + 3];
+        }
+    }
 }
 
-/// Linear F32 → PQ F32 (OETF, same depth). SIMD-dispatched.
-fn linear_f32_to_pq_f32(src: &[u8], dst: &mut [u8], width: usize, channels: usize) {
+/// Linear F32 → PQ F32 (OETF, same depth), alpha-preserving. Precise SIMD.
+///
+/// `scale` is the `diffuse_white / 10000` anchor (see [`linear_f32_to_pq_u16`]);
+/// the RGB lanes are multiplied by it before the OETF and, for `channels == 4`,
+/// the alpha lane is restored to its (un-transformed) linear input.
+fn linear_f32_to_pq_f32(src: &[u8], dst: &mut [u8], width: usize, channels: usize, scale: f32) {
     let count = width * channels;
     let srcf: &[f32] = bytemuck::cast_slice(&src[..count * 4]);
     let dstf: &mut [f32] = bytemuck::cast_slice_mut(&mut dst[..count * 4]);
     dstf[..count].copy_from_slice(&srcf[..count]);
-    linear_srgb::default::linear_to_pq_slice(&mut dstf[..count]);
+    multiply_color_channels(&mut dstf[..count], channels, scale);
+    pq_oetf_slice(&mut dstf[..count]);
+    if channels == 4 {
+        for (i, px) in dstf[..count].chunks_exact_mut(4).enumerate() {
+            px[3] = srcf[i * 4 + 3];
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
 // HLG (ARIB STD-B67) transfer function — delegates to linear-srgb
 // ---------------------------------------------------------------------------
+//
+// PHOTOMETRY HAZARD: these kernels apply only the HLG OETF/inverse-OETF, which
+// produce **scene-referred, normalized** linear ([0,1], no absolute luminance,
+// no OOTF). PQ's linear is **absolute display** light (cd/m²). So a planned
+// HLG↔PQ conversion (HLG-EOTF → "linear" → PQ-OETF) is mechanically defined but
+// **not photometrically correct** — it conflates the two domains, skipping the
+// HLG OOTF (system γ ≈ 1.2 + 0.42·log10(Lw/1000)) and the peak-luminance (Lw)
+// mapping. Correct HLG↔PQ needs `(diffuse_white, Lw)` threaded through these
+// steps + the OOTF (zentone::hlg) — tracked for a follow-up; deliberately out of
+// the PQ-only scope here. `quantize_to` already refuses HLG targets for this
+// reason; the general `convert_*` path does not yet guard it.
 
 /// HLG OETF: scene-linear [0,1] → encoded [0,1].
 ///

--- a/zenpixels-convert/src/converter.rs
+++ b/zenpixels-convert/src/converter.rs
@@ -830,27 +830,52 @@ mod tests {
     }
 
     #[test]
-    fn pq_to_hlg_via_linear_f32() {
-        let pq = PixelDescriptor::new(
-            ChannelType::F32,
-            ChannelLayout::Rgb,
-            None,
-            TransferFunction::Pq,
-        );
-        let hlg = PixelDescriptor::new(
+    fn hlg_pq_conversion_refuses() {
+        // HLG↔PQ conflates scene-normalized HLG with absolute-nits PQ (no OOTF/
+        // `Lw`) — a gross brightness error — so the planner refuses with `NoPath`,
+        // the signal-range-refusal posture. HLG↔SDR and HLG↔Linear stay allowed
+        // (endpoint-correct; only the OOTF mid-tone gamma is missing). Correct
+        // HLG↔PQ is #45 S2's OOTF threading.
+        let hlg_f32 = PixelDescriptor::new(
             ChannelType::F32,
             ChannelLayout::Rgb,
             None,
             TransferFunction::Hlg,
         );
-        let src_f: [f32; 3] = [0.0, 0.5, 1.0];
-        let src: &[u8] = bytemuck::cast_slice(&src_f);
-        let dst = convert_pixel(pq, hlg, src);
-        let f: &[f32] = bytemuck::cast_slice(&dst);
-        // PQ 0 → HLG 0.
-        assert_eq!(f[0], 0.0);
-        // PQ 0.5 → some HLG value.
-        assert!(f[1] > 0.0 && f[1] <= 1.0);
+        let pq_f32 = PixelDescriptor::new(
+            ChannelType::F32,
+            ChannelLayout::Rgb,
+            None,
+            TransferFunction::Pq,
+        );
+        match RowConverter::new(hlg_f32, pq_f32) {
+            Err(e) => assert!(matches!(*e.error(), ConvertError::NoPath { .. })),
+            Ok(_) => panic!("HLG→PQ must refuse, not emit wrong pixels"),
+        }
+        // Both directions and the u16 form refuse.
+        assert!(RowConverter::new(pq_f32, hlg_f32).is_err());
+        assert!(
+            RowConverter::new(
+                PixelDescriptor::RGB16_BT2100_HLG,
+                PixelDescriptor::RGB16_BT2100_PQ
+            )
+            .is_err()
+        );
+        // HLG↔SDR and HLG↔Linear are NOT refused (only HLG↔PQ is).
+        assert!(
+            RowConverter::new(
+                PixelDescriptor::RGB16_BT2100_HLG,
+                PixelDescriptor::RGB8_SRGB
+            )
+            .is_ok()
+        );
+        let lin = PixelDescriptor::new(
+            ChannelType::F32,
+            ChannelLayout::Rgb,
+            None,
+            TransferFunction::Linear,
+        );
+        assert!(RowConverter::new(hlg_f32, lin).is_ok());
     }
 
     #[test]
@@ -871,6 +896,8 @@ mod tests {
 
     #[test]
     fn hdr_u16_to_sdr_u8_hlg() {
+        // HLG→SDR stays allowed (endpoint-correct; the OOTF mid-tone gamma is the
+        // only gap). Only HLG↔PQ is refused — see `hlg_pq_conversion_refuses`.
         let hlg_u16 = PixelDescriptor::new(
             ChannelType::U16,
             ChannelLayout::Rgb,

--- a/zenpixels-convert/src/hdr.rs
+++ b/zenpixels-convert/src/hdr.rs
@@ -7,11 +7,12 @@
 //! The core PQ/HLG EOTF/OETF math is always available through the main
 //! conversion pipeline in [`ConvertPlan`](crate::ConvertPlan).
 
-use crate::adapt::convert_buffer;
+use crate::adapt::{convert_buffer_with_anchor, convert_into_with_anchor};
 use crate::error::ConvertError;
 use crate::{PixelBuffer, PixelDescriptor, PixelFormat, PixelSlice, TransferFunction};
-use alloc::vec::Vec;
+use alloc::sync::Arc;
 use whereat::At;
+use zenpixels::{Cicp, ColorContext};
 
 // Re-export metadata types from the core crate.
 pub use zenpixels::hdr::{ContentLightLevel, MasteringDisplay};
@@ -155,65 +156,27 @@ pub fn exposure_tonemap(v: f32, exposure: f32) -> f32 {
 // HDR quantization (relative-linear f32 → a PQ HDR descriptor)
 // ---------------------------------------------------------------------------
 
-/// Read one native-endian f32 sample from a pixel's bytes.
-#[inline]
-fn sample_f32(bytes: &[u8], k: usize) -> f32 {
-    f32::from_ne_bytes([
-        bytes[4 * k],
-        bytes[4 * k + 1],
-        bytes[4 * k + 2],
-        bytes[4 * k + 3],
-    ])
-}
-
-/// Quantize relative-linear RGB(A) f32 pixels to a **PQ** HDR target
-/// descriptor (e.g. [`PixelDescriptor::RGB16_BT2100_PQ`]).
-///
-/// The absolute-luminance anchor — the nits that sample `1.0` represents — is
-/// read from the source `ColorContext`'s `diffuse_white`, defaulting to
-/// [`DiffuseWhite::BT2408`] (203, the cross-vendor relative-linear convention)
-/// when unsignaled. Attach a custom anchor with
-/// `ColorContext::with_diffuse_white` (e.g. a buffer reconstructed at a
-/// different reference white). The anchor is the one thing the pipeline's fixed
-/// `1.0 = 10000 cd/m²` PQ domain can't yet express; the transfer (linear → PQ)
-/// and depth (f32 → u16) quantization reuse
-/// [`convert_buffer`](crate::adapt::convert_buffer). The anchor scales the
-/// linear samples by `anchor / 10000`, clamps to the PQ peak, and drops any
-/// alpha lane. PQ codes match the f64 ST 2084 oracle within ±1.
-///
-/// **Primaries are not converted** — the source gamut is signaled as the
-/// target's (feed BT.2020-relative-linear for `RGB16_BT2100_PQ`). Measure CLL
-/// separately with [`ContentLightLevel::measure`].
-///
-/// The successor to the withdrawn `encode_pq16` (rationale:
-/// `docs/hdr-design-survey-2026-06-13.md`). It collapses fully into
-/// `convert_buffer` once the anchor threads into the PQ/HLG `ConvertStep`s
-/// themselves — tracked as a refinement in the M×N HDR epic (#45).
-///
-/// # Errors
-///
-/// - [`ConvertError::NoMatch`] if `px` is not `RgbF32`/`RgbaF32`;
-///   [`ConvertError::UnsupportedTransfer`] if it is not `Linear`.
-/// - [`ConvertError::NoPath`] if `target`'s transfer is not PQ (HLG's
-///   scene-referred anchor differs and is not handled here).
-/// - [`ConvertError::InvalidWidth`] for zero-area input, or any error the
-///   inner [`convert_buffer`](crate::adapt::convert_buffer) raises.
-pub fn quantize_to(
-    px: PixelSlice<'_>,
+/// Shared `quantize_*` setup: read the anchor from the source `ColorContext`
+/// (default [`DiffuseWhite::BT2408`] = 203), validate the source is linear
+/// RGB(A) f32 and the target is PQ, and return the gamut-tagged source
+/// descriptor + anchor + dimensions. The source descriptor carries the target's
+/// primaries so no gamut step is planned (value-only quantize); the target's
+/// channel count then drives whether alpha is dropped or preserved.
+fn quantize_setup(
+    px: &PixelSlice<'_>,
     target: PixelDescriptor,
-) -> Result<PixelBuffer, At<ConvertError>> {
-    // The anchor travels with the pixels (S1a): read it from the source's
-    // ColorContext, default to the BT.2408 relative-linear convention (203).
-    let white = px
+) -> Result<(PixelDescriptor, DiffuseWhite, u32, u32), At<ConvertError>> {
+    let diffuse_white = px
         .color_context()
         .and_then(|c| c.diffuse_white)
         .unwrap_or(DiffuseWhite::BT2408);
     let desc = px.descriptor();
-    let channels = match desc.pixel_format() {
-        PixelFormat::RgbF32 => 3,
-        PixelFormat::RgbaF32 => 4,
+    let src = match desc.pixel_format() {
+        PixelFormat::RgbF32 => PixelDescriptor::RGBF32_LINEAR,
+        PixelFormat::RgbaF32 => PixelDescriptor::RGBAF32_LINEAR,
         _ => return Err(whereat::at!(ConvertError::NoMatch { source: desc })),
-    };
+    }
+    .with_primaries(target.primaries);
     if desc.transfer != TransferFunction::Linear {
         return Err(whereat::at!(ConvertError::UnsupportedTransfer {
             from: desc.transfer,
@@ -232,30 +195,123 @@ pub fn quantize_to(
     if w == 0 || h == 0 {
         return Err(whereat::at!(ConvertError::InvalidWidth(w)));
     }
+    Ok((src, diffuse_white, w, h))
+}
 
-    // Pre-scale relative-linear (1.0 = white nits) into the pipeline's PQ
-    // domain (1.0 = 10000 nits), clamp to the peak, drop alpha → tight RGB f32.
-    let factor = (f64::from(white.nits()) / 10_000.0) as f32;
-    let stride = px.stride();
-    let bytes = px.as_strided_bytes();
-    let row_len = w as usize * channels * 4;
-    let mut scaled: Vec<u8> = Vec::with_capacity(w as usize * h as usize * 3 * 4);
-    for row in 0..h as usize {
-        let rb = &bytes[row * stride..row * stride + row_len];
-        for pxl in rb.chunks_exact(channels * 4) {
-            for k in 0..3 {
-                let v = (sample_f32(pxl, k).max(0.0) * factor).min(1.0);
-                scaled.extend_from_slice(&v.to_ne_bytes());
-            }
-        }
+/// Quantize relative-linear RGB(A) f32 pixels to a **PQ** HDR target
+/// descriptor (e.g. [`PixelDescriptor::RGB16_BT2100_PQ`]).
+///
+/// The absolute-luminance anchor — the nits that sample `1.0` represents — is
+/// read from the source `ColorContext`'s `diffuse_white`, defaulting to
+/// [`DiffuseWhite::BT2408`] (203, the cross-vendor relative-linear convention)
+/// when unsignaled. Attach a custom anchor with
+/// `ColorContext::with_diffuse_white` (e.g. a buffer reconstructed at a
+/// different reference white). The anchor threads **into the PQ `ConvertStep`s
+/// themselves**: the linear → PQ kernel scales the RGB lanes by `anchor / 10000`
+/// across the relative-linear ↔ PQ-absolute boundary, so this is a thin wrapper
+/// that hands the source — **strided and RGBA accepted as-is, no repack** —
+/// straight to the pipeline. Negatives fold to 0 and the PQ peak clamps
+/// in-kernel; codes match the f64 ST 2084 oracle within ±1.
+///
+/// **Alpha follows the target.** An RGB target (e.g.
+/// [`RGB16_BT2100_PQ`](PixelDescriptor::RGB16_BT2100_PQ)) drops alpha; an RGBA
+/// PQ target (`RGBA16.with_transfer(Pq).with_primaries(…)`) preserves it,
+/// carried linearly and **never PQ-encoded or anchor-scaled**.
+///
+/// **Primaries are not converted** — the source gamut is signaled as the
+/// target's (feed BT.2020-relative-linear for `RGB16_BT2100_PQ`). Measure CLL
+/// separately with [`ContentLightLevel::measure`].
+///
+/// The successor to the withdrawn `encode_pq16` (rationale:
+/// `docs/hdr-design-survey-2026-06-13.md`). With the anchor living on the plan
+/// (#45 S2), the quantizer is now a straight pass to
+/// `convert_buffer_with_anchor`; HLG is still excluded (its scene-referred
+/// anchor differs).
+///
+/// # Errors
+///
+/// - [`ConvertError::NoMatch`] if `px` is not `RgbF32`/`RgbaF32`;
+///   [`ConvertError::UnsupportedTransfer`] if it is not `Linear`.
+/// - [`ConvertError::NoPath`] if `target`'s transfer is not PQ (HLG's
+///   scene-referred anchor differs and is not handled here).
+/// - [`ConvertError::InvalidWidth`] for zero-area input, or any error the
+///   inner anchored conversion raises.
+pub fn quantize_to(
+    px: PixelSlice<'_>,
+    target: PixelDescriptor,
+) -> Result<PixelBuffer, At<ConvertError>> {
+    // Hand the (possibly strided, possibly RGBA) source straight to the anchored
+    // pipeline — no caller-side pre-scale or repack. The PQ kernel applies
+    // `white / 10000` to the RGB lanes, folds negatives to 0, and the plan
+    // drops or preserves alpha per `target`. The anchor travels with the pixels
+    // (S1a): `quantize_setup` reads it from the source `ColorContext`.
+    let (src, diffuse_white, w, h) = quantize_setup(&px, target)?;
+    let out = convert_buffer_with_anchor(
+        px.as_strided_bytes(),
+        w,
+        h,
+        px.stride(),
+        src,
+        target,
+        diffuse_white,
+    )?;
+    // Carry the envelope forward. `diffuse_white` is a *reference* — it survives
+    // the encode (it's the SDR-white nits a downstream encoder signals as
+    // `ndwt`), so the output self-describes it rather than silently dropping the
+    // anchor we just applied. The target's CICP (transfer/primaries/range) rides
+    // along so the buffer is fully described for re-encode.
+    let context = match Cicp::from_descriptor(&target) {
+        Some(cicp) => ColorContext::from_cicp(cicp),
+        None => ColorContext::default(),
     }
+    .with_diffuse_white(diffuse_white);
+    Ok(out.with_color_context(Arc::new(context)))
+}
 
-    // Reuse the pipeline for linear→PQ + f32→u16. Tag the scratch with the
-    // target's primaries so no gamut step is inserted (value-only quantize).
-    let src = PixelDescriptor::RGBF32_LINEAR.with_primaries(target.primaries);
-    let out = convert_buffer(&scaled, w, h, src, target)?;
-    PixelBuffer::from_vec(out, w, h, target)
-        .map_err(|_| whereat::at!(ConvertError::AllocationFailed))
+/// [`quantize_to`] writing into a caller-provided `dst` — no output allocation.
+///
+/// The result is written at `dst_stride` bytes per row (pass
+/// `width * target.bytes_per_pixel()` for packed, or a larger stride to write
+/// into a sub-region of a bigger buffer); `dst` must hold
+/// `(rows - 1) * dst_stride + width * target.bpp` bytes, else
+/// [`ConvertError::BufferSize`]. Anchor sourcing, strided-**source** handling,
+/// and target-driven alpha (drop for an RGB target, preserve for an RGBA one)
+/// are identical to [`quantize_to`]; this only avoids allocating the output. Unlike
+/// [`quantize_to`], it writes raw bytes with no `PixelBuffer` to tag, so the
+/// caller owns the output's color envelope (e.g. re-attaching the
+/// `diffuse_white` anchor for a downstream encode).
+///
+/// Kept `pub(crate)` for now: the no-allocation capability is built and tested,
+/// but per the "no speculative `pub`" rule (and the §3.2 design doc, which routes
+/// the public HDR-convert surface through a future `PixelBuffer`-level entry and
+/// keeps the byte-level convert internal) it is not yet a public commitment.
+/// Promote the instant a concrete external consumer or §3.2 lands.
+///
+/// # Errors
+///
+/// The same validation errors as [`quantize_to`], plus
+/// [`ConvertError::BufferSize`] when `dst` is too small.
+// Exercised by the `quantize_into_*` unit tests; no non-test in-crate caller yet
+// (it is a staged, ready-to-promote public candidate — see above).
+#[allow(dead_code)]
+pub(crate) fn quantize_into(
+    px: PixelSlice<'_>,
+    target: PixelDescriptor,
+    dst: &mut [u8],
+    dst_stride: usize,
+) -> Result<(), At<ConvertError>> {
+    let (src, diffuse_white, w, h) = quantize_setup(&px, target)?;
+    convert_into_with_anchor(
+        px.as_strided_bytes(),
+        w,
+        h,
+        px.stride(),
+        src,
+        target,
+        diffuse_white,
+        dst,
+        dst_stride,
+    )
 }
 
 #[cfg(test)]
@@ -447,6 +503,7 @@ mod tests {
 
     // -- quantize_to (PQ16) parity with the f64 ST 2084 oracle --
 
+    use alloc::vec;
     use alloc::vec::Vec;
 
     /// f64 SMPTE ST 2084 inverse-EOTF oracle (exact constants).
@@ -471,6 +528,23 @@ mod tests {
             }
         }
         PixelBuffer::from_vec(data, w, h, PixelDescriptor::RGBF32_LINEAR).unwrap()
+    }
+
+    fn rgbaf32(pixels: &[[f32; 4]], w: u32, h: u32) -> PixelBuffer {
+        let mut data = Vec::with_capacity(pixels.len() * 16);
+        for p in pixels {
+            for c in p {
+                data.extend_from_slice(&c.to_ne_bytes());
+            }
+        }
+        PixelBuffer::from_vec(data, w, h, PixelDescriptor::RGBAF32_LINEAR).unwrap()
+    }
+
+    /// RGBA16 PQ target (BT.2020), matching `RGB16_BT2100_PQ` plus an alpha lane.
+    fn rgba16_pq() -> PixelDescriptor {
+        PixelDescriptor::RGBA16
+            .with_transfer(TransferFunction::Pq)
+            .with_primaries(PixelDescriptor::RGB16_BT2100_PQ.primaries)
     }
 
     #[test]
@@ -542,5 +616,132 @@ mod tests {
         // The 100-nit result differs from the 203-nit default for the same input.
         let want_203 = (pq_oracle(203.0 / 10_000.0) * 65535.0).round() as i64;
         assert_ne!(want, want_203);
+    }
+
+    #[test]
+    fn quantize_to_preserves_alpha_for_rgba_target() {
+        // RGBA f32 linear → RGBA16 PQ: RGB take the anchored PQ OETF; alpha rides
+        // through linearly (never PQ-encoded). PQ-encoding 0.5 would give a code
+        // far from the linear 32768, so the assertion is a real discriminator.
+        let target = rgba16_pq();
+        let buf = rgbaf32(&[[1.0, 1.0, 1.0, 0.5], [2.0, 2.0, 2.0, 0.25]], 2, 1);
+        let out = quantize_to(buf.as_slice(), target).unwrap();
+        assert_eq!(out.descriptor(), target);
+        let bytes = out.as_slice().as_strided_bytes();
+        let code = |i: usize| u16::from_ne_bytes([bytes[2 * i], bytes[2 * i + 1]]);
+        for (px, g, a) in [(0usize, 1.0f64, 0.5f64), (1, 2.0, 0.25)] {
+            let r = i64::from(code(px * 4));
+            let want_rgb = (pq_oracle(g * 203.0 / 10_000.0) * 65535.0).round() as i64;
+            assert!(
+                (r - want_rgb).abs() <= 1,
+                "rgb @203: got {r} want {want_rgb}"
+            );
+            let alpha = code(px * 4 + 3);
+            let want_a = (a * 65535.0).round() as u16;
+            assert_eq!(
+                alpha, want_a,
+                "alpha linear passthrough: got {alpha} want {want_a}"
+            );
+        }
+    }
+
+    #[test]
+    fn quantize_to_honors_strided_input() {
+        // A padded source stride (one sentinel pixel per row) must quantize
+        // identically to the equivalent packed buffer.
+        let target = PixelDescriptor::RGB16_BT2100_PQ;
+        let stride = 2 * 12 + 12; // two RGB f32 pixels + one padding pixel
+        let mut data = vec![0u8; stride * 2];
+        for y in 0..2usize {
+            let mut off = y * stride;
+            for c in [0.1f32, 0.1, 0.1, 1.0, 1.0, 1.0] {
+                data[off..off + 4].copy_from_slice(&c.to_ne_bytes());
+                off += 4;
+            }
+            data[off..off + 4].copy_from_slice(&999.0f32.to_ne_bytes()); // sentinel
+        }
+        let strided = PixelSlice::new(&data, 2, 2, stride, PixelDescriptor::RGBF32_LINEAR).unwrap();
+        let got = quantize_to(strided, target).unwrap();
+
+        let packed = rgbf32(&[[0.1; 3], [1.0; 3], [0.1; 3], [1.0; 3]], 2, 2);
+        let want = quantize_to(packed.as_slice(), target).unwrap();
+        assert_eq!(
+            got.as_slice().as_strided_bytes(),
+            want.as_slice().as_strided_bytes(),
+            "strided input must quantize identically to packed"
+        );
+    }
+
+    #[test]
+    fn quantize_into_matches_quantize_to() {
+        let target = PixelDescriptor::RGB16_BT2100_PQ;
+        let buf = rgbf32(&[[0.1; 3], [1.0; 3], [2.0; 3]], 3, 1);
+        let want = quantize_to(buf.as_slice(), target).unwrap();
+        let row = 3 * target.bytes_per_pixel();
+        let mut dst = vec![0u8; row];
+        quantize_into(buf.as_slice(), target, &mut dst, row).unwrap();
+        assert_eq!(dst, want.as_slice().as_strided_bytes());
+    }
+
+    #[test]
+    fn quantize_into_honors_dst_stride() {
+        // Write two PQ16 rows into a padded destination; the padding bytes must
+        // be untouched and the row content must match a packed quantize.
+        let target = PixelDescriptor::RGB16_BT2100_PQ;
+        let buf = rgbf32(&[[0.1; 3], [1.0; 3], [0.1; 3], [1.0; 3]], 2, 2);
+        let want = quantize_to(buf.as_slice(), target).unwrap();
+        let want_bytes = want.as_slice().as_strided_bytes();
+        let row = 2 * target.bytes_per_pixel(); // packed row width
+        let dst_stride = row + 8; // 8 bytes of padding per row
+        let mut dst = vec![0xAAu8; dst_stride * 2];
+        quantize_into(buf.as_slice(), target, &mut dst, dst_stride).unwrap();
+        for y in 0..2 {
+            assert_eq!(
+                &dst[y * dst_stride..y * dst_stride + row],
+                &want_bytes[y * row..(y + 1) * row]
+            );
+            assert!(
+                dst[y * dst_stride + row..y * dst_stride + dst_stride]
+                    .iter()
+                    .all(|&b| b == 0xAA),
+                "padding row {y} must be untouched"
+            );
+        }
+    }
+
+    #[test]
+    fn quantize_into_rejects_undersized_dst() {
+        let target = PixelDescriptor::RGB16_BT2100_PQ;
+        let buf = rgbf32(&[[1.0; 3]], 1, 1);
+        let mut dst = vec![0u8; 2]; // one RGB16 pixel needs 6 bytes
+        let row = target.bytes_per_pixel();
+        let err = quantize_into(buf.as_slice(), target, &mut dst, row).unwrap_err();
+        assert!(matches!(*err.error(), ConvertError::BufferSize { .. }));
+    }
+
+    #[test]
+    fn quantize_to_carries_diffuse_white_anchor_onto_output() {
+        use alloc::sync::Arc;
+        use zenpixels::{Cicp, ColorContext};
+        let target = PixelDescriptor::RGB16_BT2100_PQ;
+
+        // A signaled 100-nit anchor must ride out on the output's ColorContext —
+        // the encode applied it, so the buffer self-describes it (the `ndwt`
+        // signal a downstream encoder needs), rather than silently dropping it.
+        let buf = rgbf32(&[[1.0; 3]], 1, 1).with_color_context(Arc::new(
+            ColorContext::from_cicp(Cicp::BT2100_PQ).with_diffuse_white(DiffuseWhite::new(100.0)),
+        ));
+        let out = quantize_to(buf.as_slice(), target).unwrap();
+        let ctx = out.color_context().expect("output carries a ColorContext");
+        assert_eq!(ctx.diffuse_white, Some(DiffuseWhite::new(100.0)));
+        assert!(ctx.cicp.is_some(), "target CICP rides along for re-encode");
+
+        // An unsignaled source still yields a self-describing output at the 203 default.
+        let plain = rgbf32(&[[1.0; 3]], 1, 1);
+        let out = quantize_to(plain.as_slice(), target).unwrap();
+        assert_eq!(
+            out.color_context().unwrap().diffuse_white,
+            Some(DiffuseWhite::BT2408)
+        );
     }
 }

--- a/zenpixels-convert/src/lib.rs
+++ b/zenpixels-convert/src/lib.rs
@@ -513,6 +513,8 @@ pub use load_bearing::{LoadBearingReport, PixelBufferLoadBearingExt, PixelSliceL
 pub use hdr::exposure_tonemap;
 // Anchor-aware HDR PQ quantizer — reads `DiffuseWhite` from the source's
 // `ColorContext` (default BT.2408 = 203); the canonical linear→PQ16 encoder.
+// (The no-allocation `quantize_into` sibling stays `pub(crate)` until a concrete
+// consumer or the §3.2 PixelBuffer-level surface lands — see hdr.rs.)
 pub use hdr::quantize_to;
 // `HdrMetadata` is re-exported but deprecated (see the `hdr` module); the
 // re-export itself names it, hence the allow.

--- a/zenpixels-convert/tests/cicp_transfer_correctness.rs
+++ b/zenpixels-convert/tests/cicp_transfer_correctness.rs
@@ -501,6 +501,14 @@ fn all_f32_tf_pairs_create_converters() {
             if from_tf == to_tf {
                 continue;
             }
+            // HLG↔PQ is refused (scene-vs-absolute, no OOTF — #45 S2); skip it.
+            if matches!(
+                (from_tf, to_tf),
+                (TransferFunction::Hlg, TransferFunction::Pq)
+                    | (TransferFunction::Pq, TransferFunction::Hlg)
+            ) {
+                continue;
+            }
             let from = PixelDescriptor::new(ChannelType::F32, ChannelLayout::Rgb, None, from_tf);
             let to = PixelDescriptor::new(ChannelType::F32, ChannelLayout::Rgb, None, to_tf);
             assert!(
@@ -533,6 +541,14 @@ fn all_f32_tf_pairs_roundtrip() {
     for &from_tf in &tfs {
         for &to_tf in &tfs {
             if from_tf == to_tf {
+                continue;
+            }
+            // HLG↔PQ is refused (scene-vs-absolute, no OOTF — #45 S2); skip it.
+            if matches!(
+                (from_tf, to_tf),
+                (TransferFunction::Hlg, TransferFunction::Pq)
+                    | (TransferFunction::Pq, TransferFunction::Hlg)
+            ) {
                 continue;
             }
             let mut fwd = f32_converter(from_tf, to_tf);
@@ -578,6 +594,15 @@ fn cross_tf_via_linear_matches_direct() {
     for &src_tf in sdrs.iter().chain(hdrs.iter()) {
         for &dst_tf in sdrs.iter().chain(hdrs.iter()) {
             if src_tf == dst_tf {
+                continue;
+            }
+            // HLG↔PQ refuses directly (scene-vs-absolute, no OOTF — #45 S2), so
+            // there's no "direct" to compare against; skip the cross.
+            if matches!(
+                (src_tf, dst_tf),
+                (TransferFunction::Hlg, TransferFunction::Pq)
+                    | (TransferFunction::Pq, TransferFunction::Hlg)
+            ) {
                 continue;
             }
             let mut direct = f32_converter(src_tf, dst_tf);
@@ -627,6 +652,14 @@ fn black_preserved_all_tf_pairs() {
             if from_tf == to_tf {
                 continue;
             }
+            // HLG↔PQ is refused (scene-vs-absolute, no OOTF — #45 S2); skip it.
+            if matches!(
+                (from_tf, to_tf),
+                (TransferFunction::Hlg, TransferFunction::Pq)
+                    | (TransferFunction::Pq, TransferFunction::Hlg)
+            ) {
+                continue;
+            }
             let mut conv = f32_converter(from_tf, to_tf);
             let result = convert_f32_pixel(&mut conv, 0.0, 0.0, 0.0);
             for (ch, &v) in result.iter().enumerate() {
@@ -649,6 +682,14 @@ fn white_preserved_all_tf_pairs() {
     for &from_tf in &tfs {
         for &to_tf in &tfs {
             if from_tf == to_tf {
+                continue;
+            }
+            // HLG↔PQ is refused (scene-vs-absolute, no OOTF — #45 S2); skip it.
+            if matches!(
+                (from_tf, to_tf),
+                (TransferFunction::Hlg, TransferFunction::Pq)
+                    | (TransferFunction::Pq, TransferFunction::Hlg)
+            ) {
                 continue;
             }
             let mut conv = f32_converter(from_tf, to_tf);

--- a/zenpixels-convert/tests/planner_silent_passthrough.rs
+++ b/zenpixels-convert/tests/planner_silent_passthrough.rs
@@ -580,44 +580,22 @@ fn hlg_f32_roundtrip_via_linear() {
 
 #[test]
 fn pq_to_hlg_f32_via_linear() {
+    // PQ↔HLG is now **refused** (absolute PQ vs scene-referred HLG, no OOTF —
+    // #45 S2) rather than silently converting through the conflated linear
+    // intermediate and emitting wrong brightness.
     let pq_d = rgb(ChannelType::F32, TransferFunction::Pq);
     let hlg_d = rgb(ChannelType::F32, TransferFunction::Hlg);
-    let mut c = RowConverter::new(pq_d, hlg_d).unwrap();
-    let src = [0.5f32; 3];
-    let mut dst = [0f32; 3];
-    c.convert_row(
-        bytemuck::cast_slice(&src),
-        bytemuck::cast_slice_mut(&mut dst),
-        1,
-    );
-    let expected = hlg_oetf(pq_eotf(0.5));
-    for ch in dst {
-        assert!(
-            (ch - expected).abs() < F32_TOL_LOOSE,
-            "PQ→HLG F32 @ 0.5: got {ch}, expected {expected}"
-        );
-    }
+    assert!(RowConverter::new(pq_d, hlg_d).is_err());
 }
 
 #[test]
 fn hlg_to_pq_f32_via_linear() {
+    // HLG↔PQ is now **refused** (scene-referred HLG vs absolute PQ, no OOTF —
+    // #45 S2) rather than silently converting through the conflated linear
+    // intermediate and emitting wrong brightness.
     let hlg_d = rgb(ChannelType::F32, TransferFunction::Hlg);
     let pq_d = rgb(ChannelType::F32, TransferFunction::Pq);
-    let mut c = RowConverter::new(hlg_d, pq_d).unwrap();
-    let src = [0.5f32; 3];
-    let mut dst = [0f32; 3];
-    c.convert_row(
-        bytemuck::cast_slice(&src),
-        bytemuck::cast_slice_mut(&mut dst),
-        1,
-    );
-    let expected = pq_oetf(hlg_eotf(0.5));
-    for ch in dst {
-        assert!(
-            (ch - expected).abs() < F32_TOL_LOOSE,
-            "HLG→PQ F32 @ 0.5: got {ch}, expected {expected}"
-        );
-    }
+    assert!(RowConverter::new(hlg_d, pq_d).is_err());
 }
 
 // =========================================================================

--- a/zenpixels-convert/tests/roundtrip.rs
+++ b/zenpixels-convert/tests/roundtrip.rs
@@ -451,12 +451,11 @@ fn pq_u16_to_srgb_u8() {
     assert!(dst[9] < dst[6], "low PQ should be less than mid PQ");
 }
 
-/// PQ ↔ HLG cross-TF conversion via F32 linear intermediary.
+/// PQ ↔ HLG cross-TF conversion is **refused** (scene-referred HLG vs absolute
+/// PQ, no OOTF — #45 S2) rather than silently converting through the conflated
+/// linear intermediary and emitting wrong brightness.
 #[test]
-fn pq_hlg_cross_conversion() {
-    let width = 32u32;
-    let src = make_rgb_f32_row(width as usize);
-
+fn pq_hlg_cross_conversion_refuses() {
     let pq_f32 = PixelDescriptor::new(
         ChannelType::F32,
         ChannelLayout::Rgb,
@@ -469,26 +468,8 @@ fn pq_hlg_cross_conversion() {
         None,
         TransferFunction::Hlg,
     );
-
-    let mut pq_to_hlg = RowConverter::new(pq_f32, hlg_f32).unwrap();
-    let mut hlg_to_pq = RowConverter::new(hlg_f32, pq_f32).unwrap();
-
-    let mut hlg_buf = vec![0u8; width as usize * 3 * 4];
-    let mut back = vec![0u8; width as usize * 3 * 4];
-
-    pq_to_hlg.convert_row(&src, &mut hlg_buf, width);
-    hlg_to_pq.convert_row(&hlg_buf, &mut back, width);
-
-    for i in 0..width as usize * 3 {
-        let base = i * 4;
-        let orig = f32::from_ne_bytes([src[base], src[base + 1], src[base + 2], src[base + 3]]);
-        let result =
-            f32::from_ne_bytes([back[base], back[base + 1], back[base + 2], back[base + 3]]);
-        assert!(
-            (orig - result).abs() < 1e-3,
-            "PQ→HLG→PQ roundtrip error at sample {i}: {orig:.6} vs {result:.6}",
-        );
-    }
+    assert!(RowConverter::new(pq_f32, hlg_f32).is_err());
+    assert!(RowConverter::new(hlg_f32, pq_f32).is_err());
 }
 
 /// Verify that different primaries with same depth triggers gamut conversion.


### PR DESCRIPTION
**The real S2 of the M×N HDR pipeline (#45)** — the work #47 explicitly deferred ("won't hand-thread an anchor scale through [the plan builder] under time pressure and risk corrupting existing SDR conversions").

#47 made `quantize_to` *read* the anchor from `ColorContext`, but applied it as a hand-rolled **pre-scale pass**, leaving the PQ `ConvertStep`s themselves anchor-blind (`1.0` hard-pinned to 10000 cd/m²). This threads the anchor **into the kernels**, so the pipeline honors it natively.

## Change
- **`ConvertPlan` carries `pq_anchor_scale`** (`= diffuse_white / 10000`), default **`1.0`**; `with_pq_anchor` sets it (both `pub(crate)`). The PQ kernels — u16 + f32, encode + decode — scale across the relative-linear ↔ PQ-absolute boundary: **encode multiplies before the OETF, decode divides after the EOTF.**
- **`convert_buffer_with_anchor`** runs the anchored plan on the built-in plan path, so the PQ steps are never bypassed by a CMS matlut fast path.
- **`quantize_to` dissolves its pre-scale**: packs to tight RGB and hands the anchor to the pipeline.

## Pixels are sacred — byte-parity
- `scale == 1.0` is the **exact identity** (`x * 1.0 == x`, `1.0 / 1.0 == 1.0`), so every conversion built **without** an anchor is byte-for-byte unchanged. The **full convert suite (435+ tests) passes untouched.**
- `quantize_to`'s PQ codes still match the **f64 ST 2084 oracle within ±1** — byte-identical to the old pre-scale (the per-sample `max(0)`/peak-clamp move into the kernel was proven equivalent).

## New tests (prove the anchor is honored *in-kernel*, not by a caller)
- encode matches the ST 2084 oracle through the pipeline,
- a non-default anchor (100 vs 203) **changes the PQ code**,
- decode `÷scale` **round-trips** encode `×scale`,
- the **f32 slice kernel** (`LinearF32ToPqF32`) honors it too,
- `scale == 1.0` is unscaled (1.0 → code 65535).

## Scope
- **HLG intentionally excluded** — scene-referred anchoring differs from PQ's absolute `1.0 = 10000`; same scope as `quantize_to` today. Documented on `with_pq_anchor` / the HLG kernels.
- **No public API change** — the carrier, `with_pq_anchor`, and `convert_buffer_with_anchor` are all `pub(crate)`; `quantize_to`'s signature and output are unchanged.

Opened as a PR (rather than direct-to-main) because it's pixel-sensitive and touches the conversion kernels.