### PR TITLE
fix(error): preserve zenpixels At<BufferError> trace across convert boundaries (map_err_at) + structured Buffer variant

### DIFF
--- a/zenpixels-convert/src/cms_lite.rs
+++ b/zenpixels-convert/src/cms_lite.rs
@@ -275,9 +275,14 @@ impl crate::cms::PluggableCms for ZenCmsLite {
                 let inner = crate::converter::RowConverter::from_plan(plan);
                 Some(Ok(Box::new(LiteTransformMut { inner })))
             }
-            Err(e) => Some(Err(whereat::at!(crate::cms::CmsPluginError::msg(
-                alloc::format!("ZenCmsLite plan construction failed: {e:?}")
-            )))),
+            // Render the inner At<ConvertError> (which carries its own trace
+            // frames) into the message, then `map_error` so those frames carry
+            // through to At<CmsPluginError> instead of being dropped by a fresh
+            // `at!` frame.
+            Err(e) => {
+                let msg = alloc::format!("ZenCmsLite plan construction failed: {e:?}");
+                Some(Err(e.map_error(|_| crate::cms::CmsPluginError::msg(msg))))
+            }
         }
     }
 }

--- a/zenpixels-convert/src/converter.rs
+++ b/zenpixels-convert/src/converter.rs
@@ -148,9 +148,13 @@ impl RowConverter {
 
             // Convert a plugin failure into ConvertError::CmsError. The
             // `At<CmsPluginError>` Display impl already renders the full
-            // frame trace + crate info (plugin + crate boundary).
+            // frame trace + crate info (plugin + crate boundary). Render that
+            // into the message first, then `map_error` so the accumulated
+            // At<_> trace frames carry through to At<ConvertError> instead of
+            // being dropped by a fresh `at!` frame.
             let plugin_err = |e: whereat::At<crate::cms::CmsPluginError>| {
-                whereat::at!(ConvertError::CmsError(alloc::format!("{e}")))
+                let msg = alloc::format!("{e}");
+                e.map_error(|_| ConvertError::CmsError(msg))
             };
 
             let mut external: Option<ExternalTransform> = None;

--- a/zenpixels-convert/src/ext.rs
+++ b/zenpixels-convert/src/ext.rs
@@ -195,8 +195,13 @@ impl PixelBufferConvertExt for PixelBuffer {
                 let dst_start = y as usize * dst_stride;
                 out[dst_start..dst_start + src_row.len()].copy_from_slice(src_row);
             }
+            // FIXME: mislabels non-alloc BufferError (StrideTooSmall /
+            // InvalidDimensions) as AllocationFailed; a structured
+            // ConvertError::Buffer(BufferError) variant needs a
+            // non_exhaustive / breaking (0.3.0) change. map_err_at preserves
+            // the At<BufferError> trace.
             let mut buf = PixelBuffer::from_vec(out, self.width(), self.height(), target)
-                .map_err(|_| whereat::at!(crate::ConvertError::AllocationFailed))?;
+                .map_err_at(|_| crate::ConvertError::AllocationFailed)?;
             if let Some(ctx) = self.color_context() {
                 buf = buf.with_color_context(Arc::clone(ctx));
             }
@@ -219,8 +224,12 @@ impl PixelBufferConvertExt for PixelBuffer {
             converter.convert_row(src_row, &mut out[dst_start..dst_end], self.width());
         }
 
+        // FIXME: mislabels non-alloc BufferError (StrideTooSmall /
+        // InvalidDimensions) as AllocationFailed; a structured
+        // ConvertError::Buffer(BufferError) variant needs a non_exhaustive /
+        // breaking (0.3.0) change. map_err_at preserves the At<BufferError> trace.
         let mut buf = PixelBuffer::from_vec(out, self.width(), self.height(), target)
-            .map_err(|_| whereat::at!(crate::ConvertError::AllocationFailed))?;
+            .map_err_at(|_| crate::ConvertError::AllocationFailed)?;
         if let Some(ctx) = self.color_context() {
             buf = buf.with_color_context(Arc::clone(ctx));
         }

--- a/zenpixels-convert/src/hdr.rs
+++ b/zenpixels-convert/src/hdr.rs
@@ -11,7 +11,7 @@ use crate::adapt::convert_buffer;
 use crate::error::ConvertError;
 use crate::{PixelBuffer, PixelDescriptor, PixelFormat, PixelSlice, TransferFunction};
 use alloc::vec::Vec;
-use whereat::At;
+use whereat::{At, ResultAtExt};
 
 // Re-export metadata types from the core crate.
 pub use zenpixels::hdr::{ContentLightLevel, MasteringDisplay};
@@ -254,8 +254,11 @@ pub fn quantize_to(
     // target's primaries so no gamut step is inserted (value-only quantize).
     let src = PixelDescriptor::RGBF32_LINEAR.with_primaries(target.primaries);
     let out = convert_buffer(&scaled, w, h, src, target)?;
-    PixelBuffer::from_vec(out, w, h, target)
-        .map_err(|_| whereat::at!(ConvertError::AllocationFailed))
+    // FIXME: mislabels non-alloc BufferError (StrideTooSmall /
+    // InvalidDimensions) as AllocationFailed; a structured
+    // ConvertError::Buffer(BufferError) variant needs a non_exhaustive /
+    // breaking (0.3.0) change. map_err_at preserves the At<BufferError> trace.
+    PixelBuffer::from_vec(out, w, h, target).map_err_at(|_| ConvertError::AllocationFailed)
 }
 
 #[cfg(test)]

--- a/zenpixels-convert/src/output.rs
+++ b/zenpixels-convert/src/output.rs
@@ -281,8 +281,12 @@ pub fn finalize_for_output<C: ColorManagement>(
             build_cms_transform(origin, &metadata, &source_desc, pixel_format, cms)?
     {
         let src_slice = buffer.as_slice();
+        // FIXME: mislabels non-alloc BufferError (StrideTooSmall /
+        // InvalidDimensions) as AllocationFailed; a structured
+        // ConvertError::Buffer(BufferError) variant needs a non_exhaustive /
+        // breaking (0.3.0) change. map_err_at preserves the At<BufferError> trace.
         let mut out = PixelBuffer::try_new(buffer.width(), buffer.height(), target_desc)
-            .map_err(|_| whereat::at!(ConvertError::AllocationFailed))?;
+            .map_err_at(|_| ConvertError::AllocationFailed)?;
 
         {
             let mut dst_slice = out.as_slice_mut();
@@ -310,13 +314,16 @@ pub fn finalize_for_output<C: ColorManagement>(
         // No conversion needed — copy the buffer.
         let src_slice = buffer.as_slice();
         let bytes = src_slice.contiguous_bytes();
+        // FIXME: mislabels non-alloc BufferError as AllocationFailed (needs
+        // structured ConvertError::Buffer variant = 0.3.0 break). map_err_at
+        // preserves the At<BufferError> trace.
         let out = PixelBuffer::from_vec(
             bytes.into_owned(),
             buffer.width(),
             buffer.height(),
             target_desc_full,
         )
-        .map_err(|_| whereat::at!(ConvertError::AllocationFailed))?;
+        .map_err_at(|_| ConvertError::AllocationFailed)?;
         return Ok(EncodeReady {
             pixels: out,
             metadata,
@@ -326,8 +333,11 @@ pub fn finalize_for_output<C: ColorManagement>(
     // Use RowConverter for format conversion.
     let mut converter = crate::RowConverter::new(source_desc, target_desc_full).at()?;
     let src_slice = buffer.as_slice();
+    // FIXME: mislabels non-alloc BufferError as AllocationFailed (needs
+    // structured ConvertError::Buffer variant = 0.3.0 break). map_err_at
+    // preserves the At<BufferError> trace.
     let mut out = PixelBuffer::try_new(buffer.width(), buffer.height(), target_desc_full)
-        .map_err(|_| whereat::at!(ConvertError::AllocationFailed))?;
+        .map_err_at(|_| ConvertError::AllocationFailed)?;
 
     {
         let mut dst_slice = out.as_slice_mut();
@@ -456,13 +466,16 @@ pub fn finalize_for_output_with(
     {
         let src_slice = buffer.as_slice();
         let bytes = src_slice.contiguous_bytes();
+        // FIXME: mislabels non-alloc BufferError as AllocationFailed (needs
+        // structured ConvertError::Buffer variant = 0.3.0 break). map_err_at
+        // preserves the At<BufferError> trace.
         let out = PixelBuffer::from_vec(
             bytes.into_owned(),
             buffer.width(),
             buffer.height(),
             target_desc_full,
         )
-        .map_err(|_| whereat::at!(ConvertError::AllocationFailed))?;
+        .map_err_at(|_| ConvertError::AllocationFailed)?;
         return Ok(EncodeReady {
             pixels: out,
             metadata,
@@ -477,8 +490,11 @@ pub fn finalize_for_output_with(
         cms,
     )?;
     let src_slice = buffer.as_slice();
+    // FIXME: mislabels non-alloc BufferError as AllocationFailed (needs
+    // structured ConvertError::Buffer variant = 0.3.0 break). map_err_at
+    // preserves the At<BufferError> trace.
     let mut out = PixelBuffer::try_new(buffer.width(), buffer.height(), target_desc_full)
-        .map_err(|_| whereat::at!(ConvertError::AllocationFailed))?;
+        .map_err_at(|_| ConvertError::AllocationFailed)?;
 
     {
         let mut dst_slice = out.as_slice_mut();


### PR DESCRIPTION
## Summary

The cross-crate `zenpixels` buffer constructors — `PixelBuffer::{try_new, from_vec}` and `PixelSlice::new` — return `Result<_, whereat::At<BufferError>>`. Ten sites in `zenpixels-convert` flattened that traced error into a non-traced `at!(...)`, losing the `At<BufferError>` frame chain at the crate boundary (the dominant trace-loss pattern in the fleet). This fixes all ten with `map_err_at` / `At::map_error`, which preserve the accumulated trace frames.

## The 10 sites fixed

**8 `AllocationFailed` sites** — were `.map_err(|_| whereat::at!(ConvertError::AllocationFailed))`:

| File | Constructor |
|------|-------------|
| `src/ext.rs` (x2) | `PixelBuffer::from_vec` |
| `src/output.rs` (x5) | `try_new` x3, `from_vec` x2 |
| `src/hdr.rs` (x1) | `PixelBuffer::from_vec` |

Switched to `.map_err_at(|_| ConvertError::AllocationFailed)` — preserves the `At<BufferError>` trace.

**The mislabel (deferred, FIXME at each site):** the `|_|` not only dropped the trace, it also mislabels non-alloc `BufferError`s (`StrideTooSmall`, `InvalidDimensions`) as `AllocationFailed`. The clean fix is a structured `ConvertError::Buffer(BufferError)` variant + `impl From`. **`ConvertError` is NOT `#[non_exhaustive]`** (there is an explicit `// TODO(0.3.0): add #[non_exhaustive]` comment in `error.rs`, removed to avoid a semver break vs 0.2.3). Per the repo's `CLAUDE.md` 0.2.x policy, adding a variant to an exhaustive enum is a **non-tolerated break requiring 0.3.0**, so I did the minimum trace-preserving fix and left a `FIXME` at each site noting the structured variant needs the `non_exhaustive`/breaking change. Worth queuing for the 0.3.0 batch.

**2 format-flatten sites** — were `at!(ConvertError::CmsError(format!("{e}")))` / `at!(CmsPluginError::msg(format!("{e:?}")))` where `e` was itself an `At<_>`, so `at!` created a fresh frame and dropped the inner trace:

- `src/converter.rs` `plugin_err` closure (`e: At<CmsPluginError>`)
- `src/cms_lite.rs` `ZenCmsLite` plan-construction arm (`e: At<ConvertError>`)

Both rewritten to render the full `At` Display into the message first, then `At::map_error(...)` — the inner trace frames carry through to the outer `At<_>` instead of being dropped. `CmsError` is a `String`-only variant so the structured `At` source can't be embedded; `map_error` keeps the frame chain while the message still shows the inner error.

## Out of scope (intentionally not touched)

`src/output.rs:381` (`build_transform_for_format`) uses the `ColorManagement::Error` associated type, which is only bounded by `core::fmt::Debug` — it is **not** an `At<_>` (could be `lcms2::Error`). Its existing `at!(...{e:?})` is the correct pattern (fresh frame at the boundary, foreign error captured via Debug); there is no inner `At` trace to preserve, so it was left as-is.

## Concurrent HDR WIP overlap (`src/hdr.rs`)

A concurrent session has uncommitted HDR-SIMD work (`hdr-s2-anchor-threading`) that also modifies `src/hdr.rs` (among others). This PR branches from `main@origin` and only touches the `from_vec` tail expression near line 258. **A future rebase conflict in `hdr.rs` is expected and resolvable** — flagging so the HDR WIP author sees the overlap when they rebase. The HDR author's working copy was left byte-identical (verified).

## Verification

All scoped to `zenpixels-convert --all-features`, via `run-heavy` (no `target-cpu=native`):
- `cargo build` — green (rc=0)
- `cargo test` — green (27 result lines, 0 failed)
- `cargo clippy --all-targets` — green, no warnings
- `cargo fmt --check` — clean

Leaving OPEN for a maintainer glance given the `hdr.rs` concurrent-WIP overlap.
