### PR TITLE
docs(zenpixels-convert): queue ConvertError::Buffer(BufferError) + non_exhaustive for 0.3.0 (mislabel fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,21 @@
   (`zenpixels::hdr` and `zencodec::info`, sibling crates). Make `zenpixels`
   the single canonical home and have `zencodec` re-export, so codecs stop
   converting between two identical types.
+- **`ConvertError`: add `#[non_exhaustive]` and a new
+  `Buffer(zenpixels::BufferError)` variant (+ `From<BufferError>`).** The 8
+  `PixelBuffer::{try_new,from_vec}` / `PixelSlice::new` construction sites
+  (in `ext.rs`, `hdr.rs`, `output.rs`) switch from the catch-all
+  `.map_err_at(|_| ConvertError::AllocationFailed)?` to
+  `.map_err_at(ConvertError::from)?`, so the real cause — `StrideTooSmall` /
+  `InvalidDimensions` / `AlignmentViolation` / `StrideNotPixelAligned` /
+  `InsufficientData` / `IncompatibleDescriptor` vs a genuine `AllocationFailed`
+  — is preserved instead of every buffer error being mislabeled as an
+  allocation (OOM) failure. The trace-preservation half (keeping the
+  `At<BufferError>` chain across the convert boundary) landed in #52; this is
+  the *classification* half — it needs the new variant and `#[non_exhaustive]`
+  on `ConvertError`, both of which are semver breaks, hence 0.3.0. (See the
+  per-site `FIXME`s and the authoritative note at the `ConvertError`
+  definition in `src/error.rs`.)
 
 ### zenpixels — docs
 

--- a/zenpixels-convert/src/error.rs
+++ b/zenpixels-convert/src/error.rs
@@ -4,7 +4,36 @@ use crate::{PixelDescriptor, TransferFunction};
 use core::fmt;
 
 /// Errors that can occur during pixel format negotiation or conversion.
-// TODO(0.3.0): add #[non_exhaustive] — removed to avoid semver break vs 0.2.3.
+//
+// ── ConvertError 0.3.0 note (authoritative) ─────────────────────────────────
+// This enum is currently EXHAUSTIVE: `#[non_exhaustive]` was removed to avoid a
+// semver break vs 0.2.3, so adding any variant is itself a break. Two related
+// changes are batched for the next 0.3.0 release (see CHANGELOG "QUEUED
+// BREAKING CHANGES"):
+//
+//   (a) Add `#[non_exhaustive]` to `ConvertError`.
+//   (b) Add a new variant `Buffer(zenpixels::BufferError)` that carries the
+//       real underlying buffer error instead of collapsing it.
+//   (c) Add `impl From<zenpixels::BufferError> for ConvertError` (wrapping into
+//       the new `Buffer` variant) so the `?`/`map_err_at` ergonomics are clean.
+//   (d) Switch the 8 `PixelBuffer::{try_new,from_vec}` / `PixelSlice::new`
+//       construction sites — 2 in `ext.rs`, 1 in `hdr.rs`, 5 in `output.rs`,
+//       each tagged with a per-site `FIXME` — from the catch-all
+//       `.map_err_at(|_| ConvertError::AllocationFailed)?` to
+//       `.map_err_at(ConvertError::from)?`.
+//
+// Why: `zenpixels::PixelBuffer`/`PixelSlice` construction returns
+// `At<zenpixels::BufferError>`, a 7-variant enum (`AlignmentViolation`,
+// `InsufficientData`, `StrideTooSmall`, `StrideNotPixelAligned`,
+// `InvalidDimensions`, `IncompatibleDescriptor`, `AllocationFailed`). Today all
+// 7 are mislabeled as `ConvertError::AllocationFailed` — i.e. a `StrideTooSmall`
+// or `InvalidDimensions` *layout* error is reported as an out-of-memory failure.
+// The #52 fix already preserves the `At<BufferError>` *trace* across the convert
+// boundary (via `map_err_at`); the remaining 0.3.0 work fixes the
+// *classification* so the true reason survives. Adding the variant and
+// `#[non_exhaustive]` are both semver breaks, which is why this is deferred to
+// 0.3.0 rather than shipped in a 0.2.N patch.
+// ────────────────────────────────────────────────────────────────────────────
 #[derive(Debug, Clone, PartialEq)]
 pub enum ConvertError {
     /// No supported format could be found for the source descriptor.


### PR DESCRIPTION
Doc/comment-only. No logic change. CI verifies (a comment can't break the build).

## What this queues

Documents — in two authoritative places — a **0.3.0 breaking change** to `zenpixels-convert::ConvertError` that fixes a misclassification bug, deferred because it needs `#[non_exhaustive]` + a new variant (both semver breaks).

### The bug being fixed (in 0.3.0)

`zenpixels::PixelBuffer::{try_new,from_vec}` / `PixelSlice::new` return `At<zenpixels::BufferError>` — a 7-variant enum (`AlignmentViolation`, `InsufficientData`, `StrideTooSmall`, `StrideNotPixelAligned`, `InvalidDimensions`, `IncompatibleDescriptor`, `AllocationFailed`). The 8 construction sites in `ConvertError`-returning code (2 in `ext.rs`, 1 in `hdr.rs`, 5 in `output.rs`) currently do:

```rust
.map_err_at(|_| ConvertError::AllocationFailed)?
```

This **mislabels all 7 reasons as `AllocationFailed`** — a `StrideTooSmall` / `InvalidDimensions` *layout* error is reported as an out-of-memory failure. The trace-preservation half (keeping the `At<BufferError>` chain across the convert boundary via `map_err_at`) already landed in #52; this is the remaining **classification** half. Each of the 8 sites already carries a `FIXME` (from #52) pointing at this.

### The planned 0.3.0 change

- (a) add `#[non_exhaustive]` to `ConvertError`
- (b) add a new variant `Buffer(zenpixels::BufferError)` carrying the real underlying error
- (c) add `impl From<zenpixels::BufferError> for ConvertError`
- (d) switch the 8 sites from `.map_err_at(|_| ConvertError::AllocationFailed)?` to `.map_err_at(ConvertError::from)?` so the true reason survives

Variant name `Buffer(zenpixels::BufferError)` matches the name the existing `output.rs` `FIXME`s already reference.

## Changes in this PR (docs only)

1. **`CHANGELOG.md`** — a new bullet under the existing `[Unreleased]` → `### QUEUED BREAKING CHANGES` list, batched for 0.3.0, referencing #52.
2. **`zenpixels-convert/src/error.rs`** — the existing one-line `// TODO(0.3.0): add #[non_exhaustive]` comment at the `ConvertError` definition is expanded into one authoritative block describing the full (a)–(d) plan and the rationale. The per-site `FIXME`s already point here; they're left intact.

Refs #52.