### PR TITLE
fix(planar+descriptor): div-by-zero panic + 32-bit silent under-alloc (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,33 @@
   (`benchmarks/orient_fast_transpose_2026-06-18.md`). Flipping a default feature
   batches here; size-sensitive builds opt out via `default-features = false`.
 
+### zenpixels — fixed
+
+- **`PlaneDescriptor::plane_width` / `plane_height` no longer panic with
+  divide-by-zero on `h_subsample == 0` / `v_subsample == 0`** (`planar.rs`,
+  [#43](https://github.com/imazen/zenpixels/issues/43) item 1). The
+  subsample fields are public, so any code path that struct-literals a
+  `PlaneDescriptor` or maps an out-of-range codec subsampling code to
+  factor 0 could set them to 0 — the next `plane_width` call then
+  panicked in release. Now `0` is treated as `1` (full resolution) at the
+  use-site, so production servers never see the abort. The
+  [`with_subsampling`](https://docs.rs/zenpixels/0.2/zenpixels/struct.PlaneDescriptor.html#method.with_subsampling)
+  builder's `debug_assert!` still catches the misuse in dev / test.
+  Non-breaking; signature unchanged.
+- **`PixelDescriptor::aligned_stride` / `simd_aligned_stride` overflow-safe
+  on 32-bit targets (i686, wasm32)** (`descriptor.rs`,
+  [#43](https://github.com/imazen/zenpixels/issues/43) item 2). The plain
+  `width as usize * bpp` multiply could wrap silently on 32-bit `usize` —
+  producing a small stride that passed the subsequent `checked_mul(height)`
+  guard and yielded an under-sized allocation paired with the full-size
+  `width` field (silent buffer corruption / deferred OOB, instead of the
+  documented `InvalidDimensions` typed error). Both methods now use
+  `saturating_mul`, and the `align_up_general` helper saturates too so
+  the upstream guard isn't undone by a wrap in `value + (align − rem)`.
+  Strides saturate to `usize::MAX`, which downstream `checked_mul` then
+  surfaces as `InvalidDimensions`. Matches the `PixelBuffer::from_pixels`
+  guard that already had this treatment. Non-breaking.
+
 ## [0.2.15] - 2026-06-18
 
 ### zenpixels — added

--- a/zenpixels/src/descriptor.rs
+++ b/zenpixels/src/descriptor.rs
@@ -1259,21 +1259,36 @@ impl PixelDescriptor {
         self.format.channel_type().byte_size()
     }
 
-    /// Tightly-packed byte stride for a given width.
+    /// Tightly-packed byte stride for a given width, in bytes.
+    ///
+    /// **Overflow-safe.** `width * bytes_per_pixel` is computed with
+    /// [`usize::saturating_mul`] so the result never wraps — on 32-bit
+    /// targets (i686, wasm32) a width that would overflow `usize` returns
+    /// `usize::MAX` instead of a silently-truncated small stride.
+    /// Downstream `checked_mul(height)` then surfaces the overflow as
+    /// [`BufferError::InvalidDimensions`](crate::BufferError::InvalidDimensions)
+    /// rather than silently under-allocating; before this guard, a 32-bit
+    /// wrap could pass the height multiply and produce a small buffer
+    /// paired with the full-size `width` field — silent corruption.
     #[inline]
     pub const fn aligned_stride(self, width: u32) -> usize {
-        width as usize * self.bytes_per_pixel()
+        (width as usize).saturating_mul(self.bytes_per_pixel())
     }
 
-    /// SIMD-friendly byte stride for a given width.
+    /// SIMD-friendly byte stride for a given width, in bytes.
     ///
     /// The stride is a multiple of `lcm(bytes_per_pixel, simd_align)`,
     /// ensuring every row start is both pixel-aligned and SIMD-aligned.
     /// `simd_align` must be a power of 2.
+    ///
+    /// **Overflow-safe** (see [`aligned_stride`](Self::aligned_stride)):
+    /// the `width * bpp` multiply saturates, and the align-up step is
+    /// also saturating, so the result stays bounded at `usize::MAX` on
+    /// overflow and downstream allocation surfaces a typed error.
     #[inline]
     pub const fn simd_aligned_stride(self, width: u32, simd_align: usize) -> usize {
         let bpp = self.bytes_per_pixel();
-        let raw = width as usize * bpp;
+        let raw = (width as usize).saturating_mul(bpp);
         let align = lcm(bpp, simd_align);
         align_up_general(raw, align)
     }
@@ -1308,12 +1323,26 @@ const fn lcm(a: usize, b: usize) -> usize {
     }
 }
 
+/// Round `value` up to the next multiple of `align`, saturating at
+/// `usize::MAX` on overflow.
+///
+/// Saturation matters when `value` is itself the saturating-mul result of
+/// [`PixelDescriptor::aligned_stride`] / [`PixelDescriptor::simd_aligned_stride`]:
+/// without it, `value + (align - rem)` could wrap from `usize::MAX` back
+/// down to a small number, defeating the saturating-mul guard one layer up.
 const fn align_up_general(value: usize, align: usize) -> usize {
     if align == 0 {
         return value;
     }
     let rem = value % align;
-    if rem == 0 { value } else { value + align - rem }
+    if rem == 0 {
+        value
+    } else {
+        match value.checked_add(align - rem) {
+            Some(v) => v,
+            None => usize::MAX,
+        }
+    }
 }
 
 impl fmt::Display for PixelDescriptor {
@@ -2127,6 +2156,44 @@ mod tests {
         assert_eq!(PixelDescriptor::RGB8_SRGB.aligned_stride(100), 300);
         assert_eq!(PixelDescriptor::RGBA8_SRGB.aligned_stride(100), 400);
         assert_eq!(PixelDescriptor::RGBF32_LINEAR.aligned_stride(10), 120);
+    }
+
+    #[test]
+    fn aligned_stride_saturates_at_usize_overflow() {
+        // On 32-bit usize, width × bpp can wrap. Saturating-mul keeps the
+        // stride at usize::MAX so downstream `checked_mul(height)` raises
+        // a typed error rather than silently under-allocating. Verified
+        // here on 64-bit too (u32::MAX × bpp doesn't overflow 64-bit usize
+        // but still exercises the wide multiply path).
+        let huge = u32::MAX; // 4 294 967 295
+        // RGBA8 = 4 bytes/pixel.
+        let stride = PixelDescriptor::RGBA8_SRGB.aligned_stride(huge);
+        // On 32-bit (usize == u32): u32::MAX × 4 wraps → saturating returns usize::MAX.
+        // On 64-bit (usize == u64): no wrap (~17 GB), saturating no-op.
+        #[cfg(target_pointer_width = "32")]
+        assert_eq!(stride, usize::MAX);
+        #[cfg(target_pointer_width = "64")]
+        assert_eq!(stride, huge as usize * 4);
+
+        // RGBF32 = 12 bytes/pixel — overflows usize at 357 913 942 px on 32-bit.
+        let stride = PixelDescriptor::RGBF32_LINEAR.aligned_stride(huge);
+        #[cfg(target_pointer_width = "32")]
+        assert_eq!(stride, usize::MAX);
+        #[cfg(target_pointer_width = "64")]
+        assert_eq!(stride, huge as usize * 12);
+    }
+
+    #[test]
+    fn simd_aligned_stride_saturates_and_does_not_wrap_via_align_up() {
+        // Even when raw width*bpp saturates to usize::MAX, the align-up
+        // step is now also saturating — without that fix, `value + (align
+        // - rem)` could wrap from MAX back to a small number, defeating
+        // the upstream guard. Verify the saturating path stays at MAX.
+        let stride = PixelDescriptor::RGBA8_SRGB.simd_aligned_stride(u32::MAX, 64);
+        #[cfg(target_pointer_width = "32")]
+        assert_eq!(stride, usize::MAX);
+        #[cfg(target_pointer_width = "64")]
+        assert!(stride >= u32::MAX as usize * 4);
     }
 
     #[test]

--- a/zenpixels/src/planar.rs
+++ b/zenpixels/src/planar.rs
@@ -295,17 +295,38 @@ impl PlaneDescriptor {
     /// Compute the width of this plane given a reference (luma) width.
     ///
     /// Uses ceiling division so subsampled planes always cover the full image.
+    ///
+    /// **Robustness**: `h_subsample` is a public field, so a struct-literal
+    /// write or a codec mapping an out-of-range subsampling code to factor 0
+    /// can leave the divisor at 0 — which would panic the `div_ceil` in
+    /// release. We saturate the divisor at 1 here so production servers
+    /// never see a divide-by-zero abort; the [`with_subsampling`] builder's
+    /// `debug_assert!` still catches the misuse in dev/test.
     #[inline]
     pub const fn plane_width(&self, ref_width: u32) -> u32 {
-        ref_width.div_ceil(self.h_subsample as u32)
+        // `max` is not const-stable on `u32` for older MSRVs, so unroll.
+        let f = if self.h_subsample == 0 {
+            1
+        } else {
+            self.h_subsample as u32
+        };
+        ref_width.div_ceil(f)
     }
 
     /// Compute the height of this plane given a reference (luma) height.
     ///
     /// Uses ceiling division so subsampled planes always cover the full image.
+    ///
+    /// **Robustness**: see [`plane_width`](Self::plane_width) — same div-by-zero
+    /// guard for `v_subsample`.
     #[inline]
     pub const fn plane_height(&self, ref_height: u32) -> u32 {
-        ref_height.div_ceil(self.v_subsample as u32)
+        let f = if self.v_subsample == 0 {
+            1
+        } else {
+            self.v_subsample as u32
+        };
+        ref_height.div_ceil(f)
     }
 
     /// Whether this plane is subsampled (either axis).
@@ -1326,5 +1347,45 @@ mod tests {
         assert!(layout.luma_mask().is_empty());
         assert!(layout.chroma_mask().is_empty());
         assert!(layout.alpha_mask().is_empty());
+    }
+
+    #[test]
+    fn plane_width_height_do_not_panic_when_subsample_is_zero() {
+        // `h_subsample` / `v_subsample` are public fields — any code path
+        // that constructs a PlaneDescriptor with a literal or sets the
+        // field directly can leave the factor at 0. Pre-fix, the next
+        // `plane_width` / `plane_height` call panicked in release with
+        // divide-by-zero. We now treat 0 as 1 (full resolution) so a
+        // production server never sees the abort.
+        let plane = PlaneDescriptor {
+            semantic: PlaneSemantic::Luma,
+            channel_type: ChannelType::U8,
+            h_subsample: 0,
+            v_subsample: 0,
+        };
+        // No panic; result is the full reference size.
+        assert_eq!(plane.plane_width(1920), 1920);
+        assert_eq!(plane.plane_height(1080), 1080);
+
+        // Mixed: h zero, v sane.
+        let plane = PlaneDescriptor {
+            semantic: PlaneSemantic::ChromaCb,
+            channel_type: ChannelType::U8,
+            h_subsample: 0,
+            v_subsample: 2,
+        };
+        assert_eq!(plane.plane_width(1920), 1920);
+        assert_eq!(plane.plane_height(1080), 540);
+    }
+
+    #[test]
+    fn plane_width_height_still_work_normally() {
+        // Sanity: non-zero subsampling still divides correctly.
+        let plane =
+            PlaneDescriptor::new(PlaneSemantic::Luma, ChannelType::U8).with_subsampling(2, 2);
+        assert_eq!(plane.plane_width(1920), 960);
+        assert_eq!(plane.plane_height(1080), 540);
+        // Odd input + ceiling division.
+        assert_eq!(plane.plane_width(1921), 961);
     }
 }


### PR DESCRIPTION
Closes #43.

Two production-readiness bugs from the audit, both fixable non-breakingly at the use site.

## 1. `PlaneDescriptor::plane_width` / `plane_height` div-by-zero panic

`ref_width.div_ceil(self.h_subsample as u32)` panicked in release whenever `h_subsample` was 0. The fields are public (`planar.rs:257,259`) so any struct-literal write or out-of-range codec subsampling code could trigger it. The only guard, `with_subsampling`'s `debug_assert!`, is a no-op in release.

**Fix**: saturate the divisor at 1 at the use site (treating 0 as full resolution). Production servers never see the abort; the builder's `debug_assert!` still catches the misuse in dev/test. **Non-breaking; signature unchanged**.

## 2. `aligned_stride` / `simd_aligned_stride` 32-bit silent under-allocation

`width as usize * bpp` plain unchecked multiply inside `const fn` (`descriptor.rs:1264-1278`). On 32-bit targets (i686, wasm32 — both primary CI targets) this wraps silently → small stride → passes downstream `checked_mul(height)` guard → under-sized allocation paired with full-size `width` field. Silent corruption / deferred OOB instead of the documented `InvalidDimensions` typed error. `PixelBuffer::from_pixels` (`buffer.rs:1665`) already had the 32-bit guard; the stride computation hadn't been given the same treatment.

**Fix**: both methods use `saturating_mul`. `align_up_general` also saturates so `value + (align − rem)` can't wrap from `usize::MAX` back down to a small number, undoing the upstream guard. Strides saturate to `usize::MAX`, which downstream `checked_mul` surfaces as `InvalidDimensions` cleanly. **Non-breaking**.

## Verification

4 new regression tests, all passing:
- `plane_width_height_do_not_panic_when_subsample_is_zero` — literal-zero field write, mixed zero/non-zero, both axes
- `plane_width_height_still_work_normally` — builder path still divides correctly
- `aligned_stride_saturates_at_usize_overflow` — `u32::MAX × {4, 12}`, `cfg(target_pointer_width)`-branched so the saturation assertion fires on the targets where the bug is real
- `simd_aligned_stride_saturates_and_does_not_wrap_via_align_up` — the align-up step doesn't undo the saturation

`cargo test -p zenpixels --lib`: 240 passed (was 236). `cargo clippy -- -D warnings`: clean. `cargo fmt`: clean.

CHANGELOG entry added under `[Unreleased] → zenpixels — fixed`.