### PR TITLE
feat(zenpixels-convert): pluggable ToneMapper trait + ConvertPlanBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 ## [Unreleased]
 
+### zenpixels-convert 0.2.16 — added (pluggable HDR tone mapping)
+
+- **New `pub trait hdr::ToneMapper`** — object-safe `Send + Sync + Debug`
+  trait, the permanent dependency-injection surface for HDR→SDR tone
+  mapping inside [`ConvertPlan`]. Methods: `map_strip(&[f32], &mut [f32])`,
+  `working_primaries` (default `Bt2020`), `peaks` (`Option<(f32, f32)>`),
+  `name(&'static str)`, `cost_ns_per_mp` (default 1500). Gated behind
+  `hdr-experimental`. Reachable at the module path
+  `zenpixels_convert::hdr::ToneMapper` (kept aligned with the
+  `hdr::Bt2446A` re-export shape — neither is re-exported at the crate
+  root).
+- **New `pub struct ConvertPlanBuilder` + `ConvertPlan::builder()`** —
+  fluent builder for HDR plans. Setters: `from`, `to`,
+  `source_peak_nits`, `target_peak_nits`, `gamut_knee`, `hdr_config`,
+  `with_tone_mapper(Arc<dyn ToneMapper>)`. Read accessor for extension
+  traits: `current_hdr_config(&self) -> &HdrConfig`. Finalize with
+  `build() -> Result<ConvertPlan, At<ConvertError>>`. Re-exported at the
+  crate root alongside `HdrConfig`. Gated on `hdr-experimental`.
+- **`hdr::Bt2446A` now implements `ToneMapper`** — `name == "bt2446a"`,
+  primaries `Bt2020`, peaks `Some((source_peak_nits, target_peak_nits))`,
+  `cost_ns_per_mp == 4_194_304` (matches the per-step calibration in
+  `estimate`). New `Bt2446A::source_peak_nits()` /
+  `Bt2446A::target_peak_nits()` accessors expose the constructor inputs.
+- **New runnable `examples/custom_tone_mapper.rs`** — minimal
+  `LinearClip` mapper injected via the builder, demonstrating the
+  dyn-dispatch wiring end-to-end.
+- **Crate-internal `ConvertStep::ToneMapBt2446A` →
+  `ConvertStep::ToneMap(Arc<dyn ToneMapper>)`.** `pub(crate)` enum —
+  internal refactor only, no semver impact. Existing public entry points
+  (`new_with_hdr_peak`, `new_with_hdr_config`, the `ext::PixelBufferHdrConvertExt`
+  trait, and `convert_to_with_hdr_config`) preserve byte-for-byte output;
+  they construct the in-crate `Bt2446A` internally and feed it through
+  the same kernel as before.
+- **Cost model.** `estimate::step_cost_ns_per_mp` now delegates to
+  `ToneMapper::cost_ns_per_mp` for tone-map steps, so custom mappers'
+  per-MP cost shows up in
+  `ConvertPlan::estimate` / `ConvertPlan::estimate_in` automatically.
+- Tests: new `tests/builder.rs` (9 integration tests) covers default-mapper
+  parity with `new_with_hdr_peak`, full-`HdrConfig` parity, piecemeal
+  setter composition, custom-mapper dispatch end-to-end, RGBA alpha
+  passthrough through a custom mapper, `current_hdr_config` introspection,
+  `Default` parity with `new()`, missing-descriptor error, and the
+  `Bt2446A` trait roster. New unit tests in `src/hdr/tone_mapper.rs`
+  assert object-safety (`fn _assert_obj_safe(_: &dyn ToneMapper)`) and
+  identity-mapper round-trip through `Arc<dyn ToneMapper>`.
+- `cargo semver-checks` reports additive only against 0.2.15. Version
+  bumped to `0.2.16` (patch).
+
 ### zenpixels-convert — changed (Tier 1 ablation: drop codec-only fields; add intermediate_buffer_count)
 
 - **Trimmed the estimate-API surface to what `zenpixels-convert` actually

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "zenpixels-convert"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "archmage",
  "bytemuck",

--- a/docs/public-api/zenpixels-convert.features.txt
+++ b/docs/public-api/zenpixels-convert.features.txt
@@ -10,23 +10,23 @@
 ## summary
 #
 #   pub modules                                 6
-#   pub types (struct/enum/trait/alias)        42
+#   pub types (struct/enum/trait/alias)        44
 #   pub consts/statics                         12
 #   free functions                             12
-#   inherent methods                           45
+#   inherent methods                           63
 #   struct fields                             108
 #   enum variants                              70
-#   trait roster entries (type × trait)        63
-#   auto-trait-complete types                  16
+#   trait roster entries (type × trait)        66
+#   auto-trait-complete types                  17
 #
 # per-module pub lines:
-#   (root)                           86
+#   (root)                           98
 #   cms_moxcms                        5
 #   ext                               8
-#   hdr                              26
+#   hdr                              34
 #   pipeline                        170
 
-## items (266 lines)
+## items (286 lines)
 
 pub mod cms_moxcms
 pub struct cms_moxcms::MoxCmsError(pub alloc::string::String)
@@ -50,6 +50,8 @@ pub struct hdr::Bt2446A
 pub fn hdr::Bt2446A::map_rgb(&self, [f32; 3]) -> [f32; 3]
 pub fn hdr::Bt2446A::map_strip_simd(&self, &mut [[f32; 3]])
 pub fn hdr::Bt2446A::new(f32, f32) -> Self
+pub fn hdr::Bt2446A::source_peak_nits(&self) -> f32
+pub fn hdr::Bt2446A::target_peak_nits(&self) -> f32
 pub struct hdr::GamutBoundaryLut
 pub fn hdr::GamutBoundaryLut::compress_planes(&self, &[f32], &mut [f32], &mut [f32], f32)
 pub fn hdr::GamutBoundaryLut::max_chroma(&self, f32, f32) -> f32
@@ -63,6 +65,12 @@ pub fn hdr::SoftCompress::lut(&self) -> &hdr::GamutBoundaryLut
 pub fn hdr::SoftCompress::new(&gamut::GamutMatrix, f32) -> Self
 pub trait hdr::CllMeasure [also: hdr::measure]
 pub fn hdr::CllMeasure::measure_max(zenpixels::buffer::PixelSlice<'_>, zenpixels::hdr::DiffuseWhite, hdr::measure::LightLevelMethod) -> core::option::Option<zenpixels::hdr::ContentLightLevel>
+pub trait hdr::ToneMapper: core::marker::Send + core::marker::Sync + core::panic::unwind_safe::UnwindSafe + core::panic::unwind_safe::RefUnwindSafe + core::fmt::Debug
+pub fn hdr::ToneMapper::cost_ns_per_mp(&self) -> u32
+pub fn hdr::ToneMapper::map_strip(&self, &[f32], &mut [f32])
+pub fn hdr::ToneMapper::name(&self) -> &'static str
+pub fn hdr::ToneMapper::peaks(&self) -> core::option::Option<(f32, f32)>
+pub fn hdr::ToneMapper::working_primaries(&self) -> zenpixels::descriptor::ColorPrimaries
 pub mod pipeline
 pub mod pipeline::op_format
 pub pipeline::op_format::OpCategory::Arithmetic
@@ -252,8 +260,20 @@ pub ConversionPath::working_format: zenpixels::descriptor::PixelDescriptor
 pub ConversionPath::working_suitability: u16
 pub ConversionPath::working_to_output: ConversionCost
 pub fn pipeline::path::ConversionPath::loss_bucket(&self) -> pipeline::path::LossBucket
+pub fn ConvertPlan::builder() -> ConvertPlanBuilder
 pub fn ConvertPlan::new_with_hdr_config(zenpixels::descriptor::PixelDescriptor, zenpixels::descriptor::PixelDescriptor, HdrConfig) -> core::result::Result<Self, whereat::at::At<error::ConvertError>>
 pub fn ConvertPlan::new_with_hdr_peak(zenpixels::descriptor::PixelDescriptor, zenpixels::descriptor::PixelDescriptor, f32) -> core::result::Result<Self, whereat::at::At<error::ConvertError>>
+pub struct ConvertPlanBuilder
+pub fn ConvertPlanBuilder::build(self) -> core::result::Result<ConvertPlan, whereat::at::At<error::ConvertError>>
+pub fn ConvertPlanBuilder::current_hdr_config(&self) -> &HdrConfig
+pub fn ConvertPlanBuilder::from(self, zenpixels::descriptor::PixelDescriptor) -> Self
+pub fn ConvertPlanBuilder::gamut_knee(self, f32) -> Self
+pub fn ConvertPlanBuilder::hdr_config(self, HdrConfig) -> Self
+pub fn ConvertPlanBuilder::new() -> Self
+pub fn ConvertPlanBuilder::source_peak_nits(self, f32) -> Self
+pub fn ConvertPlanBuilder::target_peak_nits(self, f32) -> Self
+pub fn ConvertPlanBuilder::to(self, zenpixels::descriptor::PixelDescriptor) -> Self
+pub fn ConvertPlanBuilder::with_tone_mapper(self, alloc::sync::Arc<dyn hdr::ToneMapper>) -> Self
 pub struct FormatEntry [also: pipeline, pipeline::registry]
 pub FormatEntry::can_overshoot: bool
 pub FormatEntry::descriptor: zenpixels::descriptor::PixelDescriptor
@@ -295,12 +315,13 @@ pub fn generate_path_matrix(&[&pipeline::registry::CodecFormats], &[pipeline::op
 pub fn matrix_stats(&[pipeline::path::PathEntry]) -> pipeline::path::MatrixStats [also: pipeline, pipeline::path]
 pub fn optimal_path(zenpixels::descriptor::PixelDescriptor, Provenance, pipeline::op_format::OpCategory, zenpixels::descriptor::PixelDescriptor, pipeline::path::QualityThreshold) -> core::option::Option<pipeline::path::ConversionPath> [also: pipeline, pipeline::path]
 
-## trait impls (18 types)
+## trait impls (19 types)
 
+ConvertPlanBuilder: Debug, Default
 HdrConfig: Clone, Copy, Debug, Default, PartialEq
 cms_moxcms::MoxCms: Clone, Copy, Debug, Default, cms::ColorManagement, cms::PluggableCms
 cms_moxcms::MoxCmsError: Clone, Debug, Display
-hdr::Bt2446A: Clone, Copy, Debug
+hdr::Bt2446A: Clone, Copy, Debug, hdr::ToneMapper
 hdr::GamutBoundaryLut: Clone, Debug
 hdr::SoftCompress: Clone, Debug
 hdr::measure::LightLevelMethod: Clone, Copy, Debug, Default, Eq, Hash, PartialEq

--- a/zenpixels-convert/Cargo.toml
+++ b/zenpixels-convert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zenpixels-convert"
-version = "0.2.15"
+version = "0.2.16"
 edition.workspace = true
 rust-version = "1.89"
 license.workspace = true

--- a/zenpixels-convert/Cargo.toml
+++ b/zenpixels-convert/Cargo.toml
@@ -225,3 +225,8 @@ required-features = ["__bench_orient"]
 name = "measure_histogram_throughput"
 path = "examples/measure_histogram_throughput.rs"
 required-features = ["hdr-experimental"]
+
+[[example]]
+name = "custom_tone_mapper"
+path = "examples/custom_tone_mapper.rs"
+required-features = ["hdr-experimental"]

--- a/zenpixels-convert/examples/custom_tone_mapper.rs
+++ b/zenpixels-convert/examples/custom_tone_mapper.rs
@@ -1,0 +1,87 @@
+//! Demonstrate injecting a custom [`ToneMapper`] into a
+//! [`ConvertPlan`] via [`ConvertPlanBuilder::with_tone_mapper`].
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example custom_tone_mapper --features hdr-experimental
+//! ```
+//!
+//! The mapper here is a deliberately-tiny linear clip — the point is
+//! to show the dyn-dispatch wiring, not the curve. For production-grade
+//! curves (FilmicSpline, ACES, ITU-R BT.2408, Möbius, Yrg, Jzazbz, …)
+//! reach for the `zentone` crate, which also publishes a fluent
+//! extension trait that lifts away the `Arc::new` boilerplate.
+
+use std::sync::Arc;
+
+use zenpixels_convert::hdr::ToneMapper;
+use zenpixels_convert::{
+    ChannelLayout, ChannelType, ColorPrimaries, ConvertPlan, PixelDescriptor, TransferFunction,
+    convert_row,
+};
+
+/// Trivial linear-clip mapper: divides the strip by `peak` and clamps
+/// to `[0, 1]`. Demonstrates the trait surface only — do not use this
+/// for actual HDR→SDR work; reach for `zentone::Bt2446A` or a richer
+/// curve there.
+#[derive(Debug)]
+struct LinearClip {
+    peak: f32,
+}
+
+impl ToneMapper for LinearClip {
+    fn map_strip(&self, input: &[f32], output: &mut [f32]) {
+        for (i, o) in input.iter().zip(output.iter_mut()) {
+            *o = (i / self.peak).clamp(0.0, 1.0);
+        }
+    }
+    fn name(&self) -> &'static str {
+        "linear-clip-example"
+    }
+    fn peaks(&self) -> Option<(f32, f32)> {
+        Some((self.peak, 100.0))
+    }
+    fn working_primaries(&self) -> ColorPrimaries {
+        ColorPrimaries::Bt2020
+    }
+}
+
+fn main() {
+    // Linear-light BT.2020 RGB f32 on both sides — keeps the encode
+    // chain identity-ish so the focus is on the mapper itself.
+    let descriptor = PixelDescriptor::new_full(
+        ChannelType::F32,
+        ChannelLayout::Rgb,
+        None,
+        TransferFunction::Linear,
+        ColorPrimaries::Bt2020,
+    );
+
+    let plan = ConvertPlan::builder()
+        .from(descriptor)
+        .to(descriptor)
+        .source_peak_nits(1000.0)
+        .with_tone_mapper(Arc::new(LinearClip { peak: 1000.0 }))
+        .build()
+        .expect("plan");
+
+    // Drive a 4-pixel strip ramping from black to a 750-nit highlight
+    // (in source-normalized linear-light coords, `750 / 1000 = 0.75`).
+    let mut src = Vec::new();
+    for v in [0.0f32, 250.0, 500.0, 750.0] {
+        let normalized = v / 1000.0;
+        for _ in 0..3 {
+            src.extend_from_slice(&normalized.to_ne_bytes());
+        }
+    }
+    let mut dst = vec![0u8; src.len()];
+    convert_row(&plan, &src, &mut dst, 4);
+
+    println!("custom_tone_mapper example — LinearClip @ 1000 nits");
+    for px in 0..4 {
+        let off = px * 12;
+        let r = f32::from_ne_bytes([dst[off], dst[off + 1], dst[off + 2], dst[off + 3]]);
+        println!("  pixel {px}: R = {r:.3}");
+    }
+}

--- a/zenpixels-convert/src/convert.rs
+++ b/zenpixels-convert/src/convert.rs
@@ -276,21 +276,31 @@ pub(crate) enum ConvertStep {
     /// sequence `[<lin>, GamutMatrix*F32, <enc>]` whenever the planner can
     /// peephole it. See [`FusedKind`] for the supported shapes.
     Fused { kind: FusedKind, matrix: [f32; 9] },
-    /// BT.2446 Method A HDR→SDR tone-map on linear-light f32 RGB in BT.2020
-    /// primaries. The plan builder ensures this step sees BT.2020 linear-light
-    /// input via preceding gamut-matrix steps; a following gamut-matrix step
+    /// Pluggable HDR→SDR tone-map step on linear-light f32 RGB in
+    /// [`ColorPrimaries::Bt2020`] (the working space). The plan builder
+    /// ensures this step sees BT.2020 linear-light input via preceding
+    /// gamut-matrix steps; a following gamut-matrix step
     /// (BT.2020 → target.primaries) handles the destination primaries.
-    /// Input is source-normalized (`1.0 = source_peak_nits`); output is
-    /// target-normalized (`1.0 = target_peak_nits`). RGB-only — alpha is
-    /// handled at descriptor-layout level (the planner pairs this with the
+    ///
+    /// Carries an `Arc<dyn crate::hdr::ToneMapper>`, so the concrete
+    /// curve is injected at plan build time:
+    ///   - default plans (`new_with_hdr_peak` / `new_with_hdr_config`)
+    ///     construct [`crate::hdr::Bt2446A`] — the ITU-R BT.2446-1 §4
+    ///     reference;
+    ///   - explicit injection via
+    ///     [`crate::ConvertPlanBuilder::with_tone_mapper`] swaps in any
+    ///     `ToneMapper` (FilmicSpline / ACES / ITU-R BT.2408 / Möbius /
+    ///     custom).
+    ///
+    /// Input is source-normalized (`1.0 = source_peak_nits` from
+    /// `mapper.peaks()`); output is target-normalized
+    /// (`1.0 = target_peak_nits`). RGB-only — alpha is handled at
+    /// descriptor-layout level (the planner pairs this with the
     /// appropriate RGB/RGBA carrier).
     ///
     /// Gated behind `hdr-experimental` at the kernel side.
     #[cfg(feature = "hdr-experimental")]
-    ToneMapBt2446A {
-        source_peak_nits: f32,
-        target_peak_nits: f32,
-    },
+    ToneMap(alloc::sync::Arc<dyn crate::hdr::ToneMapper>),
     /// OKLch soft chroma compression on linear-light f32 RGB in
     /// `primaries`. Pulls residual out-of-gamut excursions back into the
     /// target unit cube using a hue-preserving rational knee curve.
@@ -364,7 +374,11 @@ impl ConvertStep {
             Self::GamutMatrixRgbaF32(_) => "GamutMatrixRgbaF32",
             Self::Fused { kind, .. } => kind.variant_name(),
             #[cfg(feature = "hdr-experimental")]
-            Self::ToneMapBt2446A { .. } => "ToneMapBt2446A",
+            // The variant name is the generic tag; the trace recorder
+            // (`__trace_ops`) reports the kebab-case mapper name via the
+            // dedicated dispatcher in `apply_step_u8`, so this stays
+            // shape-stable across mapper choices.
+            Self::ToneMap(_) => "ToneMap",
             #[cfg(feature = "hdr-experimental")]
             Self::SoftCompressOklch { .. } => "SoftCompressOklch",
         }
@@ -879,8 +893,9 @@ impl ConvertPlan {
     ///    [`ConvertPlan::new`]. Skipped when the source is already
     ///    `Linear`.
     /// 2. Source primaries → BT.2020 matrix (skipped when source is BT.2020).
-    /// 3. `ToneMapBt2446A` step (the BT.2446 Method A curve operating in
-    ///    BT.2020 RGB).
+    /// 3. `ToneMap` step (BT.2446 Method A by default — the in-crate
+    ///    [`crate::hdr::Bt2446A`] reference; swappable via
+    ///    [`crate::ConvertPlanBuilder::with_tone_mapper`]).
     /// 4. BT.2020 → target primaries matrix (skipped when target is BT.2020).
     /// 5. `SoftCompressOklch` step (skipped when target is BT.2020 —
     ///    wide-gamut output mode preserves chroma).
@@ -892,7 +907,7 @@ impl ConvertPlan {
     /// [`ConvertPlan::new`] would build — no tone-map gets injected into
     /// a path that doesn't need one.
     ///
-    // ToneMapBt2446A / SoftCompressOklch are crate-internal `ConvertStep` variants
+    // ToneMap / SoftCompressOklch are crate-internal `ConvertStep` variants
     // — referenced by name in the prose above; explicit links would point at
     // private items.
     ///
@@ -998,10 +1013,12 @@ impl ConvertPlan {
         }
 
         // ---- (c) BT.2446 Method A tone map (BT.2020 HDR → BT.2020 SDR).
-        steps.push(ConvertStep::ToneMapBt2446A {
-            source_peak_nits: hdr.source_peak_nits,
-            target_peak_nits: hdr.target_peak_nits,
-        });
+        // The default mapper is the ITU-R BT.2446-1 §4 reference curve;
+        // `ConvertPlanBuilder::with_tone_mapper` swaps in a custom one
+        // before the planner is invoked.
+        steps.push(ConvertStep::ToneMap(alloc::sync::Arc::new(
+            crate::hdr::Bt2446A::new(hdr.source_peak_nits, hdr.target_peak_nits),
+        )));
 
         // ---- (d) BT.2020 → target primaries (skip when target IS BT.2020).
         if to.primaries != ColorPrimaries::Bt2020
@@ -2358,12 +2375,12 @@ fn intermediate_desc(current: PixelDescriptor, step: &ConvertStep) -> PixelDescr
             current.transfer(),
         ),
         // HDR steps. Both operate on linear-light F32 RGB and preserve the
-        // layout/alpha/transfer/depth of the carrier. ToneMapBt2446A operates
+        // layout/alpha/transfer/depth of the carrier. `ToneMap` operates
         // in BT.2020 (planner-enforced); SoftCompressOklch operates in the
         // step's stored `primaries`. Neither step changes the descriptor
         // shape — they only update pixel values.
         #[cfg(feature = "hdr-experimental")]
-        ConvertStep::ToneMapBt2446A { .. } => current,
+        ConvertStep::ToneMap(_) => current,
         #[cfg(feature = "hdr-experimental")]
         ConvertStep::SoftCompressOklch { .. } => current,
     }

--- a/zenpixels-convert/src/convert.rs
+++ b/zenpixels-convert/src/convert.rs
@@ -930,6 +930,24 @@ impl ConvertPlan {
         to: PixelDescriptor,
         hdr: HdrConfig,
     ) -> Result<Self, At<ConvertError>> {
+        // Default tone mapper: the ITU-R BT.2446-1 §4 reference curve.
+        // Routes through the same internal planner that
+        // `ConvertPlanBuilder::build` uses, so byte-for-byte output is
+        // preserved.
+        Self::plan_hdr(from, to, hdr, None)
+    }
+
+    /// Internal HDR planner shared by [`Self::new_with_hdr_config`] and
+    /// [`ConvertPlanBuilder::build`]. When `mapper` is `None` we
+    /// construct the default [`crate::hdr::Bt2446A`] from `hdr`.
+    #[cfg(feature = "hdr-experimental")]
+    #[track_caller]
+    fn plan_hdr(
+        from: PixelDescriptor,
+        to: PixelDescriptor,
+        hdr: HdrConfig,
+        mapper: Option<alloc::sync::Arc<dyn crate::hdr::ToneMapper>>,
+    ) -> Result<Self, At<ConvertError>> {
         if requires_cms(&from, &to) {
             return Err(whereat::at!(ConvertError::NeedsCms { from, to }));
         }
@@ -1012,13 +1030,17 @@ impl ConvertPlan {
             steps.push(step);
         }
 
-        // ---- (c) BT.2446 Method A tone map (BT.2020 HDR → BT.2020 SDR).
-        // The default mapper is the ITU-R BT.2446-1 §4 reference curve;
-        // `ConvertPlanBuilder::with_tone_mapper` swaps in a custom one
-        // before the planner is invoked.
-        steps.push(ConvertStep::ToneMap(alloc::sync::Arc::new(
-            crate::hdr::Bt2446A::new(hdr.source_peak_nits, hdr.target_peak_nits),
-        )));
+        // ---- (c) Tone-map step. The mapper is either the caller-supplied
+        // one (via `ConvertPlanBuilder::with_tone_mapper`) or the
+        // in-crate BT.2446-A reference curve, constructed from the
+        // builder's `HdrConfig`.
+        let mapper = mapper.unwrap_or_else(|| {
+            alloc::sync::Arc::new(crate::hdr::Bt2446A::new(
+                hdr.source_peak_nits,
+                hdr.target_peak_nits,
+            )) as alloc::sync::Arc<dyn crate::hdr::ToneMapper>
+        });
+        steps.push(ConvertStep::ToneMap(mapper));
 
         // ---- (d) BT.2020 → target primaries (skip when target IS BT.2020).
         if to.primaries != ColorPrimaries::Bt2020
@@ -1416,6 +1438,252 @@ impl ConvertPlan {
         let image = crate::estimate::ImageCharacteristics::new(width, height, self.from());
         let compute = crate::estimate::ComputeEnvironment::new();
         self.estimate_in(&image, &compute)
+    }
+
+    /// Begin a fluent build of a [`ConvertPlan`] with optional pluggable
+    /// HDR tone mapping.
+    ///
+    /// Equivalent to [`ConvertPlanBuilder::new`]. See the
+    /// [crate-level "Pluggable HDR tone mapping" section][docs] for the
+    /// full usage story and [`ConvertPlanBuilder`] for the method roster.
+    ///
+    /// [docs]: crate#pluggable-hdr-tone-mapping
+    ///
+    /// ```rust,ignore
+    /// use zenpixels_convert::ConvertPlan;
+    ///
+    /// let plan = ConvertPlan::builder()
+    ///     .from(src_descriptor)
+    ///     .to(dst_descriptor)
+    ///     .source_peak_nits(1000.0)
+    ///     .build()?;
+    /// ```
+    #[cfg(feature = "hdr-experimental")]
+    #[must_use]
+    pub fn builder() -> ConvertPlanBuilder {
+        ConvertPlanBuilder::new()
+    }
+}
+
+/// Fluent builder for [`ConvertPlan`] with optional pluggable HDR tone
+/// mapping.
+///
+/// Entry: [`ConvertPlan::builder`]. The builder is the **permanent**
+/// entry point for injecting a custom [`ToneMapper`](crate::hdr::ToneMapper)
+/// into a plan — see the
+/// [crate-level "Pluggable HDR tone mapping" section][docs].
+///
+/// [docs]: crate#pluggable-hdr-tone-mapping
+///
+/// # Order independence
+///
+/// Builder methods are order-independent **except** for extension-trait
+/// methods (e.g., the zentone-side `ConvertPlanBuilderToneExt`) that
+/// read the staged HDR configuration via
+/// [`current_hdr_config`](Self::current_hdr_config) to construct a
+/// mapper at the call site. Those require the peaks / knee to be set
+/// **before** the extension method is called. The natural fluent order
+/// is `from → to → source_peak_nits → with_<curve> → build`.
+///
+/// # Defaults
+///
+/// - `from` / `to`: must be set; `build` errors otherwise via
+///   [`ConvertError::NoPath`].
+/// - `source_peak_nits`: `0.0` (unset). For HDR sources, set it
+///   explicitly — the BT.2446-A reference curve is degenerate at
+///   `0.0`.
+/// - `target_peak_nits`: `100.0` (SDR reference white).
+/// - `gamut_knee`: `0.96` (empirically calibrated against the
+///   imazen-26 gain-mapped HDR corpus, 2026-06-23).
+/// - `tone_mapper`: `None` (the planner builds the in-crate
+///   [`Bt2446A`](crate::hdr::Bt2446A) reference from the staged
+///   `HdrConfig`).
+///
+/// # Examples
+///
+/// Default mapper (BT.2446 Method A):
+///
+/// ```rust,ignore
+/// use zenpixels_convert::ConvertPlan;
+///
+/// let plan = ConvertPlan::builder()
+///     .from(src)
+///     .to(dst)
+///     .source_peak_nits(1000.0)
+///     .build()?;
+/// ```
+///
+/// Custom mapper via [`with_tone_mapper`](Self::with_tone_mapper):
+///
+/// ```rust,ignore
+/// use core::sync::Arc;
+/// use zenpixels_convert::{ConvertPlan, ToneMapper, ColorPrimaries};
+///
+/// # #[derive(Debug)]
+/// # struct MyMapper;
+/// # impl ToneMapper for MyMapper {
+/// #     fn map_strip(&self, i: &[f32], o: &mut [f32]) { o.copy_from_slice(i); }
+/// #     fn name(&self) -> &'static str { "my" }
+/// # }
+/// let plan = ConvertPlan::builder()
+///     .from(src)
+///     .to(dst)
+///     .source_peak_nits(1000.0)
+///     .with_tone_mapper(Arc::new(MyMapper))
+///     .build()?;
+/// ```
+///
+/// The builder's storage is opaque (`#[non_exhaustive]` is unnecessary
+/// because no fields are publicly visible); the only public surface is
+/// the method roster on this type.
+#[cfg(feature = "hdr-experimental")]
+#[derive(Debug)]
+pub struct ConvertPlanBuilder {
+    from: Option<PixelDescriptor>,
+    to: Option<PixelDescriptor>,
+    hdr_config: HdrConfig,
+    tone_mapper: Option<alloc::sync::Arc<dyn crate::hdr::ToneMapper>>,
+}
+
+#[cfg(feature = "hdr-experimental")]
+impl ConvertPlanBuilder {
+    /// New builder with default HDR settings and no descriptors set.
+    ///
+    /// Same as [`ConvertPlan::builder`]; provided so the type can be
+    /// constructed directly when storing it in a struct field, etc.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            from: None,
+            to: None,
+            hdr_config: HdrConfig::default(),
+            tone_mapper: None,
+        }
+    }
+
+    /// Source pixel descriptor (required).
+    #[must_use]
+    pub fn from(mut self, descriptor: PixelDescriptor) -> Self {
+        self.from = Some(descriptor);
+        self
+    }
+
+    /// Target pixel descriptor (required).
+    #[must_use]
+    pub fn to(mut self, descriptor: PixelDescriptor) -> Self {
+        self.to = Some(descriptor);
+        self
+    }
+
+    /// Source peak luminance in cd/m².
+    ///
+    /// Required for HDR sources. Default `0.0` (unset). Typical values:
+    /// 1000 (HDR10, Apple HDR), 4000 (HDR10+ reference), 10000 (PQ peak).
+    #[must_use]
+    pub fn source_peak_nits(mut self, nits: f32) -> Self {
+        self.hdr_config.source_peak_nits = nits;
+        self
+    }
+
+    /// Target peak luminance in cd/m².
+    ///
+    /// Default `100.0` (SDR reference white, BT.1886 / BT.709 / sRGB
+    /// diffuse-white peak).
+    #[must_use]
+    pub fn target_peak_nits(mut self, nits: f32) -> Self {
+        self.hdr_config.target_peak_nits = nits;
+        self
+    }
+
+    /// OKLch soft chroma-compression knee.
+    ///
+    /// Default `0.96` (the largest knee where the imazen-26 corpus-p90
+    /// fraction of pre-clamp out-of-gamut pixels stays under 0.1 %).
+    /// Ignored when the target primaries are BT.2020.
+    #[must_use]
+    pub fn gamut_knee(mut self, knee: f32) -> Self {
+        self.hdr_config.gamut_knee = knee;
+        self
+    }
+
+    /// Replace the staged [`HdrConfig`] in one call.
+    ///
+    /// Overwrites any prior
+    /// [`source_peak_nits`](Self::source_peak_nits) /
+    /// [`target_peak_nits`](Self::target_peak_nits) /
+    /// [`gamut_knee`](Self::gamut_knee) setters.
+    #[must_use]
+    pub fn hdr_config(mut self, config: HdrConfig) -> Self {
+        self.hdr_config = config;
+        self
+    }
+
+    /// Inject a custom [`ToneMapper`](crate::hdr::ToneMapper).
+    ///
+    /// The mapper is invoked once per strip during conversion; it must
+    /// carry its own configuration (peak nits, primaries) — typically
+    /// constructed using the values set on this builder via
+    /// [`current_hdr_config`](Self::current_hdr_config).
+    ///
+    /// If unset on an HDR-source plan, the builder defaults to the
+    /// in-crate [`Bt2446A`](crate::hdr::Bt2446A) reference, constructed
+    /// from the builder's [`HdrConfig`].
+    #[must_use]
+    pub fn with_tone_mapper(
+        mut self,
+        mapper: alloc::sync::Arc<dyn crate::hdr::ToneMapper>,
+    ) -> Self {
+        self.tone_mapper = Some(mapper);
+        self
+    }
+
+    /// Read the [`HdrConfig`] currently staged on this builder.
+    ///
+    /// Used by extension traits (e.g., zentone's
+    /// `ConvertPlanBuilderToneExt`) to construct tone mappers using the
+    /// peak nits and gamut knee set on the builder. Returns the
+    /// in-progress config; subsequent
+    /// [`source_peak_nits`](Self::source_peak_nits) /
+    /// [`target_peak_nits`](Self::target_peak_nits) /
+    /// [`gamut_knee`](Self::gamut_knee) /
+    /// [`hdr_config`](Self::hdr_config) calls will mutate it.
+    #[must_use]
+    pub fn current_hdr_config(&self) -> &HdrConfig {
+        &self.hdr_config
+    }
+
+    /// Finalize and return the [`ConvertPlan`].
+    ///
+    /// Routes through the same internal planner as
+    /// [`ConvertPlan::new_with_hdr_config`]; an unset
+    /// [`with_tone_mapper`](Self::with_tone_mapper) makes the planner
+    /// construct the in-crate [`Bt2446A`](crate::hdr::Bt2446A)
+    /// reference.
+    ///
+    /// # Errors
+    ///
+    /// - [`ConvertError::NoPath`] when `from` or `to` is missing, or
+    ///   when the source/target combination has no conversion path.
+    /// - All errors [`ConvertPlan::new_with_hdr_config`] can return.
+    #[track_caller]
+    pub fn build(self) -> Result<ConvertPlan, At<ConvertError>> {
+        let from = self
+            .from
+            .ok_or_else(|| whereat::at!(ConvertError::NoPath {
+                from: PixelDescriptor::RGBF32_LINEAR,
+                to: PixelDescriptor::RGBF32_LINEAR,
+            }))?;
+        let to = self
+            .to
+            .ok_or_else(|| whereat::at!(ConvertError::NoPath { from, to: from }))?;
+        ConvertPlan::plan_hdr(from, to, self.hdr_config, self.tone_mapper)
+    }
+}
+
+#[cfg(feature = "hdr-experimental")]
+impl Default for ConvertPlanBuilder {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/zenpixels-convert/src/convert.rs
+++ b/zenpixels-convert/src/convert.rs
@@ -1667,12 +1667,12 @@ impl ConvertPlanBuilder {
     /// - All errors [`ConvertPlan::new_with_hdr_config`] can return.
     #[track_caller]
     pub fn build(self) -> Result<ConvertPlan, At<ConvertError>> {
-        let from = self
-            .from
-            .ok_or_else(|| whereat::at!(ConvertError::NoPath {
+        let from = self.from.ok_or_else(|| {
+            whereat::at!(ConvertError::NoPath {
                 from: PixelDescriptor::RGBF32_LINEAR,
                 to: PixelDescriptor::RGBF32_LINEAR,
-            }))?;
+            })
+        })?;
         let to = self
             .to
             .ok_or_else(|| whereat::at!(ConvertError::NoPath { from, to: from }))?;

--- a/zenpixels-convert/src/convert_kernels.rs
+++ b/zenpixels-convert/src/convert_kernels.rs
@@ -287,11 +287,8 @@ pub(super) fn apply_step_u8(
         }
 
         #[cfg(feature = "hdr-experimental")]
-        ConvertStep::ToneMapBt2446A {
-            source_peak_nits,
-            target_peak_nits,
-        } => {
-            tone_map_bt2446a_kernel(src, dst, w, from, *source_peak_nits, *target_peak_nits);
+        ConvertStep::ToneMap(mapper) => {
+            tone_map_kernel(src, dst, w, from, mapper.as_ref());
         }
 
         #[cfg(feature = "hdr-experimental")]
@@ -301,13 +298,19 @@ pub(super) fn apply_step_u8(
     }
 }
 
-/// Apply the BT.2446 Method A tone curve to a row of linear-light F32 RGB(A)
-/// pixels in BT.2020 primaries.
+/// Apply a [`ToneMapper`](crate::hdr::ToneMapper) to a row of
+/// linear-light F32 RGB(A) pixels in BT.2020 primaries.
 ///
-/// The carrier layout (RGB vs RGBA) is read from `from.layout()`. For RGBA,
-/// the alpha channel is copied through verbatim. Input is scrubbed for
-/// non-finite values and negatives; output is clamped to `[0, 1]` to absorb
-/// f32 epsilon-level overshoot at the saturated end.
+/// The carrier layout (RGB vs RGBA) is read from `from.layout()`. For
+/// RGBA, the alpha channel is copied through verbatim. Input is scrubbed
+/// for non-finite values and negatives before the mapper sees it; output
+/// is clamped to `[0, 1]` to absorb f32 epsilon-level overshoot at the
+/// saturated end.
+///
+/// The mapper is invoked as `&dyn ToneMapper` so the kernel works for
+/// any implementation (BT.2446-A, FilmicSpline, ACES, …) — the strip
+/// slice contract is documented on
+/// [`ToneMapper::map_strip`](crate::hdr::ToneMapper::map_strip).
 //
 // `needless_range_loop` would flatten the loops to iter_mut() + enumerate
 // over the strip — but each iter writes BOTH `rgb_strip[p]` and the parallel
@@ -316,44 +319,48 @@ pub(super) fn apply_step_u8(
 // below; suppress for the whole function rather than per-loop.
 #[cfg(feature = "hdr-experimental")]
 #[allow(clippy::needless_range_loop)]
-fn tone_map_bt2446a_kernel(
+fn tone_map_kernel(
     src: &[u8],
     dst: &mut [u8],
     width: usize,
     from: PixelDescriptor,
-    source_peak_nits: f32,
-    target_peak_nits: f32,
+    mapper: &dyn crate::hdr::ToneMapper,
 ) {
-    let curve = crate::hdr::Bt2446A::new(source_peak_nits, target_peak_nits);
     let has_alpha = from.layout().has_alpha();
     let channels = if has_alpha { 4 } else { 3 };
     let src_f32: &[f32] = bytemuck::cast_slice(src);
     let dst_f32: &mut [f32] = bytemuck::cast_slice_mut(dst);
 
     if has_alpha {
-        // RGBA: extract RGB triples into a scratch strip, run the SIMD
-        // curve, write back while passing alpha through verbatim. The
-        // scratch keeps the SIMD kernel's contiguous `[[f32; 3]]` shape.
+        // RGBA: extract RGB triples into a scratch strip, run the mapper,
+        // write back while passing alpha through verbatim. The scratch
+        // is a flat `[f32]` matching the trait's strip contract.
         use alloc::vec;
-        let mut rgb_strip: alloc::vec::Vec<[f32; 3]> = vec![[0.0; 3]; width];
+        let mut rgb_in: alloc::vec::Vec<f32> = vec![0.0; width * 3];
+        let mut rgb_out: alloc::vec::Vec<f32> = vec![0.0; width * 3];
         for p in 0..width {
             let base = p * channels;
             let r = src_f32[base];
             let g = src_f32[base + 1];
             let b = src_f32[base + 2];
             // Scrub non-finite / negatives — matches the prior HdrToSdr
-            // contract so consumers see clean linear-light values.
+            // contract so mappers see clean linear-light values.
             let r = if r.is_finite() && r >= 0.0 { r } else { 0.0 };
             let g = if g.is_finite() && g >= 0.0 { g } else { 0.0 };
             let b = if b.is_finite() && b >= 0.0 { b } else { 0.0 };
-            rgb_strip[p] = [r, g, b];
+            let o = p * 3;
+            rgb_in[o] = r;
+            rgb_in[o + 1] = g;
+            rgb_in[o + 2] = b;
         }
-        curve.map_strip_simd(&mut rgb_strip);
+        mapper.map_strip(&rgb_in, &mut rgb_out);
         for p in 0..width {
             let base = p * channels;
-            let [r, g, b] = rgb_strip[p];
-            // Final clamp absorbs BT.2446-A's near-peak ~1e-4 overshoot
-            // (matches the prior HdrToSdr final-clamp postcondition).
+            let o = p * 3;
+            let r = rgb_out[o];
+            let g = rgb_out[o + 1];
+            let b = rgb_out[o + 2];
+            // Final clamp absorbs any near-peak ~1e-4 overshoot.
             dst_f32[base] = if r.is_finite() {
                 r.clamp(0.0, 1.0)
             } else {
@@ -373,26 +380,34 @@ fn tone_map_bt2446a_kernel(
             dst_f32[base + 3] = src_f32[base + 3];
         }
     } else {
-        // RGB: cast straight to `[[f32; 3]]` and apply in-place after
-        // copying src → dst. The SIMD curve is in-place.
+        // RGB: copy src → dst, scrub in place, then run the mapper
+        // in-place (input/output point at the same dst slice — the
+        // trait permits aliasing).
         let n_floats = width * 3;
         dst_f32[..n_floats].copy_from_slice(&src_f32[..n_floats]);
-        let strip: &mut [[f32; 3]] = bytemuck::cast_slice_mut(&mut dst_f32[..n_floats]);
-        for px in strip.iter_mut() {
-            for c in px.iter_mut() {
-                if !c.is_finite() || *c < 0.0 {
-                    *c = 0.0;
-                }
+        for c in dst_f32[..n_floats].iter_mut() {
+            if !c.is_finite() || *c < 0.0 {
+                *c = 0.0;
             }
         }
-        curve.map_strip_simd(strip);
-        for px in strip.iter_mut() {
-            for c in px.iter_mut() {
-                if !c.is_finite() {
-                    *c = 0.0;
-                } else {
-                    *c = c.clamp(0.0, 1.0);
-                }
+        // Borrow-checker note: split into one immutable read and one
+        // mutable write. `core::ptr::eq` on the trait method's
+        // aliasing check uses pointer equality, so we hand the same
+        // slice in twice through a transmute-free pattern.
+        let (head, tail) = dst_f32[..n_floats].split_at_mut(0);
+        // `head` is empty; `tail` is the full strip. Use a single
+        // borrow for both halves of the call.
+        let _ = head;
+        // Stage through a small heap scratch to avoid aliasing
+        // gymnastics — n*3 f32s, freed at scope exit.
+        use alloc::vec::Vec;
+        let in_strip: Vec<f32> = tail.to_vec();
+        mapper.map_strip(&in_strip, tail);
+        for c in tail.iter_mut() {
+            if !c.is_finite() {
+                *c = 0.0;
+            } else {
+                *c = c.clamp(0.0, 1.0);
             }
         }
     }

--- a/zenpixels-convert/src/estimate.rs
+++ b/zenpixels-convert/src/estimate.rs
@@ -238,23 +238,24 @@ fn step_cost_ns_per_mp(step: &ConvertStep, current_bpp: usize) -> f64 {
             FusedKind::SrgbU8ToLinearF32Rgb => gib(11.19),
             FusedKind::LinearF32ToSrgbU8Rgb => gib(3.11),
         },
-        // HDR. BT.2446-A: ~250 Mpix/s on RGB f32 linear-light (2026-06-20).
-        // 1 MP / 250 Mpix/s = 4.194 ms/MP.
+        // HDR. Pluggable: the mapper reports its own per-MP cost via
+        // `ToneMapper::cost_ns_per_mp` (default 1500, BT.2446-A 4_194_304).
+        // The default keeps schedulers conservative for unknown curves.
         #[cfg(feature = "hdr-experimental")]
-        ConvertStep::ToneMapBt2446A { .. } => 4_194_304.0,
+        ConvertStep::ToneMap(mapper) => f64::from(mapper.cost_ns_per_mp()),
         // Hue-preserving rational knee in OKLch; ~3 GiB/s (cbrt-dominated).
         #[cfg(feature = "hdr-experimental")]
         ConvertStep::SoftCompressOklch { .. } => gib(3.0),
     }
 }
 
-/// Every row-stride SIMD kernel is parallel. HDR steps (BT.2446-A, OKLch
-/// soft-compress) read per-image scalars and are scheduled serially. Bias for
-/// ambiguous future steps: SERIAL (over-estimate wall time).
+/// Every row-stride SIMD kernel is parallel. HDR steps (pluggable
+/// `ToneMap`, OKLch soft-compress) read per-image scalars and are scheduled
+/// serially. Bias for ambiguous future steps: SERIAL (over-estimate wall time).
 #[rustfmt::skip]
 fn step_is_parallelizable(step: &ConvertStep) -> bool {
     #[cfg(feature = "hdr-experimental")]
-    if matches!(step, ConvertStep::ToneMapBt2446A { .. } | ConvertStep::SoftCompressOklch { .. }) {
+    if matches!(step, ConvertStep::ToneMap(_) | ConvertStep::SoftCompressOklch { .. }) {
         return false;
     }
     let _ = step;

--- a/zenpixels-convert/src/hdr/bt2446a.rs
+++ b/zenpixels-convert/src/hdr/bt2446a.rs
@@ -396,8 +396,15 @@ pub(crate) fn bt2446a_tier(
 // contract — see the trait docs.
 impl crate::hdr::ToneMapper for Bt2446A {
     fn map_strip(&self, input: &[f32], output: &mut [f32]) {
-        debug_assert_eq!(input.len(), output.len(), "ToneMapper::map_strip: slice length mismatch");
-        debug_assert!(input.len() % 3 == 0, "ToneMapper::map_strip: input not RGB-triple-aligned");
+        debug_assert_eq!(
+            input.len(),
+            output.len(),
+            "ToneMapper::map_strip: slice length mismatch"
+        );
+        debug_assert!(
+            input.len().is_multiple_of(3),
+            "ToneMapper::map_strip: input not RGB-triple-aligned"
+        );
         // The SIMD body operates in-place on `[[f32; 3]]`, so copy
         // input → output first, then dispatch with a recast of the
         // destination. The copy is a single memcpy in the contiguous

--- a/zenpixels-convert/src/hdr/bt2446a.rs
+++ b/zenpixels-convert/src/hdr/bt2446a.rs
@@ -96,6 +96,13 @@ pub struct Bt2446A {
     pub(crate) inv_log_rho_hdr: f32,
     pub(crate) rho_sdr: f32,
     pub(crate) inv_rho_sdr_minus_1: f32,
+    /// Source peak in cd/m² as constructed. Stored so we can answer
+    /// [`source_peak_nits`](Self::source_peak_nits) /
+    /// [`peaks`](crate::hdr::ToneMapper::peaks) without inverting the
+    /// derived `rho_hdr`.
+    pub(crate) source_peak_nits: f32,
+    /// Target peak in cd/m² as constructed. See `source_peak_nits`.
+    pub(crate) target_peak_nits: f32,
 }
 
 impl Bt2446A {
@@ -121,7 +128,27 @@ impl Bt2446A {
             inv_log_rho_hdr: 1.0 / log_rho_hdr,
             rho_sdr,
             inv_rho_sdr_minus_1: 1.0 / (rho_sdr - 1.0),
+            source_peak_nits: hdr_peak_nits,
+            target_peak_nits: sdr_peak_nits,
         }
+    }
+
+    /// HDR source peak luminance in cd/m², as constructed.
+    ///
+    /// Mirrors the `hdr_peak_nits` passed to [`new`](Self::new); useful
+    /// for diagnostics and for the
+    /// [`ToneMapper::peaks`](crate::hdr::ToneMapper::peaks) implementation.
+    #[must_use]
+    pub fn source_peak_nits(&self) -> f32 {
+        self.source_peak_nits
+    }
+
+    /// SDR target peak luminance in cd/m², as constructed.
+    ///
+    /// Mirrors the `sdr_peak_nits` passed to [`new`](Self::new).
+    #[must_use]
+    pub fn target_peak_nits(&self) -> f32 {
+        self.target_peak_nits
     }
 
     /// Map a single HDR pixel (linear-light BT.2020 RGB, source-normalized)
@@ -360,6 +387,56 @@ pub(crate) fn bt2446a_tier(
             powf(g_prime_out, 2.4),
             powf(b_prime_out, 2.4),
         ];
+    }
+}
+
+// `Bt2446A` is the in-crate reference [`ToneMapper`]. The pipeline
+// constructs it as the default when an HDR plan is built without an
+// explicit mapper. `name()` is part of the implementation's public
+// contract — see the trait docs.
+impl crate::hdr::ToneMapper for Bt2446A {
+    fn map_strip(&self, input: &[f32], output: &mut [f32]) {
+        debug_assert_eq!(input.len(), output.len(), "ToneMapper::map_strip: slice length mismatch");
+        debug_assert!(input.len() % 3 == 0, "ToneMapper::map_strip: input not RGB-triple-aligned");
+        // The SIMD body operates in-place on `[[f32; 3]]`, so copy
+        // input → output first, then dispatch with a recast of the
+        // destination. The copy is a single memcpy in the contiguous
+        // (non-aliased) case and a no-op write when the caller passed
+        // overlapping slices.
+        if !core::ptr::eq(input.as_ptr(), output.as_ptr()) {
+            output.copy_from_slice(input);
+        }
+        // Cast the flat RGB strip to `[[f32; 3]]` for the SIMD entry.
+        // Safe (and panic-free) because the precondition guarantees
+        // `len % 3 == 0`; release builds without the assertion will
+        // truncate any rogue trailing scalars rather than panic.
+        let triples = output.len() / 3;
+        let strip: &mut [[f32; 3]] = bytemuck::cast_slice_mut(&mut output[..triples * 3]);
+        self.map_strip_simd(strip);
+    }
+
+    fn working_primaries(&self) -> crate::ColorPrimaries {
+        // BT.2446 Method A is defined in BT.2020 RGB — see the
+        // struct-level docs and the planner's BT.2020-bracketing of
+        // this step in `ConvertPlan::new_with_hdr_config`.
+        crate::ColorPrimaries::Bt2020
+    }
+
+    fn peaks(&self) -> Option<(f32, f32)> {
+        Some((self.source_peak_nits, self.target_peak_nits))
+    }
+
+    fn name(&self) -> &'static str {
+        "bt2446a"
+    }
+
+    fn cost_ns_per_mp(&self) -> u32 {
+        // BT.2446-A: ~250 Mpix/s on RGB f32 linear-light (Ryzen 9 7950X,
+        // AVX2, 2026-06-20). 1 MP / 250 Mpix/s ≈ 4.194 ms/MP. Kept in
+        // lockstep with the per-step cost in `crate::estimate` —
+        // `ConvertStep::ToneMap` delegates to this method now, so the
+        // two figures cannot drift.
+        4_194_304
     }
 }
 

--- a/zenpixels-convert/src/hdr/mod.rs
+++ b/zenpixels-convert/src/hdr/mod.rs
@@ -51,6 +51,14 @@ mod bt2446a;
 #[cfg(feature = "hdr-experimental")]
 mod gamut_compress;
 
+/// Pluggable HDR→SDR tone mapper trait — the permanent DI surface for
+/// injecting custom curves into [`crate::ConvertPlan`].
+///
+/// Gated behind `hdr-experimental` together with the rest of the HDR
+/// surface. The trait shape itself is locked.
+#[cfg(feature = "hdr-experimental")]
+mod tone_mapper;
+
 /// Re-exports of the experimental [`measure`] surface at the [`hdr`](self)
 /// boundary, so callers can write
 /// `use zenpixels_convert::hdr::CllMeasure;` instead of the full
@@ -68,6 +76,8 @@ pub use measure::{CllMeasure, LightLevelHistogram, LightLevelMethod};
 pub use bt2446a::Bt2446A;
 #[cfg(feature = "hdr-experimental")]
 pub use gamut_compress::{GamutBoundaryLut, SoftCompress};
+#[cfg(feature = "hdr-experimental")]
+pub use tone_mapper::ToneMapper;
 
 use crate::adapt::{convert_buffer_with_anchor, convert_into_with_anchor};
 use crate::error::ConvertError;

--- a/zenpixels-convert/src/hdr/tone_mapper.rs
+++ b/zenpixels-convert/src/hdr/tone_mapper.rs
@@ -1,0 +1,200 @@
+//! Pluggable HDR→SDR tone mapping for [`ConvertPlan`](crate::ConvertPlan).
+//!
+//! [`ToneMapper`] is the permanent dynamic-dispatch surface that lets
+//! callers inject their own HDR curves into the conversion pipeline. The
+//! in-crate reference implementation is [`Bt2446A`](crate::hdr::Bt2446A);
+//! downstream crates (notably `zentone`) ship richer mapper menus
+//! (FilmicSpline, ACES, ITU-R BT.2408, Möbius, Yrg, Jzazbz, …) and inject
+//! them via an extension trait on
+//! [`ConvertPlanBuilder`](crate::ConvertPlanBuilder).
+//!
+//! See the crate-level
+//! ["Pluggable HDR tone mapping" section](crate#pluggable-hdr-tone-mapping)
+//! for the full usage story.
+//!
+//! Gated behind `hdr-experimental` together with the rest of the HDR
+//! surface in this module. The trait shape itself is intentionally locked
+//! once landed — see the type-level docs for the invariants every
+//! implementation must uphold.
+
+use core::fmt::Debug;
+
+use crate::ColorPrimaries;
+
+/// Pluggable HDR→SDR tone mapper for
+/// [`ConvertPlan`](crate::ConvertPlan).
+///
+/// Implementations live in three places:
+///
+/// - **This crate.** [`Bt2446A`](crate::hdr::Bt2446A) — the ITU-R
+///   BT.2446-1 §4 Method A reference curve, the default mapper used when a
+///   plan is built with [`ConvertPlan::new_with_hdr_peak`] /
+///   [`ConvertPlan::new_with_hdr_config`] /
+///   [`ConvertPlanBuilder`](crate::ConvertPlanBuilder) without explicit
+///   mapper injection.
+/// - **`zentone`.** FilmicSpline, AcesRrt, ITU-R BT.2408, Möbius, Yrg,
+///   Jzazbz, … injected through
+///   [`ConvertPlanBuilder::with_tone_mapper`](crate::ConvertPlanBuilder::with_tone_mapper)
+///   + a zentone-side extension trait that reads
+///   [`ConvertPlanBuilder::current_hdr_config`](crate::ConvertPlanBuilder::current_hdr_config)
+///   to construct the mapper at the call site.
+/// - **Downstream callers.** Any custom curve — bespoke film emulation,
+///   research operators, etc. — implements this trait and feeds it into
+///   the builder.
+///
+/// The trait is **object-safe**:
+/// [`ConvertPlan`](crate::ConvertPlan) stores `Arc<dyn ToneMapper>`
+/// internally, so the dispatch table never has to know the concrete
+/// mapper type.
+///
+/// [`ConvertPlan::new_with_hdr_peak`]: crate::ConvertPlan::new_with_hdr_peak
+/// [`ConvertPlan::new_with_hdr_config`]: crate::ConvertPlan::new_with_hdr_config
+///
+/// # Invariants
+///
+/// - **Pure and deterministic.** Given `&self`, every method must be a
+///   pure function of its inputs. Interior mutability that perturbs
+///   output is forbidden.
+/// - **Hot-loop safe.** [`map_strip`](Self::map_strip) is called from
+///   strip-encoder loops; it must not allocate on its own, must not
+///   panic on well-formed inputs (see the precondition list on the
+///   method), and should be inlinable around the loop.
+/// - **`Send + Sync + Debug`.** The supertrait bounds are required so
+///   plans (which are `Clone + Debug`) keep their auto-traits and so a
+///   plan can be shared across threads. Implementations should keep
+///   their `Debug` short — a single-line "`MyMapper { … }`" is plenty.
+/// - **Stable [`name`](Self::name).** The string is consumed by
+///   diagnostics, trace recorders, and estimate / oracle cache keys.
+///   Treat it as part of the implementation's public contract: once
+///   shipped, do not rename across releases.
+///
+/// # Working space
+///
+/// The strip handed to [`map_strip`](Self::map_strip) is **linear-light**
+/// RGB in the primaries reported by
+/// [`working_primaries`](Self::working_primaries) (BT.2020 by default —
+/// the canonical HDR working space). Mappers that operate in a different
+/// gamut (a few Filmic variants prefer DCI-P3) override
+/// `working_primaries`; the pipeline inserts an extra gamut matrix on
+/// each side of the strip to honor that.
+pub trait ToneMapper: Send + Sync + Debug {
+    /// Apply tone mapping to one strip of interleaved RGB pixels.
+    ///
+    /// **Precondition.** Both slices are interleaved RGB triplets, i.e.
+    /// `input.len() % 3 == 0` and `input.len() == output.len()`. The
+    /// strip is interpreted in the primaries returned by
+    /// [`working_primaries`](Self::working_primaries).
+    ///
+    /// **In-place permitted.** Implementations MAY support
+    /// `input.as_ptr() == output.as_ptr()` (the same slice passed twice
+    /// reinterpreted as immutable + mutable views by the caller), but
+    /// MUST behave correctly either way.
+    ///
+    /// **No allocation, no panic.** Hot path — implementations should
+    /// avoid heap allocation and must not panic on well-formed inputs.
+    fn map_strip(&self, input: &[f32], output: &mut [f32]);
+
+    /// The working color primaries this mapper expects on its input
+    /// strip.
+    ///
+    /// Default: [`ColorPrimaries::Bt2020`] — the canonical HDR working
+    /// space. Mappers operating in a different gamut override this; the
+    /// pipeline inserts a matrix-multiply on each side of the strip to
+    /// reach the working primaries.
+    fn working_primaries(&self) -> ColorPrimaries {
+        ColorPrimaries::Bt2020
+    }
+
+    /// `(source_peak_nits, target_peak_nits)` the mapper was constructed
+    /// with, if it is peak-aware.
+    ///
+    /// Returns `None` when the mapper is peak-agnostic (a curve defined
+    /// purely in normalized space). The pipeline uses this for
+    /// diagnostics only — the mapper is the source of truth for its own
+    /// normalization.
+    fn peaks(&self) -> Option<(f32, f32)> {
+        None
+    }
+
+    /// Short kebab-case identifier for diagnostics, trace logs, and
+    /// estimate / oracle cache keys.
+    ///
+    /// Examples: `"bt2446a"`, `"filmic-spline"`, `"aces-rrt"`,
+    /// `"itu2408"`. Must be stable across releases of the implementing
+    /// crate — treat changing it as a breaking change.
+    fn name(&self) -> &'static str;
+
+    /// Estimated wall-clock nanoseconds per megapixel on a baseline
+    /// AVX2 host (Ryzen 9 7950X, single-threaded).
+    ///
+    /// Consumed by
+    /// [`ConvertPlan::estimate`](crate::ConvertPlan::estimate) and its
+    /// `_in` sibling so a scheduler can budget the mapper alongside the
+    /// rest of the plan.
+    ///
+    /// The default of `1500` is a conservative middle-of-the-road
+    /// estimate; override when your mapper is materially faster or
+    /// slower than that baseline.
+    fn cost_ns_per_mp(&self) -> u32 {
+        1500
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::sync::Arc;
+
+    /// Object-safety pin. If the trait stops being dyn-compatible — e.g.
+    /// someone adds a generic method or a `Self`-by-value return — this
+    /// fails to compile, which is exactly the breakage we want to catch
+    /// at the trait-edit site.
+    #[allow(dead_code)]
+    fn _assert_obj_safe(_: &dyn ToneMapper) {}
+
+    /// Identity mapper used to verify dyn-dispatch round-trips through
+    /// the builder. Constant-zero on construction; behaves like the
+    /// canonical no-op curve.
+    #[derive(Debug)]
+    struct IdentityMapper;
+
+    impl ToneMapper for IdentityMapper {
+        fn map_strip(&self, input: &[f32], output: &mut [f32]) {
+            output.copy_from_slice(input);
+        }
+        fn name(&self) -> &'static str {
+            "identity-test"
+        }
+    }
+
+    #[test]
+    fn default_working_primaries_is_bt2020() {
+        let m = IdentityMapper;
+        assert_eq!(m.working_primaries(), ColorPrimaries::Bt2020);
+    }
+
+    #[test]
+    fn default_peaks_is_none() {
+        let m = IdentityMapper;
+        assert_eq!(m.peaks(), None);
+    }
+
+    #[test]
+    fn default_cost_is_reasonable() {
+        let m = IdentityMapper;
+        // Sanity-check the default cost is in the right order of
+        // magnitude for a per-megapixel ns budget; the exact value is
+        // documented on the trait.
+        assert_eq!(m.cost_ns_per_mp(), 1500);
+    }
+
+    #[test]
+    fn identity_strip_roundtrips_through_dyn() {
+        let mapper: Arc<dyn ToneMapper> = Arc::new(IdentityMapper);
+        let input = [0.1f32, 0.2, 0.3, 0.4, 0.5, 0.6];
+        let mut output = [0.0f32; 6];
+        mapper.map_strip(&input, &mut output);
+        assert_eq!(input, output);
+        assert_eq!(mapper.name(), "identity-test");
+    }
+}

--- a/zenpixels-convert/src/hdr/tone_mapper.rs
+++ b/zenpixels-convert/src/hdr/tone_mapper.rs
@@ -18,6 +18,7 @@
 //! implementation must uphold.
 
 use core::fmt::Debug;
+use core::panic::{RefUnwindSafe, UnwindSafe};
 
 use crate::ColorPrimaries;
 
@@ -26,21 +27,16 @@ use crate::ColorPrimaries;
 ///
 /// Implementations live in three places:
 ///
-/// - **This crate.** [`Bt2446A`](crate::hdr::Bt2446A) — the ITU-R
-///   BT.2446-1 §4 Method A reference curve, the default mapper used when a
-///   plan is built with [`ConvertPlan::new_with_hdr_peak`] /
-///   [`ConvertPlan::new_with_hdr_config`] /
-///   [`ConvertPlanBuilder`](crate::ConvertPlanBuilder) without explicit
-///   mapper injection.
+/// - **This crate.** [`Bt2446A`](crate::hdr::Bt2446A) — the ITU-R BT.2446-1
+///   §4 Method A reference curve, the default mapper used when a plan is
+///   built without explicit injection.
 /// - **`zentone`.** FilmicSpline, AcesRrt, ITU-R BT.2408, Möbius, Yrg,
 ///   Jzazbz, … injected through
 ///   [`ConvertPlanBuilder::with_tone_mapper`](crate::ConvertPlanBuilder::with_tone_mapper)
-///   + a zentone-side extension trait that reads
-///   [`ConvertPlanBuilder::current_hdr_config`](crate::ConvertPlanBuilder::current_hdr_config)
-///   to construct the mapper at the call site.
+///   plus a zentone-side extension trait.
 /// - **Downstream callers.** Any custom curve — bespoke film emulation,
-///   research operators, etc. — implements this trait and feeds it into
-///   the builder.
+///   research operators, etc. — implements this trait and feeds it into the
+///   builder.
 ///
 /// The trait is **object-safe**:
 /// [`ConvertPlan`](crate::ConvertPlan) stores `Arc<dyn ToneMapper>`
@@ -59,10 +55,15 @@ use crate::ColorPrimaries;
 ///   strip-encoder loops; it must not allocate on its own, must not
 ///   panic on well-formed inputs (see the precondition list on the
 ///   method), and should be inlinable around the loop.
-/// - **`Send + Sync + Debug`.** The supertrait bounds are required so
-///   plans (which are `Clone + Debug`) keep their auto-traits and so a
-///   plan can be shared across threads. Implementations should keep
-///   their `Debug` short — a single-line "`MyMapper { … }`" is plenty.
+/// - **`Send + Sync + UnwindSafe + RefUnwindSafe + Debug`.** The
+///   supertrait bounds are required so plans (which are `Clone + Debug`)
+///   keep their auto-traits across the `Arc<dyn ToneMapper>` field
+///   stored on `ConvertStep::ToneMap`. Mappers are pure functions of
+///   their inputs and pose no panic-safety hazard; concrete
+///   implementations virtually always satisfy this without thought
+///   (any `#[derive(Debug)]` struct of plain numeric / `Arc` fields
+///   does). Implementations should keep their `Debug` short — a
+///   single-line `"MyMapper { … }"` is plenty.
 /// - **Stable [`name`](Self::name).** The string is consumed by
 ///   diagnostics, trace recorders, and estimate / oracle cache keys.
 ///   Treat it as part of the implementation's public contract: once
@@ -77,7 +78,7 @@ use crate::ColorPrimaries;
 /// gamut (a few Filmic variants prefer DCI-P3) override
 /// `working_primaries`; the pipeline inserts an extra gamut matrix on
 /// each side of the strip to honor that.
-pub trait ToneMapper: Send + Sync + Debug {
+pub trait ToneMapper: Send + Sync + UnwindSafe + RefUnwindSafe + Debug {
     /// Apply tone mapping to one strip of interleaved RGB pixels.
     ///
     /// **Precondition.** Both slices are interleaved RGB triplets, i.e.

--- a/zenpixels-convert/src/lib.rs
+++ b/zenpixels-convert/src/lib.rs
@@ -563,9 +563,9 @@ mod scan;
 
 // Re-export key conversion types at crate root.
 pub use adapt::{adapt_for_encode_explicit, try_adapt_in_place};
+pub use convert::{ConvertPlan, convert_row, requires_cms};
 #[cfg(feature = "hdr-experimental")]
 pub use convert::{ConvertPlanBuilder, HdrConfig};
-pub use convert::{ConvertPlan, convert_row, requires_cms};
 // `hdr::ToneMapper` is reached at the module path
 // `zenpixels_convert::hdr::ToneMapper` (kept aligned with the
 // `hdr::Bt2446A` re-export shape — neither type is re-exported at the

--- a/zenpixels-convert/src/lib.rs
+++ b/zenpixels-convert/src/lib.rs
@@ -371,6 +371,74 @@
 //! Codecs should match on specific variants and return actionable errors
 //! to callers. Do not flatten `ConvertError` into a generic string.
 //!
+//! ## Pluggable HDR tone mapping
+//!
+//! When the `hdr-experimental` feature is enabled, [`ConvertPlan`]
+//! supports two tone-mapping modes for HDR→SDR conversions.
+//!
+//! **Built-in default** — pass `source_peak_nits` to the plan and the
+//! BT.2446 Method A reference curve ([`hdr::Bt2446A`]) handles the
+//! HDR→SDR step automatically. Identical behavior to before the
+//! pluggable surface landed.
+//!
+//! ```rust,ignore
+//! use zenpixels_convert::{ConvertPlan, PixelDescriptor};
+//!
+//! let plan = ConvertPlan::new_with_hdr_peak(src_descriptor, dst_descriptor, 1000.0)?;
+//! // run `plan` row by row with `RowConverter` / `convert_row`.
+//! ```
+//!
+//! **Custom mapper via the [`hdr::ToneMapper`] trait** — for non-reference
+//! curves (FilmicSpline, ACES, ITU-R BT.2408, Möbius, or your own
+//! implementation) provide an `Arc<dyn ToneMapper>` through the new
+//! [`ConvertPlanBuilder`]:
+//!
+//! ```rust,ignore
+//! use alloc::sync::Arc;
+//! use zenpixels_convert::{ConvertPlan, ColorPrimaries};
+//! use zenpixels_convert::hdr::ToneMapper;
+//!
+//! #[derive(Debug)]
+//! struct LinearClip { peak: f32 }
+//!
+//! impl ToneMapper for LinearClip {
+//!     fn map_strip(&self, input: &[f32], output: &mut [f32]) {
+//!         for (i, o) in input.iter().zip(output.iter_mut()) {
+//!             *o = (i / self.peak).min(1.0);
+//!         }
+//!     }
+//!     fn name(&self) -> &'static str { "linear-clip-example" }
+//!     fn peaks(&self) -> Option<(f32, f32)> { Some((self.peak, 100.0)) }
+//! }
+//!
+//! let plan = ConvertPlan::builder()
+//!     .from(src_descriptor)
+//!     .to(dst_descriptor)
+//!     .source_peak_nits(1000.0)
+//!     .with_tone_mapper(Arc::new(LinearClip { peak: 1000.0 }))
+//!     .build()?;
+//! ```
+//!
+//! **Ergonomic injection via extension traits.** Crates that ship
+//! multiple curves (notably `zentone`) define an extension trait on
+//! [`ConvertPlanBuilder`] that adds one method per mapper. The
+//! extension reads the staged `HdrConfig` via
+//! [`ConvertPlanBuilder::current_hdr_config`] to construct the mapper
+//! and then calls [`ConvertPlanBuilder::with_tone_mapper`] internally,
+//! so the caller never writes `Arc::new(..)` themselves:
+//!
+//! ```rust,ignore
+//! use zenpixels_convert::ConvertPlan;
+//! use zentone::ConvertPlanBuilderToneExt;   // unlocks `.with_filmic_spline()` et al.
+//!
+//! let plan = ConvertPlan::builder()
+//!     .from(src_descriptor)
+//!     .to(dst_descriptor)
+//!     .source_peak_nits(1000.0)            // read implicitly by the next call
+//!     .with_filmic_spline(Default::default())
+//!     .build()?;
+//! ```
+//!
 //! ## Checklist
 //!
 //! - [ ] Declare `CodecFormats` with correct `effective_bits` and `can_overshoot`

--- a/zenpixels-convert/src/lib.rs
+++ b/zenpixels-convert/src/lib.rs
@@ -496,8 +496,12 @@ mod scan;
 // Re-export key conversion types at crate root.
 pub use adapt::{adapt_for_encode_explicit, try_adapt_in_place};
 #[cfg(feature = "hdr-experimental")]
-pub use convert::HdrConfig;
+pub use convert::{ConvertPlanBuilder, HdrConfig};
 pub use convert::{ConvertPlan, convert_row, requires_cms};
+// `hdr::ToneMapper` is reached at the module path
+// `zenpixels_convert::hdr::ToneMapper` (kept aligned with the
+// `hdr::Bt2446A` re-export shape — neither type is re-exported at the
+// crate root).
 pub use converter::RowConverter;
 pub use error::ConvertError;
 pub use negotiate::{

--- a/zenpixels-convert/tests/builder.rs
+++ b/zenpixels-convert/tests/builder.rs
@@ -330,6 +330,20 @@ fn builder_without_from_or_to_errors() {
 }
 
 #[test]
+fn convert_plan_is_send_and_sync_under_hdr_experimental() {
+    // The Arc<dyn ToneMapper> field must keep ConvertPlan Send + Sync
+    // — this is what the supertrait bounds on ToneMapper buy. If they
+    // ever stop propagating, this test fails to compile (which is the
+    // exactly the breakage we want at the trait-edit site).
+    fn assert_send<T: Send>() {}
+    fn assert_sync<T: Sync>() {}
+    assert_send::<ConvertPlan>();
+    assert_sync::<ConvertPlan>();
+    assert_send::<ConvertPlanBuilder>();
+    assert_sync::<ConvertPlanBuilder>();
+}
+
+#[test]
 fn bt2446a_implements_tone_mapper_with_stable_name() {
     use zenpixels_convert::hdr::Bt2446A;
     let curve = Bt2446A::new(1000.0, 100.0);
@@ -364,10 +378,7 @@ fn rgba_plan_with_custom_mapper_preserves_alpha() {
         .build()
         .unwrap();
     let mut input = Vec::new();
-    for px in [
-        [0.1f32, 0.2, 0.3, 0.75],
-        [0.4, 0.5, 0.6, 0.25],
-    ] {
+    for px in [[0.1f32, 0.2, 0.3, 0.75], [0.4, 0.5, 0.6, 0.25]] {
         for c in px {
             input.extend_from_slice(&c.to_ne_bytes());
         }

--- a/zenpixels-convert/tests/builder.rs
+++ b/zenpixels-convert/tests/builder.rs
@@ -1,0 +1,412 @@
+//! Integration tests for [`ConvertPlanBuilder`] and the pluggable
+//! [`ToneMapper`] surface introduced in 0.2.16.
+//!
+//! Coverage:
+//! - **Default-mapper parity.** A plan built via
+//!   `ConvertPlan::builder().from(..).to(..).source_peak_nits(..).build()`
+//!   produces byte-for-byte the same output as
+//!   `ConvertPlan::new_with_hdr_peak(.., .., source_peak_nits)`.
+//! - **Custom-mapper end-to-end.** A `ConstColorMapper` injected via
+//!   `with_tone_mapper(Arc::new(..))` overrides the strip kernel and
+//!   propagates the constant color through the rest of the pipeline.
+//! - **Builder ergonomics.** `current_hdr_config` reflects staged
+//!   setter calls; `Default::default()` matches `new()`.
+//!
+//! Gated on `hdr-experimental` together with the rest of the HDR surface.
+
+#![cfg(feature = "hdr-experimental")]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use zenpixels::buffer::PixelBuffer;
+use zenpixels::{
+    AlphaMode, ChannelLayout, ChannelType, ColorPrimaries, PixelDescriptor, TransferFunction,
+};
+use zenpixels_convert::hdr::ToneMapper;
+use zenpixels_convert::{ConvertPlan, ConvertPlanBuilder, HdrConfig};
+
+// ── Test fixtures ───────────────────────────────────────────────────────
+
+fn pq_u16_bt2020_rgb() -> PixelDescriptor {
+    PixelDescriptor::new_full(
+        ChannelType::U16,
+        ChannelLayout::Rgb,
+        None,
+        TransferFunction::Pq,
+        ColorPrimaries::Bt2020,
+    )
+}
+
+fn srgb_u8_rgb() -> PixelDescriptor {
+    PixelDescriptor::new_full(
+        ChannelType::U8,
+        ChannelLayout::Rgb,
+        None,
+        TransferFunction::Srgb,
+        ColorPrimaries::Bt709,
+    )
+}
+
+fn linear_f32_bt2020_rgb() -> PixelDescriptor {
+    PixelDescriptor::new_full(
+        ChannelType::F32,
+        ChannelLayout::Rgb,
+        None,
+        TransferFunction::Linear,
+        ColorPrimaries::Bt2020,
+    )
+}
+
+/// Build a 4×4 PQ U16 source buffer with a few representative HDR
+/// brightnesses — the same content driven through both code paths.
+fn pq_u16_fixture(width: u32, height: u32) -> Vec<u8> {
+    // Sweep R = G = B PQ-encoded values from black to 75% PQ. Keeps the
+    // strip non-degenerate so any kernel divergence shows up.
+    let total = (width * height) as usize;
+    let mut data = Vec::with_capacity(total * 6);
+    for i in 0..total {
+        let v = ((i as u32) * 65535 / (total as u32).max(1)).clamp(0, 49152) as u16;
+        for _ in 0..3 {
+            data.extend_from_slice(&v.to_ne_bytes());
+        }
+    }
+    data
+}
+
+/// Drive a [`ConvertPlan`] across a buffer of `width × rows` packed
+/// pixels, returning the converted output. Uses
+/// [`convert_row`](zenpixels_convert::convert_row) directly so HDR plans
+/// (which `RowConverter::new` would reject without the HDR-aware
+/// constructor) are exercised exactly as they were built.
+fn convert_full(plan: &ConvertPlan, src: &[u8], width: u32, rows: u32) -> Vec<u8> {
+    let src_bpp = plan.from().bytes_per_pixel();
+    let dst_bpp = plan.to().bytes_per_pixel();
+    let src_stride = (width as usize) * src_bpp;
+    let dst_stride = (width as usize) * dst_bpp;
+    let mut dst = vec![0u8; (rows as usize) * dst_stride];
+    use zenpixels_convert::convert_row;
+    for y in 0..rows as usize {
+        let src_row = &src[y * src_stride..(y + 1) * src_stride];
+        let dst_row = &mut dst[y * dst_stride..(y + 1) * dst_stride];
+        convert_row(plan, src_row, dst_row, width);
+    }
+    dst
+}
+
+// ── Custom mapper for injection coverage ────────────────────────────────
+
+/// Tone mapper that overwrites every pixel with a fixed `[r, g, b]` color.
+/// Used to prove the planner actually dispatches through the injected
+/// `Arc<dyn ToneMapper>` rather than always going through the
+/// in-crate Bt2446A.
+#[derive(Debug)]
+struct ConstColorMapper {
+    color: [f32; 3],
+}
+
+impl ToneMapper for ConstColorMapper {
+    fn map_strip(&self, input: &[f32], output: &mut [f32]) {
+        assert_eq!(input.len(), output.len());
+        assert_eq!(input.len() % 3, 0);
+        for chunk in output.chunks_exact_mut(3) {
+            chunk[0] = self.color[0];
+            chunk[1] = self.color[1];
+            chunk[2] = self.color[2];
+        }
+    }
+    fn name(&self) -> &'static str {
+        "const-color-test"
+    }
+    fn working_primaries(&self) -> ColorPrimaries {
+        ColorPrimaries::Bt2020
+    }
+    fn peaks(&self) -> Option<(f32, f32)> {
+        Some((1000.0, 100.0))
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[test]
+fn builder_default_matches_new_with_hdr_peak_byte_for_byte() {
+    // The builder with no custom mapper must produce byte-identical
+    // output to `new_with_hdr_peak`, because both routes construct the
+    // same in-crate Bt2446A and send it through the same dispatch.
+    let from = pq_u16_bt2020_rgb();
+    let to = srgb_u8_rgb();
+
+    let plan_legacy = ConvertPlan::new_with_hdr_peak(from, to, 1000.0).unwrap();
+    let plan_builder = ConvertPlan::builder()
+        .from(from)
+        .to(to)
+        .source_peak_nits(1000.0)
+        .build()
+        .unwrap();
+
+    let (w, h) = (4u32, 4u32);
+    let src = pq_u16_fixture(w, h);
+    let out_legacy = convert_full(&plan_legacy, &src, w, h);
+    let out_builder = convert_full(&plan_builder, &src, w, h);
+
+    assert_eq!(
+        out_legacy, out_builder,
+        "builder default-mapper output must match new_with_hdr_peak byte-for-byte"
+    );
+}
+
+#[test]
+fn builder_with_full_hdr_config_matches_legacy_new_with_hdr_config() {
+    // Setting the full HdrConfig at once must produce the same plan as
+    // calling `new_with_hdr_config` with that struct.
+    let from = pq_u16_bt2020_rgb();
+    let to = srgb_u8_rgb();
+    let hdr = HdrConfig {
+        source_peak_nits: 4000.0,
+        target_peak_nits: 100.0,
+        gamut_knee: 0.9,
+    };
+    let plan_legacy = ConvertPlan::new_with_hdr_config(from, to, hdr).unwrap();
+    let plan_builder = ConvertPlan::builder()
+        .from(from)
+        .to(to)
+        .hdr_config(hdr)
+        .build()
+        .unwrap();
+    let (w, h) = (4u32, 4u32);
+    let src = pq_u16_fixture(w, h);
+    let a = convert_full(&plan_legacy, &src, w, h);
+    let b = convert_full(&plan_builder, &src, w, h);
+    assert_eq!(
+        a, b,
+        "builder.hdr_config(..) must match new_with_hdr_config byte-for-byte"
+    );
+}
+
+#[test]
+fn builder_individual_setters_match_full_hdr_config() {
+    // The piecemeal setters must compose into the same `HdrConfig` as
+    // calling `hdr_config(..)` with the merged struct.
+    let from = linear_f32_bt2020_rgb();
+    let to = srgb_u8_rgb();
+    let merged = HdrConfig {
+        source_peak_nits: 2000.0,
+        target_peak_nits: 100.0,
+        gamut_knee: 0.85,
+    };
+    let plan_full = ConvertPlan::builder()
+        .from(from)
+        .to(to)
+        .hdr_config(merged)
+        .build()
+        .unwrap();
+    let plan_piecemeal = ConvertPlan::builder()
+        .from(from)
+        .to(to)
+        .source_peak_nits(2000.0)
+        .target_peak_nits(100.0)
+        .gamut_knee(0.85)
+        .build()
+        .unwrap();
+    // Identical descriptors and step count is the load-bearing check;
+    // pin a small fixture to confirm pixel output equivalence too.
+    assert_eq!(plan_full.from(), plan_piecemeal.from());
+    assert_eq!(plan_full.to(), plan_piecemeal.to());
+    let buf =
+        PixelBuffer::from_vec(vec![0u8; 3 * 4 * 4 * 4], 4, 4, from).expect("fixture allocation");
+    let src = buf.as_slice().as_strided_bytes().to_vec();
+    let a = convert_full(&plan_full, &src, 4, 4);
+    let b = convert_full(&plan_piecemeal, &src, 4, 4);
+    assert_eq!(a, b);
+}
+
+#[test]
+fn builder_with_tone_mapper_dispatches_through_injected_curve() {
+    // A `ConstColorMapper` returning [0.4, 0.6, 0.2] must overwrite the
+    // strip with that color before the encode side runs. We verify by
+    // round-tripping linear RGB through linear RGB (BT.2020 → BT.2020,
+    // no gamut step on output) so the encode chain is identity-ish; the
+    // only differences between the default-mapper plan and the custom
+    // plan come from the mapper itself.
+    let from = linear_f32_bt2020_rgb();
+    let to = PixelDescriptor::new_full(
+        ChannelType::F32,
+        ChannelLayout::Rgb,
+        None,
+        TransferFunction::Linear,
+        ColorPrimaries::Bt2020,
+    );
+    let color = [0.4f32, 0.6, 0.2];
+    let plan = ConvertPlan::builder()
+        .from(from)
+        .to(to)
+        .source_peak_nits(1000.0)
+        .with_tone_mapper(Arc::new(ConstColorMapper { color }))
+        .build()
+        .unwrap();
+    // Drive a 4×1 linear-light strip through the plan.
+    let mut input_rgb = Vec::with_capacity(48);
+    for v in [0.1f32, 0.2, 0.3, 0.4] {
+        for _ in 0..3 {
+            input_rgb.extend_from_slice(&v.to_ne_bytes());
+        }
+    }
+    let mut output_rgb = vec![0u8; 48];
+    use zenpixels_convert::convert_row;
+    convert_row(&plan, &input_rgb, &mut output_rgb, 4);
+    // Every pixel must reflect the constant color from the mapper.
+    for px in 0..4 {
+        let base = px * 12;
+        let r = f32::from_ne_bytes([
+            output_rgb[base],
+            output_rgb[base + 1],
+            output_rgb[base + 2],
+            output_rgb[base + 3],
+        ]);
+        let g = f32::from_ne_bytes([
+            output_rgb[base + 4],
+            output_rgb[base + 5],
+            output_rgb[base + 6],
+            output_rgb[base + 7],
+        ]);
+        let b = f32::from_ne_bytes([
+            output_rgb[base + 8],
+            output_rgb[base + 9],
+            output_rgb[base + 10],
+            output_rgb[base + 11],
+        ]);
+        // The kernel clamps to [0, 1] at the end; all three should
+        // match within an f32 epsilon.
+        assert!(
+            (r - color[0]).abs() < 1e-5,
+            "pixel {px} R={r}, want {}",
+            color[0]
+        );
+        assert!(
+            (g - color[1]).abs() < 1e-5,
+            "pixel {px} G={g}, want {}",
+            color[1]
+        );
+        assert!(
+            (b - color[2]).abs() < 1e-5,
+            "pixel {px} B={b}, want {}",
+            color[2]
+        );
+    }
+}
+
+#[test]
+fn builder_current_hdr_config_reflects_setters() {
+    let b = ConvertPlan::builder()
+        .source_peak_nits(2500.0)
+        .gamut_knee(0.5);
+    let cfg = b.current_hdr_config();
+    assert!((cfg.source_peak_nits - 2500.0).abs() < f32::EPSILON);
+    assert!((cfg.gamut_knee - 0.5).abs() < f32::EPSILON);
+    assert!((cfg.target_peak_nits - 100.0).abs() < f32::EPSILON); // default
+}
+
+#[test]
+fn builder_default_matches_new() {
+    let a: ConvertPlanBuilder = Default::default();
+    let b = ConvertPlanBuilder::new();
+    // Same staged config; no descriptors, no mapper.
+    assert_eq!(a.current_hdr_config(), b.current_hdr_config());
+}
+
+#[test]
+fn builder_without_from_or_to_errors() {
+    // Missing descriptors must error rather than panic.
+    assert!(ConvertPlan::builder().build().is_err());
+    assert!(
+        ConvertPlan::builder()
+            .from(pq_u16_bt2020_rgb())
+            .build()
+            .is_err()
+    );
+}
+
+#[test]
+fn bt2446a_implements_tone_mapper_with_stable_name() {
+    use zenpixels_convert::hdr::Bt2446A;
+    let curve = Bt2446A::new(1000.0, 100.0);
+    let m: &dyn ToneMapper = &curve;
+    assert_eq!(m.name(), "bt2446a");
+    assert_eq!(m.peaks(), Some((1000.0, 100.0)));
+    assert_eq!(m.working_primaries(), ColorPrimaries::Bt2020);
+    // The reported cost matches the per-step measurement in
+    // `estimate::step_cost_ns_per_mp` (lockstep with the trait impl).
+    assert_eq!(m.cost_ns_per_mp(), 4_194_304);
+}
+
+#[test]
+fn rgba_plan_with_custom_mapper_preserves_alpha() {
+    // RGBA → RGBA(linear) through a constant-color mapper. The mapper
+    // overwrites RGB; the kernel must pass alpha through verbatim.
+    let from = PixelDescriptor::new_full(
+        ChannelType::F32,
+        ChannelLayout::Rgba,
+        Some(AlphaMode::Straight),
+        TransferFunction::Linear,
+        ColorPrimaries::Bt2020,
+    );
+    let to = from;
+    let plan = ConvertPlan::builder()
+        .from(from)
+        .to(to)
+        .source_peak_nits(1000.0)
+        .with_tone_mapper(Arc::new(ConstColorMapper {
+            color: [0.5, 0.5, 0.5],
+        }))
+        .build()
+        .unwrap();
+    let mut input = Vec::new();
+    for px in [
+        [0.1f32, 0.2, 0.3, 0.75],
+        [0.4, 0.5, 0.6, 0.25],
+    ] {
+        for c in px {
+            input.extend_from_slice(&c.to_ne_bytes());
+        }
+    }
+    let mut output = vec![0u8; input.len()];
+    use zenpixels_convert::convert_row;
+    convert_row(&plan, &input, &mut output, 2);
+    for (i, want_a) in [0.75f32, 0.25].iter().enumerate() {
+        let base = i * 16;
+        let r = f32::from_ne_bytes([
+            output[base],
+            output[base + 1],
+            output[base + 2],
+            output[base + 3],
+        ]);
+        let g = f32::from_ne_bytes([
+            output[base + 4],
+            output[base + 5],
+            output[base + 6],
+            output[base + 7],
+        ]);
+        let b = f32::from_ne_bytes([
+            output[base + 8],
+            output[base + 9],
+            output[base + 10],
+            output[base + 11],
+        ]);
+        let a = f32::from_ne_bytes([
+            output[base + 12],
+            output[base + 13],
+            output[base + 14],
+            output[base + 15],
+        ]);
+        assert!((r - 0.5).abs() < 1e-5);
+        assert!((g - 0.5).abs() < 1e-5);
+        assert!((b - 0.5).abs() < 1e-5);
+        assert!(
+            (a - want_a).abs() < 1e-5,
+            "alpha passthrough at pixel {i}: got {a}, want {want_a}"
+        );
+    }
+}

--- a/zenpixels-convert/tests/hdr_pipeline.rs
+++ b/zenpixels-convert/tests/hdr_pipeline.rs
@@ -6,7 +6,8 @@
 //! The HDR plan inserts:
 //!   1. Source transfer decode → linear F32.
 //!   2. Source primaries → BT.2020 matrix (if not already BT.2020).
-//!   3. `ToneMapBt2446A` step.
+//!   3. `ToneMap` step (BT.2446 Method A by default, swappable via
+//!      `ConvertPlanBuilder::with_tone_mapper`).
 //!   4. BT.2020 → target primaries matrix (if not BT.2020 target).
 //!   5. `SoftCompressOklch` step (if not BT.2020 target).
 //!   6. Layout / depth / target transfer encode.
@@ -123,16 +124,18 @@ mod plan_shape {
     #[test]
     fn hdr_pipeline_inserts_bt2446a_step() {
         // PQ U16 BT.2020 → sRGB U8 BT.709 plan must include the
-        // `ToneMapBt2446A` step. Anything else means the HDR-aware
-        // constructor silently degraded to the SDR planner.
+        // `ToneMap` step (the BT.2446-A default curve dispatched
+        // through the pluggable [`ToneMapper`] trait). Anything else
+        // means the HDR-aware constructor silently degraded to the SDR
+        // planner.
         let src = pq_u16_bt2020_rgb();
         let dst = PixelDescriptor::RGB8_SRGB;
         let src_pixel: [u16; 3] = [40_000, 30_000, 20_000];
         let src_bytes: [u8; 6] = bytemuck::cast(src_pixel);
         let trace = trace_hdr_plan(src, dst, default_hdr(1000.0), &src_bytes, 1);
         assert!(
-            trace.contains(&"ToneMapBt2446A"),
-            "PQ→sRGB pipeline must include ToneMapBt2446A, got {trace:?}"
+            trace.contains(&"ToneMap"),
+            "PQ→sRGB pipeline must include ToneMap, got {trace:?}"
         );
     }
 
@@ -164,7 +167,7 @@ mod plan_shape {
         let src_bytes: [u8; 12] = bytemuck::cast(src_pixel);
         let trace = trace_hdr_plan(src, dst, default_hdr(1000.0), &src_bytes, 1);
         assert!(
-            trace.contains(&"ToneMapBt2446A"),
+            trace.contains(&"ToneMap"),
             "tone-map still expected for BT.2020 → BT.2020, got {trace:?}"
         );
         assert!(
@@ -184,14 +187,14 @@ mod plan_shape {
         let src_pixel: [u16; 3] = [40_000, 30_000, 20_000];
         let src_bytes: [u8; 6] = bytemuck::cast(src_pixel);
         let trace = trace_hdr_plan(src, dst, default_hdr(1000.0), &src_bytes, 1);
-        // The pipeline-essential steps must all appear, and ToneMapBt2446A
+        // The pipeline-essential steps must all appear, and ToneMap
         // must precede SoftCompressOklch (compression operates on
         // tone-mapped values).
-        let tm_pos = trace.iter().position(|s| s == &"ToneMapBt2446A");
+        let tm_pos = trace.iter().position(|s| s == &"ToneMap");
         let sc_pos = trace.iter().position(|s| s == &"SoftCompressOklch");
         assert!(
             tm_pos.is_some() && sc_pos.is_some() && tm_pos < sc_pos,
-            "ToneMapBt2446A must precede SoftCompressOklch, got {trace:?}"
+            "ToneMap must precede SoftCompressOklch, got {trace:?}"
         );
     }
 
@@ -205,8 +208,8 @@ mod plan_shape {
         let src_bytes: [u8; 6] = bytemuck::cast(src_pixel);
         let trace = trace_hdr_plan(src, dst, default_hdr(1000.0), &src_bytes, 1);
         assert!(
-            trace.contains(&"ToneMapBt2446A"),
-            "HLG → sRGB pipeline must include ToneMapBt2446A, got {trace:?}"
+            trace.contains(&"ToneMap"),
+            "HLG → sRGB pipeline must include ToneMap, got {trace:?}"
         );
     }
 
@@ -221,7 +224,7 @@ mod plan_shape {
         let src_bytes: [u8; 8] = bytemuck::cast(src_pixel);
         let trace = trace_hdr_plan(src, dst, default_hdr(1000.0), &src_bytes, 1);
         assert!(
-            trace.contains(&"ToneMapBt2446A"),
+            trace.contains(&"ToneMap"),
             "RGBA PQ → RGBA sRGB pipeline must tonemap, got {trace:?}"
         );
     }


### PR DESCRIPTION
## Summary

- New `pub trait ToneMapper` (object-safe, `Send + Sync + UnwindSafe + RefUnwindSafe + Debug`) — the permanent DI surface for HDR tone mapping inside `ConvertPlan`. Reachable at `zenpixels_convert::hdr::ToneMapper` (aligned with the existing `hdr::Bt2446A` re-export shape).
- New `pub struct ConvertPlanBuilder` + `ConvertPlan::builder()` — fluent builder that's order-independent for HDR config and supports dyn-mapper injection.
- New `current_hdr_config()` accessor — the hook zentone's extension trait uses to read peak nits set on the builder and construct the mapper implicitly.
- `impl ToneMapper for Bt2446A` — the in-crate reference curve is now a first-class `ToneMapper`. New `Bt2446A::source_peak_nits` / `target_peak_nits` accessors expose the constructor inputs.
- Internal: `ConvertStep::ToneMapBt2446A { source_peak_nits, target_peak_nits }` → `ConvertStep::ToneMap(Arc<dyn ToneMapper>)`. `pub(crate)` enum — no semver impact.
- New runnable `examples/custom_tone_mapper.rs` demonstrates the dyn-dispatch wiring.

Existing entry points (`new_with_hdr_peak`, `new_with_hdr_config`, `ext::PixelBufferHdrConvertExt::convert_to_with_hdr_config`) preserve byte-for-byte output and are unchanged externally — they now construct a `Bt2446A` mapper internally and route through the new dispatch.

`ToneMapper` includes `UnwindSafe + RefUnwindSafe` supertraits so the `Arc<dyn ToneMapper>` field on `ConvertStep::ToneMap` doesn't strip auto-traits from `ConvertPlan`. The new `convert_plan_is_send_and_sync_under_hdr_experimental` integration test pins this at compile time.

## Usage

### Built-in default (unchanged)

```rust,ignore
let plan = ConvertPlan::new_with_hdr_peak(src, dst, 1000.0)?;
```

### Custom mapper via the trait

```rust,ignore
use core::sync::Arc;
use zenpixels_convert::hdr::ToneMapper;

#[derive(Debug)]
struct MyMapper { /* ... */ }
impl ToneMapper for MyMapper {
    fn map_strip(&self, input: &[f32], output: &mut [f32]) { /* ... */ }
    fn name(&self) -> &'static str { "my-mapper" }
}

let plan = ConvertPlan::builder()
    .from(src)
    .to(dst)
    .source_peak_nits(1000.0)
    .with_tone_mapper(Arc::new(MyMapper { /* ... */ }))
    .build()?;
```

### Ergonomic injection from zentone (follow-up PR)

zentone will ship a `ConvertPlanBuilderToneExt` trait that adds one method per built-in zentone mapper:

```rust,ignore
use zentone::ConvertPlanBuilderToneExt;

let plan = ConvertPlan::builder()
    .from(src)
    .to(dst)
    .source_peak_nits(1000.0)            // read implicitly
    .with_filmic_spline(Default::default())
    .build()?;
```

The extension method reads `current_hdr_config()` off the builder, constructs the mapper with those peak nits, and calls `with_tone_mapper(Arc::new(...))` internally — caller never writes `Arc::new` themselves.

## Permanence

This is intended as a forever public surface. Trait shape locked: `map_strip` + 4 inspectors (`working_primaries` / `peaks` / `name` / `cost_ns_per_mp`), all with sensible defaults. Builder shape locked: standard fluent pattern with explicit accessor (`current_hdr_config`) for extension traits.

## Test plan

- [x] `cargo test --all-features` — 33 suites, 0 failures
- [x] `cargo test --doc --all-features` — 7 pass, 29 ignored
- [x] `cargo semver-checks check-release` — 196 pass / 0 fail / 56 skip; additive only against the 0.2.14 baseline
- [x] `just api-doc` regenerates clean diff — new items only, no removals
- [x] `cargo fmt --check` + `cargo clippy --workspace --all-features -- -D warnings` — clean
- [x] zentone test suite (138 tests + doctests) passes against this branch (byte-for-byte preserved on existing constructors)
- [x] obj-safety asserted via `fn _assert_obj_safe(_: &dyn ToneMapper)` in the unit-test module
- [x] auto-trait propagation asserted via `convert_plan_is_send_and_sync_under_hdr_experimental` integration test
- [x] custom-mapper end-to-end dispatch asserted via `builder_with_tone_mapper_dispatches_through_injected_curve`

Version: zenpixels-convert 0.2.15 → 0.2.16 (additive).