### PR TITLE
Ergonomic helpers, tested usage galleries + pre-release API-surface audit (semver-compatible, 0.2.x)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,12 @@ jobs:
       - name: Test (workspace)
         run: cargo test --workspace
 
+      # `cargo test --workspace` builds example targets but does not run the
+      # `#[test]`s inside them (that needs `--examples`). The `common_usage` /
+      # `convert_pipeline` galleries assert the documented behavior, so run them.
+      - name: Test (usage examples)
+        run: cargo test --workspace --examples
+
       # Default `cargo test` exercises only the portable scalar transpose tiers.
       # Run the orient suite again with the SIMD kernels enabled so the per-width
       # AVX2 (x64) / NEON (arm64 runners) register transposes are executed and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,14 @@ jobs:
       - name: Test (zenpixels-convert HDR measurement, hdr-experimental)
         run: cargo test -p zenpixels-convert --features hdr-experimental
 
+      # The estimate surface (estimate module + ConvertPlan::estimate(_in)) and
+      # its whole test suite (tests/resource_estimate.rs is `#![cfg]`-gated on
+      # the feature) only exist behind estimation-experimental. Without this
+      # step the feature-powerset job would `check` it but never RUN a single
+      # assertion — the opt-in-feature-untested-in-CI trap.
+      - name: Test (zenpixels-convert resource estimation, estimation-experimental)
+        run: cargo test -p zenpixels-convert --features estimation-experimental --examples --tests
+
       # The `avx512` feature routes the f16 slice path and the AVX-512 SIMD
       # tiers through magetypes/archmage's w512 kernels. Dispatch is at
       # runtime, so this compiles and runs on any x86-64 host (it just takes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,29 @@
   - `Cicp::from_bytes([u8; 4])` (`const fn`) — unpack a cICP-box tuple without the
     `!= 0` papercut on the full-range flag.
 
+### zenpixels-convert — changed (pre-release API-surface audit)
+
+- **Resource estimation is now behind `estimation-experimental` (default-off).**
+  The `estimate` module (`ResourceEstimate` / `ComputeEnvironment` /
+  `ImageCharacteristics` / `SimdTier`) and `ConvertPlan::estimate(_in)` were
+  added after 0.2.14 and never shipped. Pre-release audit found **zero
+  consumers**: the goal — estimating a `decode → convert → encode` job
+  end-to-end — is real, but no scheduler consumes it, so neither the API shape
+  nor the ±30 % accuracy contract has been validated against a caller. Gated
+  rather than deleted (the bench calibration is worth keeping) and rather than
+  shipped (a release would freeze an unvalidated shape forever). Opt in with
+  `features = ["estimation-experimental"]`; expect the surface to change as the
+  first consumer lands.
+  - `tests/resource_estimate.rs` is `#![cfg]`-gated on the feature, and the
+    `mem_probe_convert` example (the heaptrack/marginal-WS harness that
+    validates the estimate against measured peak RSS) gains
+    `required-features`. A CI step runs both with the feature on, so the gated
+    surface is executed, not merely `check`ed.
+  - Known gap the first consumer should force: the module doc claims shape-
+    compatibility with `zencodec::estimate::*`, but the shapes **have** diverged
+    (`zencodec` additionally tracks `cpu_ms` / `peak_memory_bytes_max` /
+    `frame_count`), so bridging still means mapping fields by hand.
+
 ### zenpixels-convert — added
 
 - **`PixelSlice`-oriented encode / convert helpers (2e1a4fb).** Additive.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,27 @@
   Validates rather than assumes — dimension mismatch → `BufferSize`, a
   destination whose descriptor is not the plan's target → `NoPath`.
 
+### zenpixels-convert — added (no-alloc / move + fallible)
+
+- **`PixelBufferConvertExt::convert_in_place(&mut self, target)`** — the
+  move-counterpart to `convert_into`: reuses the buffer's own allocation.
+  Identity is a no-op; narrowing (RGBA→RGB, U16→U8, RGB→Gray) and same-size
+  swizzles shuffle-collapse front-to-back in place (O(row) scratch only);
+  widening reallocates. Turns the common narrowing/identity cases from a
+  full-image allocation into none.
+- **`PixelBufferConvertTypedExt::try_to_rgb8` / `try_to_rgba8` / `try_to_gray8`
+  / `try_to_bgra8`** — fallible siblings of the `to_*8` decode helpers, which
+  **panic** on a CMYK / Lab / XYZ source (`RowConverter: no conversion path`).
+  Mirrors the crate's `new`/`try_new` pattern; the infallible `to_*8` stay with
+  a documented panic and now delegate through the same fixed core.
+
 ### zenpixels-convert — deprecated
 
+- **`adapt::convert_buffer`** → build a `PixelBuffer` and use
+  `PixelBufferConvertExt::convert_to` / `convert_into` / `convert_in_place`. It
+  assumes packed input (a strided buffer is read with its padding as pixels —
+  the length check cannot catch it) and returns a bare `Vec<u8>` that drops the
+  dimensions and descriptor.
 - **`RowConverter::convert_rows`** → use `convert_slice_into`. Four of its six
   positional arguments are a `PixelSlice`/`PixelSliceMut` taken apart; nothing
   type-checks that `src_stride` belongs to `src` or that the descriptors match
@@ -44,6 +63,16 @@
 
 #### Changed (BREAKING, tolerated in 0.2.x)
 
+- **`Adapted` is now `#[non_exhaustive]`** and gained `data()` / `descriptor()`
+  / `width()` / `rows()` accessors (fields stay `pub` for now). Tolerated
+  break: a grep of `~/work/zen` found zero external struct-literal
+  construction — `Adapted` is only ever *returned* by `adapt_for_encode`. This
+  lets the `stride` field (imazen/zenpixels#68) land additively later; read via
+  the accessors and it won't churn.
+- **`requires_cms` is no longer `pub`** (demoted to `pub(crate)`, removed from
+  the crate re-export). It was added after 0.2.14, has no external consumer,
+  and the public "needs a CMS" signal is the `ConvertError::NeedsCms` variant.
+  Unshipped removal — no released version exposed it.
 - **`PixelBufferConvertExt` / `PixelBufferConvertTypedExt` are now sealed**, and
   `PixelBufferConvertExt` gained the required `convert_into` method. Three
   `cargo semver-checks` failures accepted under tolerated-break categories 7+8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,43 @@
   - `Cicp::from_bytes([u8; 4])` (`const fn`) — unpack a cICP-box tuple without the
     `!= 0` papercut on the full-range flag.
 
+### zenpixels-convert — added (no-alloc primitives)
+
+- **`PixelBufferConvertExt::convert_into(&self, dst: PixelSliceMut)`** — convert
+  into a destination you already own; **no allocation**. `convert_to` is now
+  sugar over it, and `try_add_alpha` / `try_widen_to_u16` / `try_narrow_to_u8` /
+  `linearize` / `delinearize` all inherit it, since they delegate to
+  `convert_to`. Two hand-written row loops (including a special-cased identity
+  copy) are deleted — everything now flows through the single loop in
+  `RowConverter::convert_slice_into`.
+- **`RowConverter::convert_slice_into(src: PixelSlice, dst: PixelSliceMut)`** —
+  the no-alloc primitive `convert_slice` is sugar over. Neither takes a stride:
+  each slice carries its own, so both sides may be strided.
+  Validates rather than assumes — dimension mismatch → `BufferSize`, a
+  destination whose descriptor is not the plan's target → `NoPath`.
+
+### zenpixels-convert — deprecated
+
+- **`RowConverter::convert_rows`** → use `convert_slice_into`. Four of its six
+  positional arguments are a `PixelSlice`/`PixelSliceMut` taken apart; nothing
+  type-checks that `src_stride` belongs to `src` or that the descriptors match
+  the plan, so transposing a stride argument compiles and silently produces
+  wrong pixels. Still works; still tested.
+
+#### Changed (BREAKING, tolerated in 0.2.x)
+
+- **`PixelBufferConvertExt` / `PixelBufferConvertTypedExt` are now sealed**, and
+  `PixelBufferConvertExt` gained the required `convert_into` method. Three
+  `cargo semver-checks` failures accepted under tolerated-break categories 7+8
+  (see `CLAUDE.md`): `trait_newly_sealed`, `trait_added_supertrait`,
+  `trait_method_added`.
+  **Audit:** a grep of `~/work/zen` found the only `impl`s of either trait
+  anywhere are the two in-tree ones (`ext.rs`); zenpng/zentone call them but
+  never implement them. External implementation was never meaningful — these
+  are extension traits over a concrete foreign type whose methods all return
+  `PixelBuffer`. Sealing is what the API-design policy already required; it
+  makes this and every future method addition structurally non-breaking.
+
 ### zenpixels-convert — changed (pre-release API-surface audit)
 
 - **Resource estimation is now behind `estimation-experimental` (default-off).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - **Ergonomic constructors + a color-retag helper (2e1a4fb).** All additive
   (`cargo semver-checks`: minor change, no bump); each has real downstream
   consumers from the `~/work/zen` usage audit and a runnable doctest.
-  - `PixelSlice::new_tight` / `PixelSliceMut::new_tight(data, width, rows, descriptor)`
+  - `PixelSlice::new_contiguous` / `PixelSliceMut::new_contiguous(data, width, rows, descriptor)`
     — packed-stride constructor (`stride = width * bytes_per_pixel`); the single
     most-repeated line in the audit (~361 `PixelSlice::new` sites hand-compute
     the tight stride).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
   - `PixelSlice::new_contiguous` / `PixelSliceMut::new_contiguous(data, width, rows, descriptor)`
     — packed-stride constructor (`stride = width * bytes_per_pixel`); the single
     most-repeated line in the audit (~361 `PixelSlice::new` sites hand-compute
-    the tight stride).
+    the tight stride). Aliased by `new_packed` (identical behavior). Both
+    delegate to `new`, so `validate_slice`'s base-alignment + `stride % bpp`
+    checks always run — no unchecked path; every row stays aligned to the
+    channel type, so consumers may reinterpret rows as `&[u16]` / `&[f32]`.
   - `PixelDescriptor::with_color_from_cicp(Cicp)` (`const fn`) — retag transfer +
     primaries from a decoded CICP, keeping format / type / alpha / signal range.
   - `Cicp::from_bytes([u8; 4])` (`const fn`) — unpack a cICP-box tuple without the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 ## [Unreleased]
 
+### zenpixels — added
+
+- **Ergonomic constructors + a color-retag helper (2e1a4fb).** All additive
+  (`cargo semver-checks`: minor change, no bump); each has real downstream
+  consumers from the `~/work/zen` usage audit and a runnable doctest.
+  - `PixelSlice::new_tight` / `PixelSliceMut::new_tight(data, width, rows, descriptor)`
+    — packed-stride constructor (`stride = width * bytes_per_pixel`); the single
+    most-repeated line in the audit (~361 `PixelSlice::new` sites hand-compute
+    the tight stride).
+  - `PixelDescriptor::with_color_from_cicp(Cicp)` (`const fn`) — retag transfer +
+    primaries from a decoded CICP, keeping format / type / alpha / signal range.
+  - `Cicp::from_bytes([u8; 4])` (`const fn`) — unpack a cICP-box tuple without the
+    `!= 0` papercut on the full-range flag.
+
+### zenpixels-convert — added
+
+- **`PixelSlice`-oriented encode / convert helpers (2e1a4fb).** Additive.
+  - `Adapted::as_pixel_slice() -> Result<PixelSlice>` — hand the adapted bytes
+    straight to an encoder; folds the recompute-stride + `PixelSlice::new` block
+    duplicated 5× across zenpipe / zencodecs. Returns `Result` (the zero-copy
+    borrow path can be misaligned for a wide-channel `PixelSlice`).
+  - `RowConverter::convert_slice(PixelSlice) -> PixelBuffer` — bundles the
+    "alloc `rows*stride`, loop `convert_row`" block behind the `PixelSlice`
+    stride contract; carries the source color context.
+
+### Workspace — added
+
+- **Tested usage-example galleries + a CI `--examples` gate (d672211).**
+  `zenpixels/examples/common_usage.rs` (9 scenarios) and
+  `zenpixels-convert/examples/convert_pipeline.rs` (14 scenarios) exercise the
+  common usages and double as compile-tested docs; a
+  `cargo test --workspace --examples` CI step runs them across the platform
+  matrix (`cargo test --workspace` builds example targets but never runs their
+  `#[test]`s). Ergonomics analysis of the call sites lives in
+  `docs/ergonomics-2026-07-14.md`.
+
 ### zenpixels-convert — fixed (HDR correctness; all behind `hdr-experimental`, unreleased)
 
 - **Tier-consistent NaN/negative fold in the SIMD CLL kernels (eea47c01).**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,10 @@ Changes that may ship inside a `0.2.N` patch release:
 4. **Removing a Cargo feature** when the feature was either experimental (no release had it in default) or has been folded into the default behavior (e.g., `zencms-lite` was dropped when its functionality became unconditional via `OnceBox`).
 5. **Losing auto-trait impls as a mechanical consequence** of new private fields (e.g., `RowConverter` lost `Sync` because it now holds `Box<dyn RowTransformMut: Send>`). Acceptable when the type's primary use is `&mut self` and cross-thread shared access was never meaningful.
 6. **Dropping a derive like `Debug`** when the type's fields are not meaningfully Debug-able and no callers rely on the default derive. Replace with a curated manual impl or a `_opaque: "<redacted>"` placeholder if needed.
+7. **Sealing a public trait** (`trait_newly_sealed` + `trait_added_supertrait`) when a grep of `~/work/zen` finds **zero external `impl`s**, and external implementation was never meaningful — e.g. an extension trait over a concrete foreign type, whose methods all return that type. Sealing is what this file's API-design section already asks for ("Traits should be sealed … unless external implementation is a required feature"); doing it later is the tolerated cost of not having done it at first release.
+8. **Adding a method to such a trait** (`trait_method_added`) — once sealed, this is structurally non-breaking; the semver-checks failure is against the *published* unsealed shape, not against any real implementor. Requires the same zero-external-impl audit, documented in the commit.
+
+   Applied 2026-07-15 to `PixelBufferConvertExt` / `PixelBufferConvertTypedExt` (adding `convert_into`): audit found the only impls anywhere are the two in-tree ones (`ext.rs`), with zenpng/zentone *calling* but never implementing. Three failures accepted: `trait_newly_sealed`, `trait_added_supertrait`, `trait_method_added`.
 
 ### Not tolerated in 0.2.N
 

--- a/docs/ergonomics-2026-07-14.md
+++ b/docs/ergonomics-2026-07-14.md
@@ -45,7 +45,7 @@ tight stride first. It is the most-repeated single line in the whole audit.
 let stride = width as usize * descriptor.bytes_per_pixel();
 let ps = PixelSlice::new(data, width, height, stride, descriptor)?;
 
-// proposed
+// landed (`new_packed` is an alias for the same call)
 let ps = PixelSlice::new_contiguous(data, width, height, descriptor)?;
 ```
 
@@ -109,7 +109,7 @@ let plan = ConvertPlan::new(src.descriptor(), target)?;
 let mut out = vec![0u8; row_bytes * h as usize];
 for y in 0..h { convert_row(&plan, src.row(y), &mut out[y*row_bytes..][..row_bytes], w); }
 
-// proposed
+// landed
 let out: PixelBuffer = RowConverter::new(src.descriptor(), target)?.convert_slice(src.as_slice())?;
 ```
 
@@ -122,14 +122,15 @@ case; this covers "I hold a `PixelSlice` and want scratch/streaming control."
 ## 4. `PixelDescriptor::with_color_from_cicp(Cicp)` — retag transfer+primaries
 
 The "keep the format, adopt transfer+primaries from a decoded CICP" chain repeats
-(`zenpng/src/codec.rs:2063`, `zenavif/src/codec.rs:3276`, `zencodec/src/helpers/icc.rs:135`):
+(`zenpng/src/codec.rs:2063` `enrich_descriptor_from_cicp`, `zenavif/src/codec.rs:2255`
+**and** `:3274`, plus the same shape in `zenjxl/src/codec.rs` / `heic/src/codec.rs`):
 
 ```rust
 // today
 if let Some(tf) = TransferFunction::from_cicp(c.transfer_characteristics) { desc = desc.with_transfer(tf); }
 if let Some(p)  = ColorPrimaries::from_cicp(c.color_primaries)          { desc = desc.with_primaries(p); }
 
-// proposed (const fn, keeps format/type/alpha, updates only color axes)
+// landed (const fn, keeps format/type/alpha, updates only color axes)
 let desc = desc.with_color_from_cicp(cicp);
 ```
 

--- a/docs/ergonomics-2026-07-14.md
+++ b/docs/ergonomics-2026-07-14.md
@@ -12,25 +12,26 @@ grounded in two inputs:
    - `zenpixels/examples/common_usage.rs` (9 scenarios)
    - `zenpixels-convert/examples/convert_pipeline.rs` (14 scenarios)
 
-**Nothing here changes the public API.** Every public item in these crates is a
-forever commitment (see `zenpixels/CLAUDE.md`), so the additive helpers below are
-*proposals with real consumers*, not applied changes — they need explicit
-sign-off before landing. Findings 6 and this doc are the only things landed now,
-alongside the galleries.
+**Status.** Every public item in these crates is a forever commitment (see
+`zenpixels/CLAUDE.md`), so the additive helpers below were surfaced as *proposals
+with real consumers* first. Findings **1–4 and 9 were approved and have now
+landed** (all additive, 0.2.x-compatible; each demonstrated in the galleries and
+covered by a doctest). Findings 5, 6, 8 are docs-only. Finding 7 is a 0.3.0
+demotion queued for the next breaking release.
 
 ## Summary
 
-| # | Finding | Real consumers | Change | Semver |
-|---|---------|---------------:|--------|--------|
-| 1 | `PixelSlice::new_tight` / `PixelSliceMut::new_tight` (packed-stride ctor) | ~361 | add method | additive (0.2.x) |
-| 2 | `Adapted::as_pixel_slice()` | 5 | add method | additive (0.2.x) |
-| 3 | `RowConverter::convert_slice(PixelSlice) -> PixelBuffer` | 4–5 | add method | additive (0.2.x) |
-| 4 | `PixelDescriptor::with_color_from_cicp(Cicp)` | 3+ | add method | additive (0.2.x) |
-| 5 | Steer bare-`Vec` callers to `convert_to` | — | docs | none |
-| 6 | Crate-doc examples are `rust,ignore` (untested) | — | docs | none |
-| 7 | `finalize_for_output*` / `EncodeReady` / `OutputProfile` unadopted | **0** | demote | **0.3.0 breaking** |
-| 8 | `PixelBufferConvertTypedExt` (`.to_rgba8`) is top idiom but `rgb`-gated | ~93 | docs | none |
-| 9 | `Cicp::from_bytes([u8; 4])` | ~161 `Cicp::new` | add method | additive (0.2.x) |
+| # | Finding | Real consumers | Change | Semver | Status |
+|---|---------|---------------:|--------|--------|--------|
+| 1 | `PixelSlice::new_tight` / `PixelSliceMut::new_tight` (packed-stride ctor) | ~361 | add method | additive (0.2.x) | **landed** |
+| 2 | `Adapted::as_pixel_slice()` | 5 | add method | additive (0.2.x) | **landed** |
+| 3 | `RowConverter::convert_slice(PixelSlice) -> PixelBuffer` | 4–5 | add method | additive (0.2.x) | **landed** |
+| 4 | `PixelDescriptor::with_color_from_cicp(Cicp)` | 3+ | add method | additive (0.2.x) | **landed** |
+| 5 | Steer bare-`Vec` callers to `convert_to` | — | docs | none | doc |
+| 6 | Crate-doc examples are `rust,ignore` (untested) | — | docs | none | galleries |
+| 7 | `finalize_for_output*` / `EncodeReady` / `OutputProfile` unadopted | **0** | demote | **0.3.0 breaking** | queued |
+| 8 | `PixelBufferConvertTypedExt` (`.to_rgba8`) is top idiom but `rgb`-gated | ~93 | docs | none | doc |
+| 9 | `Cicp::from_bytes([u8; 4])` | ~161 `Cicp::new` | add method | additive (0.2.x) | **landed** |
 
 ---
 
@@ -81,14 +82,17 @@ let adapted_stride = adapted.width as usize * adapted.descriptor.bytes_per_pixel
 let slice = PixelSlice::new(&adapted.data, adapted.width, adapted.rows, adapted_stride, adapted.descriptor)?;
 encoder.encode(slice)?;
 
-// proposed
+// landed
 let adapted = adapt_for_encode(pixel_data, descriptor, w, h, stride, caps)?;
-encoder.encode(adapted.as_pixel_slice())?;   // infallible: Adapted invariants already hold
+encoder.encode(adapted.as_pixel_slice()?)?;   // one call, no hand-computed stride
 ```
 
-Additive method on `Adapted<'a>` returning `PixelSlice<'a>` over its own bytes.
-Shown in `convert_pipeline.rs::adapt_pixels_before_encoding` (with the verbose
-form flagged).
+Method on `Adapted<'_>` returning `PixelSlice<'_>` over its own bytes. It returns
+`Result` (not the infallible form first sketched): the zero-copy borrow path can
+hand back wide-channel bytes that are misaligned for a `PixelSlice`, so the
+alignment check stays. Shown in
+`convert_pipeline.rs::adapt_pixels_before_encoding` (with the verbose form it
+replaces quoted inline).
 
 ## 3. `RowConverter::convert_slice` — bundle the 6-arg row loop
 
@@ -178,10 +182,22 @@ An additive `Cicp::from_bytes([u8; 4])` removes the `!= 0` papercut. Low priorit
 
 ---
 
-## What landed vs. what needs approval
+## What landed
 
-- **Landed** (safe, additive/docs): the two tested example galleries, the CI
+- **Galleries + CI + docs**: the two tested example galleries, the CI
   `--examples` step, and this document.
-- **Needs sign-off** (public API is forever): findings 1–4, 8–9 are additive and
-  each has concrete current consumers — ready to implement on approval.
-- **0.3.0 queue**: finding 7 (demotion) belongs in the batched breaking release.
+- **Additive API (approved 2026-07-14)**: findings 1, 2, 3, 4, 9 — `new_tight`
+  on both slice types, `Adapted::as_pixel_slice`,
+  `RowConverter::convert_slice`, `PixelDescriptor::with_color_from_cicp`, and
+  `Cicp::from_bytes`. Each is exercised in a gallery scenario and a doctest, and
+  is used inside the crates where it removes boilerplate. `cargo semver-checks`
+  classifies all five as non-breaking additions.
+- **Docs-only**: findings 5 (steer to `convert_to`), 6 (galleries replace the
+  `rust,ignore` blocks as the source of truth), 8 (document the `rgb`-gated
+  `to_rgba8`).
+- **0.3.0 queue**: finding 7 (demote the unadopted `finalize_for_output*`
+  surface) belongs in the batched breaking release, not shipped piecemeal.
+
+Sibling repos (imageflow, zengif, zenpipe, zencodecs, zenpng, zenavif, …) still
+hold the ~361 + N hand-rolled call sites the helpers target; migrating them is a
+per-repo follow-up, done in each repo on its own.

--- a/docs/ergonomics-2026-07-14.md
+++ b/docs/ergonomics-2026-07-14.md
@@ -23,13 +23,13 @@ demotion queued for the next breaking release.
 
 | # | Finding | Real consumers | Change | Semver | Status |
 |---|---------|---------------:|--------|--------|--------|
-| 1 | `PixelSlice::new_contiguous` / `PixelSliceMut::new_contiguous` (packed-stride ctor) | ~361 | add method | additive (0.2.x) | **landed** |
+| 1 | `PixelSlice::new_contiguous` / `PixelSliceMut::new_contiguous` (+ `new_packed` alias) — packed-stride ctor | ~361 | add method | additive (0.2.x) | **landed** |
 | 2 | `Adapted::as_pixel_slice()` | 5 | add method | additive (0.2.x) | **landed** |
 | 3 | `RowConverter::convert_slice(PixelSlice) -> PixelBuffer` | 4–5 | add method | additive (0.2.x) | **landed** |
 | 4 | `PixelDescriptor::with_color_from_cicp(Cicp)` | 3+ | add method | additive (0.2.x) | **landed** |
 | 5 | Steer bare-`Vec` callers to `convert_to` | — | docs | none | doc |
 | 6 | Crate-doc examples are `rust,ignore` (untested) | — | docs | none | galleries |
-| 7 | `finalize_for_output*` / `EncodeReady` / `OutputProfile` unadopted | **0** | demote | **0.3.0 breaking** | queued |
+| 7 | `finalize_for_output_with` / `EncodeReady` — atomic encode contract, unadopted by codecs (weaker two-track path) | **0 ext.** | keep / adopt | none | see §7 |
 | 8 | `PixelBufferConvertTypedExt` (`.to_rgba8`) is top idiom but `rgb`-gated | ~93 | docs | none | doc |
 | 9 | `Cicp::from_bytes([u8; 4])` | ~161 `Cicp::new` | add method | additive (0.2.x) | **landed** |
 
@@ -154,15 +154,46 @@ source of truth; the crate docs now point at the galleries (and the illustrative
 `ignore` blocks that use pseudo-symbols like `my_codec_decode` are labeled as
 such). Follow-up: convert the self-contained ones to real doctests.
 
-## 7. Unadopted encode-finalization surface → 0.3.0 demotion candidate
+## 7. Encode-finalization surface (`finalize_for_output_with` / `EncodeReady`) — keep, do NOT demote
 
-`finalize_for_output`, `finalize_for_output_with`, `EncodeReady`,
-`OutputProfile`, `OutputMetadata` are public and documented as the "encode" step,
-but the audit found **zero** non-def/non-doc downstream call sites. The encode
-color role is filled by `adapt_for_encode` + zencodec's `resolve_color_emit`.
-Per YAGNI these should be `pub(crate)`, but they shipped in 0.2.14, so removal is
-breaking. Recommendation: add to `CHANGELOG.md` **QUEUED BREAKING CHANGES** and
-demote at 0.3.0 (do not ship piecemeal). Same status as `cms_lite::ZenCmsLite`.
+**Correction to an earlier draft of this report, which wrongly flagged this
+surface for 0.3.0 demotion.** A full consumer audit confirms
+`finalize_for_output_with`, `EncodeReady`, `OutputProfile`, `OutputMetadata`
+have **zero external consumers** — but that is *under-adoption of the stronger
+contract*, not dead weight to delete. (Only the `finalize_for_output`
+`<C: ColorManagement>` overload and the `OutputMetadata::hdr` field are
+deprecated.)
+
+`finalize_for_output_with` is the crate's **type-enforced atomic encode
+contract**: it converts pixels to the target profile and produces the matching
+ICC/CICP *together*, so they cannot diverge — and its `EncodeReady::pixels()`
+come off a `PixelBuffer`, hence always SIMD-aligned (never the
+fallible-alignment case that `Adapted::as_pixel_slice` guards).
+
+**What the codecs do instead (two-track, by-convention):**
+
+- Track A — pixels: `adapt_for_encode` (format negotiation only; it *refuses*
+  to relabel primaries/range without a real conversion).
+- Track B — metadata: `zencodec::resolve_color_emit` → `ColorEmitPlan{cicp,icc}`
+  (pure/`no_std`, never sees pixels), lowered per-codec via
+  `synthesize_icc_for_cicp`.
+
+This mostly dodges the "P3 pixels / sRGB tag" bug **because the codecs never
+color-convert at encode** — pixels arrive already in their working space. But
+the guarantee is weaker than `EncodeReady`'s: the emitted metadata comes from a
+caller-supplied `Metadata{cicp,icc}` that is a *separate input from the pixels*
+and is never cross-checked. AVIF (`zenavif/src/codec.rs:999-1053`) treats the
+caller CICP as authoritative and ignores the descriptor, so an upstream mislabel
+is emitted faithfully wrong.
+
+**Recommendation (reversed):** do NOT demote. Either (a) adopt
+`finalize_for_output_with` in the codec lowering path for the type-enforced
+guarantee, (b) keep the two-track design but add a pixel↔metadata cross-check,
+or (c) at minimum keep the API as the reference contract. Two stale docs to fix
+regardless: the crate's own module docs (`lib.rs:256,259,286,357,388`)
+recommend the **deprecated** `finalize_for_output` instead of `_with`, and
+`zencodec/src/color.rs:43` claims the encode path already lowers "through
+zenpixels_convert's atomic finalize_for_output_with" — it does not.
 
 ## 8. Top convert idiom is `rgb`-gated and under-documented
 
@@ -187,16 +218,18 @@ An additive `Cicp::from_bytes([u8; 4])` removes the `!= 0` papercut. Low priorit
 - **Galleries + CI + docs**: the two tested example galleries, the CI
   `--examples` step, and this document.
 - **Additive API (approved 2026-07-14)**: findings 1, 2, 3, 4, 9 — `new_contiguous`
-  on both slice types, `Adapted::as_pixel_slice`,
+  (+ its `new_packed` alias) on both slice types, `Adapted::as_pixel_slice`,
   `RowConverter::convert_slice`, `PixelDescriptor::with_color_from_cicp`, and
   `Cicp::from_bytes`. Each is exercised in a gallery scenario and a doctest, and
   is used inside the crates where it removes boilerplate. `cargo semver-checks`
-  classifies all five as non-breaking additions.
+  classifies all of them as non-breaking additions.
 - **Docs-only**: findings 5 (steer to `convert_to`), 6 (galleries replace the
   `rust,ignore` blocks as the source of truth), 8 (document the `rgb`-gated
   `to_rgba8`).
-- **0.3.0 queue**: finding 7 (demote the unadopted `finalize_for_output*`
-  surface) belongs in the batched breaking release, not shipped piecemeal.
+- **Finding 7 (corrected — NOT a demotion)**: `finalize_for_output_with` /
+  `EncodeReady` is the type-enforced atomic encode contract and stays. The
+  codecs' weaker two-track path (`adapt_for_encode` + `resolve_color_emit`)
+  carries the residual pixel↔metadata divergence gap. See §7.
 
 Sibling repos (imageflow, zengif, zenpipe, zencodecs, zenpng, zenavif, …) still
 hold the ~361 + N hand-rolled call sites the helpers target; migrating them is a

--- a/docs/ergonomics-2026-07-14.md
+++ b/docs/ergonomics-2026-07-14.md
@@ -1,0 +1,187 @@
+# API ergonomics findings — 2026-07-14
+
+How to make `zenpixels` / `zenpixels-convert` call sites **shorter and cleaner**,
+grounded in two inputs:
+
+1. A downstream-usage audit across the `~/work/zen/` tree (~20 sibling crates:
+   zenjpeg, zenpng, zenwebp, zengif, zenavif, zencodec, zencodecs, zenpipe,
+   imageflow, zenmetrics, zenanalyze, zentone, …). Consumer counts below are
+   from that audit.
+2. Two new tested example galleries that exercise the common usages and expose
+   the friction inline:
+   - `zenpixels/examples/common_usage.rs` (9 scenarios)
+   - `zenpixels-convert/examples/convert_pipeline.rs` (14 scenarios)
+
+**Nothing here changes the public API.** Every public item in these crates is a
+forever commitment (see `zenpixels/CLAUDE.md`), so the additive helpers below are
+*proposals with real consumers*, not applied changes — they need explicit
+sign-off before landing. Findings 6 and this doc are the only things landed now,
+alongside the galleries.
+
+## Summary
+
+| # | Finding | Real consumers | Change | Semver |
+|---|---------|---------------:|--------|--------|
+| 1 | `PixelSlice::new_tight` / `PixelSliceMut::new_tight` (packed-stride ctor) | ~361 | add method | additive (0.2.x) |
+| 2 | `Adapted::as_pixel_slice()` | 5 | add method | additive (0.2.x) |
+| 3 | `RowConverter::convert_slice(PixelSlice) -> PixelBuffer` | 4–5 | add method | additive (0.2.x) |
+| 4 | `PixelDescriptor::with_color_from_cicp(Cicp)` | 3+ | add method | additive (0.2.x) |
+| 5 | Steer bare-`Vec` callers to `convert_to` | — | docs | none |
+| 6 | Crate-doc examples are `rust,ignore` (untested) | — | docs | none |
+| 7 | `finalize_for_output*` / `EncodeReady` / `OutputProfile` unadopted | **0** | demote | **0.3.0 breaking** |
+| 8 | `PixelBufferConvertTypedExt` (`.to_rgba8`) is top idiom but `rgb`-gated | ~93 | docs | none |
+| 9 | `Cicp::from_bytes([u8; 4])` | ~161 `Cicp::new` | add method | additive (0.2.x) |
+
+---
+
+## 1. Packed-stride slice constructor — the single biggest win
+
+**~361 `PixelSlice::new(...)` call sites**, and nearly every one hand-computes a
+tight stride first. It is the most-repeated single line in the whole audit.
+
+```rust
+// today — the stride restates width * bpp every time
+let stride = width as usize * descriptor.bytes_per_pixel();
+let ps = PixelSlice::new(data, width, height, stride, descriptor)?;
+
+// proposed
+let ps = PixelSlice::new_tight(data, width, height, descriptor)?;
+```
+
+Additive inherent methods on the erased slices (mirrors the existing `new`):
+
+```rust
+impl<'a> PixelSlice<'a> {
+    /// `new` with a tightly-packed stride (`width * bytes_per_pixel`).
+    pub fn new_tight(data: &'a [u8], width: u32, rows: u32, d: PixelDescriptor)
+        -> Result<Self, At<BufferError>>
+    {
+        Self::new(data, width, rows, width as usize * d.bytes_per_pixel(), d)
+    }
+}
+// ...and the same for PixelSliceMut.
+```
+
+Representative victims: `imageflow_core/.../zen_encoder.rs:618`,
+`zengif/src/codec.rs:1166`, and the 5× `adapt_for_encode` blocks below.
+Verdict: **highest value, lowest risk.** 361 concrete consumers clear the YAGNI
+bar by a wide margin.
+
+## 2. `Adapted::as_pixel_slice()` — kill the re-slice boilerplate
+
+The `adapt_for_encode` → recompute-stride → `PixelSlice::new` → `encode` block is
+**duplicated verbatim 5×** in zenpipe/zencodecs (`avif_enc.rs:159`,
+`jxl_enc.rs:130`, `encode.rs:824`, `dispatch.rs:171`, `transcode.rs:706`).
+`Adapted` already owns `data` / `descriptor` / `width` / `rows`.
+
+```rust
+// today
+let adapted = adapt_for_encode(pixel_data, descriptor, w, h, stride, caps)?;
+let adapted_stride = adapted.width as usize * adapted.descriptor.bytes_per_pixel();
+let slice = PixelSlice::new(&adapted.data, adapted.width, adapted.rows, adapted_stride, adapted.descriptor)?;
+encoder.encode(slice)?;
+
+// proposed
+let adapted = adapt_for_encode(pixel_data, descriptor, w, h, stride, caps)?;
+encoder.encode(adapted.as_pixel_slice())?;   // infallible: Adapted invariants already hold
+```
+
+Additive method on `Adapted<'a>` returning `PixelSlice<'a>` over its own bytes.
+Shown in `convert_pipeline.rs::adapt_pixels_before_encoding` (with the verbose
+form flagged).
+
+## 3. `RowConverter::convert_slice` — bundle the 6-arg row loop
+
+The "build plan, `alloc w*h*bpp`, loop `convert_row`" block is hand-rolled in
+~5 crates (`zenmetrics-api/src/metric.rs:2164`, `zenmetrics-gpu-core/src/lib.rs:79,288`,
+`cvvdp/src/pipeline.rs:2367`, `zenanalyze/src/row_stream.rs`). `RowConverter::convert_rows`
+already does whole-buffer work but takes six positional args
+`(src, src_stride, dst, dst_stride, width, rows)` — the very unbundling
+`PixelSlice` exists to prevent.
+
+```rust
+// today (free-function plan variant)
+let plan = ConvertPlan::new(src.descriptor(), target)?;
+let mut out = vec![0u8; row_bytes * h as usize];
+for y in 0..h { convert_row(&plan, src.row(y), &mut out[y*row_bytes..][..row_bytes], w); }
+
+// proposed
+let out: PixelBuffer = RowConverter::new(src.descriptor(), target)?.convert_slice(src.as_slice())?;
+```
+
+Additive method taking a `PixelSlice` and returning an owned `PixelBuffer`
+(pairs with finding 1). Aligns with the CLAUDE.md pixel-buffer-API rule
+("anywhere a function takes the whole image it must accept stride / a `PixelSlice`").
+`PixelBufferConvertExt::convert_to` already covers the "I hold a `PixelBuffer`"
+case; this covers "I hold a `PixelSlice` and want scratch/streaming control."
+
+## 4. `PixelDescriptor::with_color_from_cicp(Cicp)` — retag transfer+primaries
+
+The "keep the format, adopt transfer+primaries from a decoded CICP" chain repeats
+(`zenpng/src/codec.rs:2063`, `zenavif/src/codec.rs:3276`, `zencodec/src/helpers/icc.rs:135`):
+
+```rust
+// today
+if let Some(tf) = TransferFunction::from_cicp(c.transfer_characteristics) { desc = desc.with_transfer(tf); }
+if let Some(p)  = ColorPrimaries::from_cicp(c.color_primaries)          { desc = desc.with_primaries(p); }
+
+// proposed (const fn, keeps format/type/alpha, updates only color axes)
+let desc = desc.with_color_from_cicp(cicp);
+```
+
+Additive `const fn` on `PixelDescriptor`. Distinct from `Cicp::to_descriptor`,
+which *builds* a fresh descriptor from a `PixelFormat` rather than retagging one.
+
+## 5. `convert_buffer` hands back a bare `Vec<u8>`
+
+`adapt::convert_buffer(bytes, w, h, from, to) -> Vec<u8>` drops dims and
+descriptor — the caller has to carry them separately. When a `PixelBuffer` is in
+hand, `PixelBufferConvertExt::convert_to` keeps everything. This is a
+documentation/steering fix (make `convert_to` the headline in the crate docs and
+in `convert_buffer`'s rustdoc), not an API change. Demonstrated side-by-side in
+`convert_pipeline.rs`.
+
+## 6. Crate-doc examples are `rust,ignore` (untested) — LANDED
+
+Both crate-level docs narrate the pipeline with `rust,ignore` blocks
+(`zenpixels-convert/src/lib.rs:81,150,198,207`, …). `ignore` blocks never
+compile, so they rot silently. The new tested galleries replace them as the
+source of truth; the crate docs now point at the galleries (and the illustrative
+`ignore` blocks that use pseudo-symbols like `my_codec_decode` are labeled as
+such). Follow-up: convert the self-contained ones to real doctests.
+
+## 7. Unadopted encode-finalization surface → 0.3.0 demotion candidate
+
+`finalize_for_output`, `finalize_for_output_with`, `EncodeReady`,
+`OutputProfile`, `OutputMetadata` are public and documented as the "encode" step,
+but the audit found **zero** non-def/non-doc downstream call sites. The encode
+color role is filled by `adapt_for_encode` + zencodec's `resolve_color_emit`.
+Per YAGNI these should be `pub(crate)`, but they shipped in 0.2.14, so removal is
+breaking. Recommendation: add to `CHANGELOG.md` **QUEUED BREAKING CHANGES** and
+demote at 0.3.0 (do not ship piecemeal). Same status as `cms_lite::ZenCmsLite`.
+
+## 8. Top convert idiom is `rgb`-gated and under-documented
+
+`PixelBufferConvertTypedExt::to_rgba8()` / `.to_rgb8()` is the most common
+decode-output one-liner downstream (~93 fully-qualified imports), but it lives
+behind the `rgb` feature and is absent from the default-features docs. The
+default-available equivalent is `PixelBufferConvertExt::convert_to(desc)`.
+Recommendation: document both prominently and cross-link the feature gate. (No
+API change — the galleries use `convert_to` since they build with default
+features.)
+
+## 9. (minor) `Cicp::from_bytes([u8; 4])`
+
+`Cicp::new(c[0], c[1], c[2], c[3] != 0)` from a parsed 4-byte tuple recurs
+(~161 `Cicp::new` sites, many of this shape, e.g. `zenpng/src/codec.rs:2152`).
+An additive `Cicp::from_bytes([u8; 4])` removes the `!= 0` papercut. Low priority.
+
+---
+
+## What landed vs. what needs approval
+
+- **Landed** (safe, additive/docs): the two tested example galleries, the CI
+  `--examples` step, and this document.
+- **Needs sign-off** (public API is forever): findings 1–4, 8–9 are additive and
+  each has concrete current consumers — ready to implement on approval.
+- **0.3.0 queue**: finding 7 (demotion) belongs in the batched breaking release.

--- a/docs/ergonomics-2026-07-14.md
+++ b/docs/ergonomics-2026-07-14.md
@@ -23,7 +23,7 @@ demotion queued for the next breaking release.
 
 | # | Finding | Real consumers | Change | Semver | Status |
 |---|---------|---------------:|--------|--------|--------|
-| 1 | `PixelSlice::new_tight` / `PixelSliceMut::new_tight` (packed-stride ctor) | ~361 | add method | additive (0.2.x) | **landed** |
+| 1 | `PixelSlice::new_contiguous` / `PixelSliceMut::new_contiguous` (packed-stride ctor) | ~361 | add method | additive (0.2.x) | **landed** |
 | 2 | `Adapted::as_pixel_slice()` | 5 | add method | additive (0.2.x) | **landed** |
 | 3 | `RowConverter::convert_slice(PixelSlice) -> PixelBuffer` | 4–5 | add method | additive (0.2.x) | **landed** |
 | 4 | `PixelDescriptor::with_color_from_cicp(Cicp)` | 3+ | add method | additive (0.2.x) | **landed** |
@@ -46,7 +46,7 @@ let stride = width as usize * descriptor.bytes_per_pixel();
 let ps = PixelSlice::new(data, width, height, stride, descriptor)?;
 
 // proposed
-let ps = PixelSlice::new_tight(data, width, height, descriptor)?;
+let ps = PixelSlice::new_contiguous(data, width, height, descriptor)?;
 ```
 
 Additive inherent methods on the erased slices (mirrors the existing `new`):
@@ -54,7 +54,7 @@ Additive inherent methods on the erased slices (mirrors the existing `new`):
 ```rust
 impl<'a> PixelSlice<'a> {
     /// `new` with a tightly-packed stride (`width * bytes_per_pixel`).
-    pub fn new_tight(data: &'a [u8], width: u32, rows: u32, d: PixelDescriptor)
+    pub fn new_contiguous(data: &'a [u8], width: u32, rows: u32, d: PixelDescriptor)
         -> Result<Self, At<BufferError>>
     {
         Self::new(data, width, rows, width as usize * d.bytes_per_pixel(), d)
@@ -186,7 +186,7 @@ An additive `Cicp::from_bytes([u8; 4])` removes the `!= 0` papercut. Low priorit
 
 - **Galleries + CI + docs**: the two tested example galleries, the CI
   `--examples` step, and this document.
-- **Additive API (approved 2026-07-14)**: findings 1, 2, 3, 4, 9 — `new_tight`
+- **Additive API (approved 2026-07-14)**: findings 1, 2, 3, 4, 9 — `new_contiguous`
   on both slice types, `Adapted::as_pixel_slice`,
   `RowConverter::convert_slice`, `PixelDescriptor::with_color_from_cicp`, and
   `Cicp::from_bytes`. Each is exercised in a gallery scenario and a doctest, and

--- a/docs/public-api/zenpixels-convert.features.txt
+++ b/docs/public-api/zenpixels-convert.features.txt
@@ -13,21 +13,21 @@
 #   pub types (struct/enum/trait/alias)        50
 #   pub consts/statics                         12
 #   free functions                             12
-#   inherent methods                           84
+#   inherent methods                           92
 #   struct fields                             108
 #   enum variants                              88
 #   trait roster entries (type × trait)        83
 #   auto-trait-complete types                  20
 #
 # per-module pub lines:
-#   (root)                          105
+#   (root)                          109
 #   cms_moxcms                        5
 #   estimate                         47
-#   ext                               8
+#   ext                              12
 #   hdr                              26
 #   pipeline                        170
 
-## items (328 lines)
+## items (336 lines)
 
 pub mod cms_moxcms
 pub struct cms_moxcms::MoxCmsError(pub alloc::string::String)
@@ -65,6 +65,10 @@ pub fn ext::PixelBufferConvertTypedExt::to_bgra8(&self) -> zenpixels::buffer::Pi
 pub fn ext::PixelBufferConvertTypedExt::to_gray8(&self) -> zenpixels::buffer::PixelBuffer<rgb::formats::gray::Gray_v08<u8>>
 pub fn ext::PixelBufferConvertTypedExt::to_rgb8(&self) -> zenpixels::buffer::PixelBuffer<rgb::formats::rgb::Rgb<u8>>
 pub fn ext::PixelBufferConvertTypedExt::to_rgba8(&self) -> zenpixels::buffer::PixelBuffer<rgb::formats::rgba::Rgba<u8>>
+pub fn ext::PixelBufferConvertTypedExt::try_to_bgra8(&self) -> core::result::Result<zenpixels::buffer::PixelBuffer<rgb::formats::bgra::Bgra<u8>>, whereat::at::At<error::ConvertError>>
+pub fn ext::PixelBufferConvertTypedExt::try_to_gray8(&self) -> core::result::Result<zenpixels::buffer::PixelBuffer<rgb::formats::gray::Gray_v08<u8>>, whereat::at::At<error::ConvertError>>
+pub fn ext::PixelBufferConvertTypedExt::try_to_rgb8(&self) -> core::result::Result<zenpixels::buffer::PixelBuffer<rgb::formats::rgb::Rgb<u8>>, whereat::at::At<error::ConvertError>>
+pub fn ext::PixelBufferConvertTypedExt::try_to_rgba8(&self) -> core::result::Result<zenpixels::buffer::PixelBuffer<rgb::formats::rgba::Rgba<u8>>, whereat::at::At<error::ConvertError>>
 pub fn ext::PixelBufferHdrConvertExt::convert_to_sdr(&self, zenpixels::descriptor::PixelDescriptor) -> core::result::Result<zenpixels::buffer::PixelBuffer, whereat::at::At<error::ConvertError>>
 pub fn ext::PixelBufferHdrConvertExt::convert_to_with_hdr_config(&self, zenpixels::descriptor::PixelDescriptor, HdrConfig) -> core::result::Result<zenpixels::buffer::PixelBuffer, whereat::at::At<error::ConvertError>>
 pub mod hdr::measure
@@ -351,6 +355,10 @@ pub fn PixelBufferConvertTypedExt::to_bgra8(&self) -> zenpixels::buffer::PixelBu
 pub fn PixelBufferConvertTypedExt::to_gray8(&self) -> zenpixels::buffer::PixelBuffer<rgb::formats::gray::Gray_v08<u8>>
 pub fn PixelBufferConvertTypedExt::to_rgb8(&self) -> zenpixels::buffer::PixelBuffer<rgb::formats::rgb::Rgb<u8>>
 pub fn PixelBufferConvertTypedExt::to_rgba8(&self) -> zenpixels::buffer::PixelBuffer<rgb::formats::rgba::Rgba<u8>>
+pub fn PixelBufferConvertTypedExt::try_to_bgra8(&self) -> core::result::Result<zenpixels::buffer::PixelBuffer<rgb::formats::bgra::Bgra<u8>>, whereat::at::At<error::ConvertError>>
+pub fn PixelBufferConvertTypedExt::try_to_gray8(&self) -> core::result::Result<zenpixels::buffer::PixelBuffer<rgb::formats::gray::Gray_v08<u8>>, whereat::at::At<error::ConvertError>>
+pub fn PixelBufferConvertTypedExt::try_to_rgb8(&self) -> core::result::Result<zenpixels::buffer::PixelBuffer<rgb::formats::rgb::Rgb<u8>>, whereat::at::At<error::ConvertError>>
+pub fn PixelBufferConvertTypedExt::try_to_rgba8(&self) -> core::result::Result<zenpixels::buffer::PixelBuffer<rgb::formats::rgba::Rgba<u8>>, whereat::at::At<error::ConvertError>>
 pub trait PixelBufferHdrConvertExt [also: ext]
 pub fn PixelBufferHdrConvertExt::convert_to_sdr(&self, zenpixels::descriptor::PixelDescriptor) -> core::result::Result<zenpixels::buffer::PixelBuffer, whereat::at::At<error::ConvertError>>
 pub fn PixelBufferHdrConvertExt::convert_to_with_hdr_config(&self, zenpixels::descriptor::PixelDescriptor, HdrConfig) -> core::result::Result<zenpixels::buffer::PixelBuffer, whereat::at::At<error::ConvertError>>

--- a/docs/public-api/zenpixels-convert.features.txt
+++ b/docs/public-api/zenpixels-convert.features.txt
@@ -1,5 +1,5 @@
 # zenpixels-convert public API — additions from non-default features
-# features: avx512,cms-moxcms,fast-transpose,hdr-experimental,icc-db,imgref,pipeline,planar,rgb,serde,std
+# features: avx512,cms-moxcms,estimation-experimental,fast-transpose,hdr-experimental,icc-db,imgref,pipeline,planar,rgb,serde,std
 # (regenerated on every `cargo test` by zenutils-apidoc; ZEN_API_DOC=check verifies, =off skips).
 # Encodings: crate-name prefix stripped; auto traits collapse to a
 # count + exceptions; trait impls collapse to one roster line per
@@ -9,30 +9,58 @@
 
 ## summary
 #
-#   pub modules                                 6
-#   pub types (struct/enum/trait/alias)        42
+#   pub modules                                 7
+#   pub types (struct/enum/trait/alias)        50
 #   pub consts/statics                         12
 #   free functions                             12
-#   inherent methods                           48
+#   inherent methods                           84
 #   struct fields                             108
-#   enum variants                              70
-#   trait roster entries (type × trait)        63
-#   auto-trait-complete types                  16
+#   enum variants                              88
+#   trait roster entries (type × trait)        83
+#   auto-trait-complete types                  20
 #
 # per-module pub lines:
-#   (root)                           89
+#   (root)                          105
 #   cms_moxcms                        5
+#   estimate                         47
 #   ext                               8
 #   hdr                              26
 #   pipeline                        170
 
-## items (269 lines)
+## items (328 lines)
 
 pub mod cms_moxcms
 pub struct cms_moxcms::MoxCmsError(pub alloc::string::String)
 pub fn cms_moxcms::cicp_transform_opts() -> moxcms::transform::TransformOptions
 pub fn cms_moxcms::lut_transform_opts() -> moxcms::transform::TransformOptions
 pub fn cms_moxcms::transform_opts(cms::ColorPriority, cms::RenderingIntent) -> moxcms::transform::TransformOptions
+pub mod estimate
+pub estimate::SimdTier::CurrentHost
+pub estimate::SimdTier::Neon
+pub estimate::SimdTier::Unknown
+pub estimate::SimdTier::Wasm
+pub estimate::SimdTier::Wasm128
+pub estimate::SimdTier::X86V1
+pub estimate::SimdTier::X86V2
+pub estimate::SimdTier::X86V3
+pub estimate::SimdTier::X86V4
+pub fn estimate::ComputeEnvironment::available_ram_bytes(&self) -> core::option::Option<u64>
+pub fn estimate::ComputeEnvironment::cores(&self) -> usize
+pub fn estimate::ComputeEnvironment::new() -> Self
+pub fn estimate::ComputeEnvironment::simd_tier(&self) -> core::option::Option<estimate::SimdTier>
+pub fn estimate::ComputeEnvironment::with_available_ram_bytes(self, u64) -> Self
+pub fn estimate::ComputeEnvironment::with_cores(self, usize) -> Self
+pub fn estimate::ComputeEnvironment::with_simd_tier(self, estimate::SimdTier) -> Self
+pub fn estimate::ImageCharacteristics::descriptor(&self) -> &zenpixels::descriptor::PixelDescriptor
+pub fn estimate::ImageCharacteristics::height(&self) -> u32
+pub fn estimate::ImageCharacteristics::new(u32, u32, zenpixels::descriptor::PixelDescriptor) -> Self
+pub fn estimate::ImageCharacteristics::width(&self) -> u32
+pub fn estimate::ResourceEstimate::intermediate_buffer_count(&self) -> core::option::Option<u32>
+pub fn estimate::ResourceEstimate::new(u64, u64) -> Self
+pub fn estimate::ResourceEstimate::peak_memory_bytes_est(&self) -> core::option::Option<u64>
+pub fn estimate::ResourceEstimate::unknown() -> Self
+pub fn estimate::ResourceEstimate::wall_ms(&self) -> core::option::Option<u64>
+pub fn estimate::ResourceEstimate::with_intermediate_buffer_count(self, u32) -> Self
 pub fn ext::PixelBufferConvertTypedExt::to_bgra8(&self) -> zenpixels::buffer::PixelBuffer<rgb::formats::bgra::Bgra<u8>>
 pub fn ext::PixelBufferConvertTypedExt::to_gray8(&self) -> zenpixels::buffer::PixelBuffer<rgb::formats::gray::Gray_v08<u8>>
 pub fn ext::PixelBufferConvertTypedExt::to_rgb8(&self) -> zenpixels::buffer::PixelBuffer<rgb::formats::rgb::Rgb<u8>>
@@ -234,6 +262,16 @@ pub QualityThreshold::Lossless
 pub QualityThreshold::MaxBucket(pipeline::path::LossBucket)
 pub QualityThreshold::NearLossless
 pub QualityThreshold::SubPerceptual
+#[non_exhaustive] pub enum SimdTier [also: estimate]
+pub SimdTier::CurrentHost
+pub SimdTier::Neon
+pub SimdTier::Unknown
+pub SimdTier::Wasm
+pub SimdTier::Wasm128
+pub SimdTier::X86V1
+pub SimdTier::X86V2
+pub SimdTier::X86V3
+pub SimdTier::X86V4
 pub struct CodecFormats [also: pipeline, pipeline::registry]
 pub CodecFormats::cicp: bool
 pub CodecFormats::decode_outputs: &'static [pipeline::registry::FormatEntry]
@@ -241,6 +279,14 @@ pub CodecFormats::encode_inputs: &'static [pipeline::registry::FormatEntry]
 pub CodecFormats::icc_decode: bool
 pub CodecFormats::icc_encode: bool
 pub CodecFormats::name: &'static str
+#[non_exhaustive] pub struct ComputeEnvironment [also: estimate]
+pub fn estimate::ComputeEnvironment::available_ram_bytes(&self) -> core::option::Option<u64>
+pub fn estimate::ComputeEnvironment::cores(&self) -> usize
+pub fn estimate::ComputeEnvironment::new() -> Self
+pub fn estimate::ComputeEnvironment::simd_tier(&self) -> core::option::Option<estimate::SimdTier>
+pub fn estimate::ComputeEnvironment::with_available_ram_bytes(self, u64) -> Self
+pub fn estimate::ComputeEnvironment::with_cores(self, usize) -> Self
+pub fn estimate::ComputeEnvironment::with_simd_tier(self, estimate::SimdTier) -> Self
 pub struct ConversionPath [also: pipeline, pipeline::path]
 pub ConversionPath::output_format: zenpixels::descriptor::PixelDescriptor
 pub ConversionPath::proven_lossless: bool
@@ -252,6 +298,8 @@ pub ConversionPath::working_format: zenpixels::descriptor::PixelDescriptor
 pub ConversionPath::working_suitability: u16
 pub ConversionPath::working_to_output: ConversionCost
 pub fn pipeline::path::ConversionPath::loss_bucket(&self) -> pipeline::path::LossBucket
+pub fn ConvertPlan::estimate(&self, u32, u32) -> estimate::ResourceEstimate
+pub fn ConvertPlan::estimate_in(&self, &estimate::ImageCharacteristics, &estimate::ComputeEnvironment) -> estimate::ResourceEstimate
 pub fn ConvertPlan::new_with_hdr_config(zenpixels::descriptor::PixelDescriptor, zenpixels::descriptor::PixelDescriptor, HdrConfig) -> core::result::Result<Self, whereat::at::At<error::ConvertError>>
 pub fn ConvertPlan::new_with_hdr_peak(zenpixels::descriptor::PixelDescriptor, zenpixels::descriptor::PixelDescriptor, f32) -> core::result::Result<Self, whereat::at::At<error::ConvertError>>
 pub struct FormatEntry [also: pipeline, pipeline::registry]
@@ -265,6 +313,11 @@ pub HdrConfig::target_peak_nits: f32
 pub fn HdrConfig::for_source_peak(f32) -> Self
 pub fn HdrConfig::with_gamut_knee(self, f32) -> Self
 pub fn HdrConfig::with_target_peak_nits(self, f32) -> Self
+#[non_exhaustive] pub struct ImageCharacteristics [also: estimate]
+pub fn estimate::ImageCharacteristics::descriptor(&self) -> &zenpixels::descriptor::PixelDescriptor
+pub fn estimate::ImageCharacteristics::height(&self) -> u32
+pub fn estimate::ImageCharacteristics::new(u32, u32, zenpixels::descriptor::PixelDescriptor) -> Self
+pub fn estimate::ImageCharacteristics::width(&self) -> u32
 pub struct MatrixStats [also: pipeline, pipeline::path]
 pub MatrixStats::by_bucket: [usize; 5]
 pub MatrixStats::distinct_working_formats: usize
@@ -286,6 +339,13 @@ pub PathEntry::path: core::option::Option<pipeline::path::ConversionPath>
 pub PathEntry::source_codec: &'static str
 pub PathEntry::source_effective_bits: u8
 pub PathEntry::source_format: zenpixels::descriptor::PixelDescriptor
+#[non_exhaustive] pub struct ResourceEstimate [also: estimate]
+pub fn estimate::ResourceEstimate::intermediate_buffer_count(&self) -> core::option::Option<u32>
+pub fn estimate::ResourceEstimate::new(u64, u64) -> Self
+pub fn estimate::ResourceEstimate::peak_memory_bytes_est(&self) -> core::option::Option<u64>
+pub fn estimate::ResourceEstimate::unknown() -> Self
+pub fn estimate::ResourceEstimate::wall_ms(&self) -> core::option::Option<u64>
+pub fn estimate::ResourceEstimate::with_intermediate_buffer_count(self, u32) -> Self
 pub trait PixelBufferConvertTypedExt: ext::PixelBufferConvertExt [also: ext]
 pub fn PixelBufferConvertTypedExt::to_bgra8(&self) -> zenpixels::buffer::PixelBuffer<rgb::formats::bgra::Bgra<u8>>
 pub fn PixelBufferConvertTypedExt::to_gray8(&self) -> zenpixels::buffer::PixelBuffer<rgb::formats::gray::Gray_v08<u8>>
@@ -298,11 +358,15 @@ pub fn generate_path_matrix(&[&pipeline::registry::CodecFormats], &[pipeline::op
 pub fn matrix_stats(&[pipeline::path::PathEntry]) -> pipeline::path::MatrixStats [also: pipeline, pipeline::path]
 pub fn optimal_path(zenpixels::descriptor::PixelDescriptor, Provenance, pipeline::op_format::OpCategory, zenpixels::descriptor::PixelDescriptor, pipeline::path::QualityThreshold) -> core::option::Option<pipeline::path::ConversionPath> [also: pipeline, pipeline::path]
 
-## trait impls (18 types)
+## trait impls (22 types)
 
 HdrConfig: Clone, Copy, Debug, Default, PartialEq
 cms_moxcms::MoxCms: Clone, Copy, Debug, Default, cms::ColorManagement, cms::PluggableCms
 cms_moxcms::MoxCmsError: Clone, Debug, Display
+estimate::ComputeEnvironment: Clone, Copy, Debug, Default, Eq, PartialEq
+estimate::ImageCharacteristics: Clone, Debug, Eq, PartialEq
+estimate::ResourceEstimate: Clone, Copy, Debug, PartialEq
+estimate::SimdTier: Clone, Copy, Debug, Eq, Hash, PartialEq
 hdr::Bt2446A: Clone, Copy, Debug
 hdr::GamutBoundaryLut: Clone, Debug
 hdr::SoftCompress: Clone, Debug

--- a/docs/public-api/zenpixels-convert.txt
+++ b/docs/public-api/zenpixels-convert.txt
@@ -12,7 +12,7 @@
 #   pub types (struct/enum/trait/alias)        57
 #   pub consts/statics                         19
 #   free functions                             40
-#   inherent methods                          129
+#   inherent methods                          132
 #   struct fields                              50
 #   enum variants                              74
 #   re-exports                                  5
@@ -22,9 +22,9 @@
 #
 # per-module pub lines:
 #   (root)                          167
-#   adapt                            10
+#   adapt                            11
 #   cms                              27
-#   converter                        23
+#   converter                        25
 #   error                            27
 #   estimate                         47
 #   ext                              13
@@ -36,7 +36,7 @@
 #   orient                            3
 #   output                           17
 
-## items (354 lines)
+## items (357 lines)
 
 pub mod zenpixels_convert
 pub use <<zenpixels::*>>
@@ -48,6 +48,7 @@ pub adapt::Adapted::data: alloc::borrow::Cow<'a, [u8]>
 pub adapt::Adapted::descriptor: zenpixels::descriptor::PixelDescriptor
 pub adapt::Adapted::rows: u32
 pub adapt::Adapted::width: u32
+pub fn adapt::Adapted<'a>::as_pixel_slice(&self) -> core::result::Result<zenpixels::buffer::PixelSlice<'_>, whereat::at::At<error::ConvertError>>
 pub fn adapt::adapt_for_encode<'a>(&'a [u8], zenpixels::descriptor::PixelDescriptor, u32, u32, usize, &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<adapt::Adapted<'a>, whereat::at::At<error::ConvertError>>
 pub fn adapt::adapt_for_encode_with_intent<'a>(&'a [u8], zenpixels::descriptor::PixelDescriptor, u32, u32, usize, &[zenpixels::descriptor::PixelDescriptor], ConvertIntent) -> core::result::Result<adapt::Adapted<'a>, whereat::at::At<error::ConvertError>>
 pub fn adapt::convert_buffer(&[u8], u32, u32, zenpixels::descriptor::PixelDescriptor, zenpixels::descriptor::PixelDescriptor) -> core::result::Result<alloc::vec::Vec<u8>, whereat::at::At<error::ConvertError>>
@@ -73,6 +74,7 @@ pub mod converter
 pub fn converter::RowConverter::compose(&self, &Self) -> core::option::Option<Self>
 pub fn converter::RowConverter::convert_row(&mut self, &[u8], &mut [u8], u32)
 pub fn converter::RowConverter::convert_rows(&mut self, &[u8], usize, &mut [u8], usize, u32, u32) -> core::result::Result<(), whereat::at::At<error::ConvertError>>
+pub fn converter::RowConverter::convert_slice(&mut self, zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<zenpixels::buffer::PixelBuffer, whereat::at::At<error::ConvertError>>
 pub fn converter::RowConverter::from_descriptor(&self) -> zenpixels::descriptor::PixelDescriptor
 pub fn converter::RowConverter::from_plan(ConvertPlan) -> Self
 pub fn converter::RowConverter::is_identity(&self) -> bool
@@ -336,6 +338,7 @@ pub struct RowConverter [also: converter]
 pub fn converter::RowConverter::compose(&self, &Self) -> core::option::Option<Self>
 pub fn converter::RowConverter::convert_row(&mut self, &[u8], &mut [u8], u32)
 pub fn converter::RowConverter::convert_rows(&mut self, &[u8], usize, &mut [u8], usize, u32, u32) -> core::result::Result<(), whereat::at::At<error::ConvertError>>
+pub fn converter::RowConverter::convert_slice(&mut self, zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<zenpixels::buffer::PixelBuffer, whereat::at::At<error::ConvertError>>
 pub fn converter::RowConverter::from_descriptor(&self) -> zenpixels::descriptor::PixelDescriptor
 pub fn converter::RowConverter::from_plan(ConvertPlan) -> Self
 pub fn converter::RowConverter::is_identity(&self) -> bool

--- a/docs/public-api/zenpixels-convert.txt
+++ b/docs/public-api/zenpixels-convert.txt
@@ -8,25 +8,24 @@
 
 ## summary
 #
-#   pub modules                                14
-#   pub types (struct/enum/trait/alias)        57
+#   pub modules                                13
+#   pub types (struct/enum/trait/alias)        49
 #   pub consts/statics                         19
 #   free functions                             40
-#   inherent methods                          132
+#   inherent methods                           96
 #   struct fields                              50
-#   enum variants                              74
+#   enum variants                              56
 #   re-exports                                  5
-#   trait roster entries (type × trait)        91
-#   auto-trait-complete types                  19
+#   trait roster entries (type × trait)        71
+#   auto-trait-complete types                  15
 #   auto-trait exceptions                       2
 #
 # per-module pub lines:
-#   (root)                          167
+#   (root)                          151
 #   adapt                            11
 #   cms                              27
 #   converter                        25
 #   error                            27
-#   estimate                         47
 #   ext                              13
 #   gamut                             6
 #   hdr                              15
@@ -36,7 +35,7 @@
 #   orient                            3
 #   output                           17
 
-## items (357 lines)
+## items (298 lines)
 
 pub mod zenpixels_convert
 pub use <<zenpixels::*>>
@@ -110,33 +109,6 @@ pub error::ConvertError::RgbToGray
 pub error::ConvertError::UnsupportedTransfer
 pub error::ConvertError::UnsupportedTransfer::from: zenpixels::descriptor::TransferFunction
 pub error::ConvertError::UnsupportedTransfer::to: zenpixels::descriptor::TransferFunction
-pub mod estimate
-pub estimate::SimdTier::CurrentHost
-pub estimate::SimdTier::Neon
-pub estimate::SimdTier::Unknown
-pub estimate::SimdTier::Wasm
-pub estimate::SimdTier::Wasm128
-pub estimate::SimdTier::X86V1
-pub estimate::SimdTier::X86V2
-pub estimate::SimdTier::X86V3
-pub estimate::SimdTier::X86V4
-pub fn estimate::ComputeEnvironment::available_ram_bytes(&self) -> core::option::Option<u64>
-pub fn estimate::ComputeEnvironment::cores(&self) -> usize
-pub fn estimate::ComputeEnvironment::new() -> Self
-pub fn estimate::ComputeEnvironment::simd_tier(&self) -> core::option::Option<estimate::SimdTier>
-pub fn estimate::ComputeEnvironment::with_available_ram_bytes(self, u64) -> Self
-pub fn estimate::ComputeEnvironment::with_cores(self, usize) -> Self
-pub fn estimate::ComputeEnvironment::with_simd_tier(self, estimate::SimdTier) -> Self
-pub fn estimate::ImageCharacteristics::descriptor(&self) -> &zenpixels::descriptor::PixelDescriptor
-pub fn estimate::ImageCharacteristics::height(&self) -> u32
-pub fn estimate::ImageCharacteristics::new(u32, u32, zenpixels::descriptor::PixelDescriptor) -> Self
-pub fn estimate::ImageCharacteristics::width(&self) -> u32
-pub fn estimate::ResourceEstimate::intermediate_buffer_count(&self) -> core::option::Option<u32>
-pub fn estimate::ResourceEstimate::new(u64, u64) -> Self
-pub fn estimate::ResourceEstimate::peak_memory_bytes_est(&self) -> core::option::Option<u64>
-pub fn estimate::ResourceEstimate::unknown() -> Self
-pub fn estimate::ResourceEstimate::wall_ms(&self) -> core::option::Option<u64>
-pub fn estimate::ResourceEstimate::with_intermediate_buffer_count(self, u32) -> Self
 pub mod ext
 pub fn ext::ColorPrimariesExt::from_xyz_matrix(&self) -> core::option::Option<&'static gamut::GamutMatrix>
 pub fn ext::ColorPrimariesExt::to_xyz_matrix(&self) -> core::option::Option<&'static gamut::GamutMatrix>
@@ -253,28 +225,10 @@ pub RenderingIntent::AbsoluteColorimetric
 pub RenderingIntent::Perceptual
 pub RenderingIntent::RelativeColorimetric
 pub RenderingIntent::Saturation
-#[non_exhaustive] pub enum SimdTier [also: estimate]
-pub SimdTier::CurrentHost
-pub SimdTier::Neon
-pub SimdTier::Unknown
-pub SimdTier::Wasm
-pub SimdTier::Wasm128
-pub SimdTier::X86V1
-pub SimdTier::X86V2
-pub SimdTier::X86V3
-pub SimdTier::X86V4
 pub struct CmsPluginError(_) [also: cms]
 pub fn cms::CmsPluginError::as_inner(&self) -> &(dyn core::error::Error + core::marker::Send + core::marker::Sync + 'static)
 pub fn cms::CmsPluginError::msg(impl core::convert::Into<alloc::string::String>) -> Self
 pub fn cms::CmsPluginError::new<E>(E) -> Self where E: core::error::Error + core::marker::Send + core::marker::Sync + 'static
-#[non_exhaustive] pub struct ComputeEnvironment [also: estimate]
-pub fn estimate::ComputeEnvironment::available_ram_bytes(&self) -> core::option::Option<u64>
-pub fn estimate::ComputeEnvironment::cores(&self) -> usize
-pub fn estimate::ComputeEnvironment::new() -> Self
-pub fn estimate::ComputeEnvironment::simd_tier(&self) -> core::option::Option<estimate::SimdTier>
-pub fn estimate::ComputeEnvironment::with_available_ram_bytes(self, u64) -> Self
-pub fn estimate::ComputeEnvironment::with_cores(self, usize) -> Self
-pub fn estimate::ComputeEnvironment::with_simd_tier(self, estimate::SimdTier) -> Self
 pub struct ConversionCost
 pub ConversionCost::effort: u16
 pub ConversionCost::loss: u16
@@ -282,8 +236,6 @@ pub const ConversionCost::ZERO: Self
 pub const fn ConversionCost::new(u16, u16) -> Self
 pub struct ConvertPlan
 pub fn ConvertPlan::compose(&self, &Self) -> core::option::Option<Self>
-pub fn ConvertPlan::estimate(&self, u32, u32) -> estimate::ResourceEstimate
-pub fn ConvertPlan::estimate_in(&self, &estimate::ImageCharacteristics, &estimate::ComputeEnvironment) -> estimate::ResourceEstimate
 pub fn ConvertPlan::from(&self) -> zenpixels::descriptor::PixelDescriptor
 pub fn ConvertPlan::is_identity(&self) -> bool
 pub fn ConvertPlan::new(zenpixels::descriptor::PixelDescriptor, zenpixels::descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<error::ConvertError>>
@@ -305,11 +257,6 @@ pub fn hdr::HdrMetadata::hdr10(zenpixels::hdr::ContentLightLevel) -> Self
 pub fn hdr::HdrMetadata::hlg() -> Self
 pub fn hdr::HdrMetadata::is_hdr(&self) -> bool
 pub fn hdr::HdrMetadata::is_sdr(&self) -> bool
-#[non_exhaustive] pub struct ImageCharacteristics [also: estimate]
-pub fn estimate::ImageCharacteristics::descriptor(&self) -> &zenpixels::descriptor::PixelDescriptor
-pub fn estimate::ImageCharacteristics::height(&self) -> u32
-pub fn estimate::ImageCharacteristics::new(u32, u32, zenpixels::descriptor::PixelDescriptor) -> Self
-pub fn estimate::ImageCharacteristics::width(&self) -> u32
 #[non_exhaustive] pub struct LoadBearingReport [also: load_bearing]
 pub LoadBearingReport::uses_alpha: core::option::Option<bool>
 pub LoadBearingReport::uses_chroma: core::option::Option<bool>
@@ -327,13 +274,6 @@ pub fn Provenance::invalidate_primaries(&mut self, zenpixels::descriptor::ColorP
 pub const fn Provenance::with_origin(zenpixels::descriptor::ChannelType, zenpixels::descriptor::ColorPrimaries) -> Self
 pub const fn Provenance::with_origin_depth(zenpixels::descriptor::ChannelType) -> Self
 pub fn Provenance::with_origin_primaries(zenpixels::descriptor::PixelDescriptor, zenpixels::descriptor::ColorPrimaries) -> Self
-#[non_exhaustive] pub struct ResourceEstimate [also: estimate]
-pub fn estimate::ResourceEstimate::intermediate_buffer_count(&self) -> core::option::Option<u32>
-pub fn estimate::ResourceEstimate::new(u64, u64) -> Self
-pub fn estimate::ResourceEstimate::peak_memory_bytes_est(&self) -> core::option::Option<u64>
-pub fn estimate::ResourceEstimate::unknown() -> Self
-pub fn estimate::ResourceEstimate::wall_ms(&self) -> core::option::Option<u64>
-pub fn estimate::ResourceEstimate::with_intermediate_buffer_count(self, u32) -> Self
 pub struct RowConverter [also: converter]
 pub fn converter::RowConverter::compose(&self, &Self) -> core::option::Option<Self>
 pub fn converter::RowConverter::convert_row(&mut self, &[u8], &mut [u8], u32)
@@ -396,7 +336,7 @@ pub fn requires_cms(&zenpixels::descriptor::PixelDescriptor, &zenpixels::descrip
 pub fn try_adapt_in_place(&mut zenpixels::buffer::PixelBuffer, zenpixels::descriptor::PixelDescriptor) -> core::result::Result<(), whereat::at::At<error::ConvertError>> [also: adapt]
 pub type GamutMatrix = [[f32; 3]; 3] [also: gamut]
 
-## trait impls (24 types)
+## trait impls (20 types)
 
 ConversionCost: Add, Clone, Copy, Debug, Default, Eq, PartialEq
 ConvertIntent: Clone, Copy, Debug, Default, Eq, PartialEq
@@ -409,10 +349,6 @@ cms::ColorPriority: Clone, Copy, Debug, Default, Eq, Hash, PartialEq
 cms::RenderingIntent: Clone, Copy, Debug, Default, Eq, Hash, PartialEq
 converter::RowConverter: Clone
 error::ConvertError: Clone, Debug, Display, Error, From<zenpixels::buffer::BufferError>, PartialEq
-estimate::ComputeEnvironment: Clone, Copy, Debug, Default, Eq, PartialEq
-estimate::ImageCharacteristics: Clone, Debug, Eq, PartialEq
-estimate::ResourceEstimate: Clone, Copy, Debug, PartialEq
-estimate::SimdTier: Clone, Copy, Debug, Eq, Hash, PartialEq
 hdr::HdrMetadata: Clone, Copy, Debug, PartialEq
 icc_profiles::SynthesizedIcc: Clone, Debug, Eq, PartialEq
 load_bearing::LoadBearingReport: Clone, Copy, Debug, Default

--- a/docs/public-api/zenpixels-convert.txt
+++ b/docs/public-api/zenpixels-convert.txt
@@ -11,8 +11,8 @@
 #   pub modules                                13
 #   pub types (struct/enum/trait/alias)        49
 #   pub consts/statics                         19
-#   free functions                             40
-#   inherent methods                          102
+#   free functions                             39
+#   inherent methods                          106
 #   struct fields                              50
 #   enum variants                              56
 #   re-exports                                  5
@@ -21,8 +21,8 @@
 #   auto-trait exceptions                       2
 #
 # per-module pub lines:
-#   (root)                          153
-#   adapt                            11
+#   (root)                          152
+#   adapt                            15
 #   cms                              27
 #   converter                        27
 #   error                            27
@@ -35,19 +35,23 @@
 #   orient                            3
 #   output                           17
 
-## items (304 lines)
+## items (307 lines)
 
 pub mod zenpixels_convert
 pub use <<zenpixels::*>>
 pub use ContentLightLevel
 pub use MasteringDisplay
 pub mod adapt
-pub struct adapt::Adapted<'a>
+#[non_exhaustive] pub struct adapt::Adapted<'a>
 pub adapt::Adapted::data: alloc::borrow::Cow<'a, [u8]>
 pub adapt::Adapted::descriptor: zenpixels::descriptor::PixelDescriptor
 pub adapt::Adapted::rows: u32
 pub adapt::Adapted::width: u32
 pub fn adapt::Adapted<'a>::as_pixel_slice(&self) -> core::result::Result<zenpixels::buffer::PixelSlice<'_>, whereat::at::At<error::ConvertError>>
+pub fn adapt::Adapted<'a>::data(&self) -> &[u8]
+pub fn adapt::Adapted<'a>::descriptor(&self) -> zenpixels::descriptor::PixelDescriptor
+pub fn adapt::Adapted<'a>::rows(&self) -> u32
+pub fn adapt::Adapted<'a>::width(&self) -> u32
 pub fn adapt::adapt_for_encode<'a>(&'a [u8], zenpixels::descriptor::PixelDescriptor, u32, u32, usize, &[zenpixels::descriptor::PixelDescriptor]) -> core::result::Result<adapt::Adapted<'a>, whereat::at::At<error::ConvertError>>
 pub fn adapt::adapt_for_encode_with_intent<'a>(&'a [u8], zenpixels::descriptor::PixelDescriptor, u32, u32, usize, &[zenpixels::descriptor::PixelDescriptor], ConvertIntent) -> core::result::Result<adapt::Adapted<'a>, whereat::at::At<error::ConvertError>>
 pub fn adapt::convert_buffer(&[u8], u32, u32, zenpixels::descriptor::PixelDescriptor, zenpixels::descriptor::PixelDescriptor) -> core::result::Result<alloc::vec::Vec<u8>, whereat::at::At<error::ConvertError>>
@@ -338,7 +342,6 @@ pub fn finalize_for_output_with(&zenpixels::buffer::PixelBuffer, &zenpixels::col
 pub fn ideal_format(zenpixels::descriptor::PixelDescriptor, ConvertIntent) -> zenpixels::descriptor::PixelDescriptor
 pub fn negotiate(zenpixels::descriptor::PixelDescriptor, Provenance, impl core::iter::traits::iterator::Iterator<Item = FormatOption>, ConvertIntent) -> core::option::Option<zenpixels::descriptor::PixelDescriptor>
 pub fn quantize_to(zenpixels::buffer::PixelSlice<'_>, zenpixels::descriptor::PixelDescriptor) -> core::result::Result<zenpixels::buffer::PixelBuffer, whereat::at::At<error::ConvertError>> [also: hdr]
-pub fn requires_cms(&zenpixels::descriptor::PixelDescriptor, &zenpixels::descriptor::PixelDescriptor) -> bool
 pub fn try_adapt_in_place(&mut zenpixels::buffer::PixelBuffer, zenpixels::descriptor::PixelDescriptor) -> core::result::Result<(), whereat::at::At<error::ConvertError>> [also: adapt]
 pub type GamutMatrix = [[f32; 3]; 3] [also: gamut]
 

--- a/docs/public-api/zenpixels-convert.txt
+++ b/docs/public-api/zenpixels-convert.txt
@@ -12,7 +12,7 @@
 #   pub types (struct/enum/trait/alias)        49
 #   pub consts/statics                         19
 #   free functions                             40
-#   inherent methods                           98
+#   inherent methods                          100
 #   struct fields                              50
 #   enum variants                              56
 #   re-exports                                  5
@@ -21,12 +21,12 @@
 #   auto-trait exceptions                       2
 #
 # per-module pub lines:
-#   (root)                          151
+#   (root)                          152
 #   adapt                            11
 #   cms                              27
 #   converter                        27
 #   error                            27
-#   ext                              13
+#   ext                              14
 #   gamut                             6
 #   hdr                              15
 #   icc_profiles                     13
@@ -35,7 +35,7 @@
 #   orient                            3
 #   output                           17
 
-## items (300 lines)
+## items (302 lines)
 
 pub mod zenpixels_convert
 pub use <<zenpixels::*>>
@@ -113,6 +113,7 @@ pub error::ConvertError::UnsupportedTransfer::to: zenpixels::descriptor::Transfe
 pub mod ext
 pub fn ext::ColorPrimariesExt::from_xyz_matrix(&self) -> core::option::Option<&'static gamut::GamutMatrix>
 pub fn ext::ColorPrimariesExt::to_xyz_matrix(&self) -> core::option::Option<&'static gamut::GamutMatrix>
+pub fn ext::PixelBufferConvertExt::convert_into(&self, zenpixels::buffer::PixelSliceMut<'_>) -> core::result::Result<(), whereat::at::At<error::ConvertError>>
 pub fn ext::PixelBufferConvertExt::convert_to(&self, zenpixels::descriptor::PixelDescriptor) -> core::result::Result<zenpixels::buffer::PixelBuffer, whereat::at::At<error::ConvertError>>
 pub fn ext::PixelBufferConvertExt::delinearize(&self, zenpixels::descriptor::TransferFunction) -> core::result::Result<zenpixels::buffer::PixelBuffer, whereat::at::At<error::ConvertError>>
 pub fn ext::PixelBufferConvertExt::linearize(&self) -> core::result::Result<zenpixels::buffer::PixelBuffer, whereat::at::At<error::ConvertError>>
@@ -297,7 +298,8 @@ pub fn ColorManagement::identify_profile(&self, &[u8]) -> core::option::Option<z
 pub trait ColorPrimariesExt [also: ext]
 pub fn ColorPrimariesExt::from_xyz_matrix(&self) -> core::option::Option<&'static gamut::GamutMatrix>
 pub fn ColorPrimariesExt::to_xyz_matrix(&self) -> core::option::Option<&'static gamut::GamutMatrix>
-pub trait PixelBufferConvertExt [also: ext]
+pub trait PixelBufferConvertExt: ext::sealed::Sealed [also: ext]
+pub fn PixelBufferConvertExt::convert_into(&self, zenpixels::buffer::PixelSliceMut<'_>) -> core::result::Result<(), whereat::at::At<error::ConvertError>>
 pub fn PixelBufferConvertExt::convert_to(&self, zenpixels::descriptor::PixelDescriptor) -> core::result::Result<zenpixels::buffer::PixelBuffer, whereat::at::At<error::ConvertError>>
 pub fn PixelBufferConvertExt::delinearize(&self, zenpixels::descriptor::TransferFunction) -> core::result::Result<zenpixels::buffer::PixelBuffer, whereat::at::At<error::ConvertError>>
 pub fn PixelBufferConvertExt::linearize(&self) -> core::result::Result<zenpixels::buffer::PixelBuffer, whereat::at::At<error::ConvertError>>

--- a/docs/public-api/zenpixels-convert.txt
+++ b/docs/public-api/zenpixels-convert.txt
@@ -12,7 +12,7 @@
 #   pub types (struct/enum/trait/alias)        49
 #   pub consts/statics                         19
 #   free functions                             40
-#   inherent methods                          100
+#   inherent methods                          102
 #   struct fields                              50
 #   enum variants                              56
 #   re-exports                                  5
@@ -21,12 +21,12 @@
 #   auto-trait exceptions                       2
 #
 # per-module pub lines:
-#   (root)                          152
+#   (root)                          153
 #   adapt                            11
 #   cms                              27
 #   converter                        27
 #   error                            27
-#   ext                              14
+#   ext                              15
 #   gamut                             6
 #   hdr                              15
 #   icc_profiles                     13
@@ -35,7 +35,7 @@
 #   orient                            3
 #   output                           17
 
-## items (302 lines)
+## items (304 lines)
 
 pub mod zenpixels_convert
 pub use <<zenpixels::*>>
@@ -113,6 +113,7 @@ pub error::ConvertError::UnsupportedTransfer::to: zenpixels::descriptor::Transfe
 pub mod ext
 pub fn ext::ColorPrimariesExt::from_xyz_matrix(&self) -> core::option::Option<&'static gamut::GamutMatrix>
 pub fn ext::ColorPrimariesExt::to_xyz_matrix(&self) -> core::option::Option<&'static gamut::GamutMatrix>
+pub fn ext::PixelBufferConvertExt::convert_in_place(&mut self, zenpixels::descriptor::PixelDescriptor) -> core::result::Result<(), whereat::at::At<error::ConvertError>>
 pub fn ext::PixelBufferConvertExt::convert_into(&self, zenpixels::buffer::PixelSliceMut<'_>) -> core::result::Result<(), whereat::at::At<error::ConvertError>>
 pub fn ext::PixelBufferConvertExt::convert_to(&self, zenpixels::descriptor::PixelDescriptor) -> core::result::Result<zenpixels::buffer::PixelBuffer, whereat::at::At<error::ConvertError>>
 pub fn ext::PixelBufferConvertExt::delinearize(&self, zenpixels::descriptor::TransferFunction) -> core::result::Result<zenpixels::buffer::PixelBuffer, whereat::at::At<error::ConvertError>>
@@ -299,6 +300,7 @@ pub trait ColorPrimariesExt [also: ext]
 pub fn ColorPrimariesExt::from_xyz_matrix(&self) -> core::option::Option<&'static gamut::GamutMatrix>
 pub fn ColorPrimariesExt::to_xyz_matrix(&self) -> core::option::Option<&'static gamut::GamutMatrix>
 pub trait PixelBufferConvertExt: ext::sealed::Sealed [also: ext]
+pub fn PixelBufferConvertExt::convert_in_place(&mut self, zenpixels::descriptor::PixelDescriptor) -> core::result::Result<(), whereat::at::At<error::ConvertError>>
 pub fn PixelBufferConvertExt::convert_into(&self, zenpixels::buffer::PixelSliceMut<'_>) -> core::result::Result<(), whereat::at::At<error::ConvertError>>
 pub fn PixelBufferConvertExt::convert_to(&self, zenpixels::descriptor::PixelDescriptor) -> core::result::Result<zenpixels::buffer::PixelBuffer, whereat::at::At<error::ConvertError>>
 pub fn PixelBufferConvertExt::delinearize(&self, zenpixels::descriptor::TransferFunction) -> core::result::Result<zenpixels::buffer::PixelBuffer, whereat::at::At<error::ConvertError>>

--- a/docs/public-api/zenpixels-convert.txt
+++ b/docs/public-api/zenpixels-convert.txt
@@ -12,7 +12,7 @@
 #   pub types (struct/enum/trait/alias)        49
 #   pub consts/statics                         19
 #   free functions                             40
-#   inherent methods                           96
+#   inherent methods                           98
 #   struct fields                              50
 #   enum variants                              56
 #   re-exports                                  5
@@ -24,7 +24,7 @@
 #   (root)                          151
 #   adapt                            11
 #   cms                              27
-#   converter                        25
+#   converter                        27
 #   error                            27
 #   ext                              13
 #   gamut                             6
@@ -35,7 +35,7 @@
 #   orient                            3
 #   output                           17
 
-## items (298 lines)
+## items (300 lines)
 
 pub mod zenpixels_convert
 pub use <<zenpixels::*>>
@@ -74,6 +74,7 @@ pub fn converter::RowConverter::compose(&self, &Self) -> core::option::Option<Se
 pub fn converter::RowConverter::convert_row(&mut self, &[u8], &mut [u8], u32)
 pub fn converter::RowConverter::convert_rows(&mut self, &[u8], usize, &mut [u8], usize, u32, u32) -> core::result::Result<(), whereat::at::At<error::ConvertError>>
 pub fn converter::RowConverter::convert_slice(&mut self, zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<zenpixels::buffer::PixelBuffer, whereat::at::At<error::ConvertError>>
+pub fn converter::RowConverter::convert_slice_into(&mut self, zenpixels::buffer::PixelSlice<'_>, zenpixels::buffer::PixelSliceMut<'_>) -> core::result::Result<(), whereat::at::At<error::ConvertError>>
 pub fn converter::RowConverter::from_descriptor(&self) -> zenpixels::descriptor::PixelDescriptor
 pub fn converter::RowConverter::from_plan(ConvertPlan) -> Self
 pub fn converter::RowConverter::is_identity(&self) -> bool
@@ -279,6 +280,7 @@ pub fn converter::RowConverter::compose(&self, &Self) -> core::option::Option<Se
 pub fn converter::RowConverter::convert_row(&mut self, &[u8], &mut [u8], u32)
 pub fn converter::RowConverter::convert_rows(&mut self, &[u8], usize, &mut [u8], usize, u32, u32) -> core::result::Result<(), whereat::at::At<error::ConvertError>>
 pub fn converter::RowConverter::convert_slice(&mut self, zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<zenpixels::buffer::PixelBuffer, whereat::at::At<error::ConvertError>>
+pub fn converter::RowConverter::convert_slice_into(&mut self, zenpixels::buffer::PixelSlice<'_>, zenpixels::buffer::PixelSliceMut<'_>) -> core::result::Result<(), whereat::at::At<error::ConvertError>>
 pub fn converter::RowConverter::from_descriptor(&self) -> zenpixels::descriptor::PixelDescriptor
 pub fn converter::RowConverter::from_plan(ConvertPlan) -> Self
 pub fn converter::RowConverter::is_identity(&self) -> bool

--- a/docs/public-api/zenpixels.txt
+++ b/docs/public-api/zenpixels.txt
@@ -10,9 +10,9 @@
 #
 #   pub modules                                10
 #   pub types (struct/enum/trait/alias)        76
-#   pub consts/statics                        276
+#   pub consts/statics                        280
 #   free functions                              4
-#   inherent methods                          232
+#   inherent methods                          236
 #   struct fields                             107
 #   enum variants                             208
 #   re-exports                                  4
@@ -21,8 +21,8 @@
 #   auto-trait exceptions                       4
 #
 # per-module pub lines:
-#   (root)                          393
-#   buffer                          212
+#   (root)                          397
+#   buffer                          216
 #   cicp                             27
 #   color                            64
 #   descriptor                      148
@@ -32,7 +32,7 @@
 #   pixel_types                       9
 #   policy                           25
 
-## items (787 lines)
+## items (793 lines)
 
 pub mod zenpixels
 pub use At
@@ -121,6 +121,7 @@ pub fn buffer::PixelSlice<'a, P>::with_primaries(self, descriptor::ColorPrimarie
 pub fn buffer::PixelSlice<'a, P>::with_signal_range(self, descriptor::SignalRange) -> Self
 pub fn buffer::PixelSlice<'a, P>::with_transfer(self, descriptor::TransferFunction) -> Self
 pub fn buffer::PixelSlice<'a>::new(&'a [u8], u32, u32, usize, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
+pub fn buffer::PixelSlice<'a>::new_tight(&'a [u8], u32, u32, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 pub fn buffer::PixelSliceMut<'a, P>::new_typed(&'a mut [u8], u32, u32, u32) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 pub fn buffer::PixelSliceMut<'a, P>::as_pixel_slice(&self) -> buffer::PixelSlice<'_, P>
 pub fn buffer::PixelSliceMut<'a, P>::as_strided_bytes(&self) -> &[u8]
@@ -148,6 +149,7 @@ pub fn buffer::PixelSliceMut<'a, P>::with_transfer(self, descriptor::TransferFun
 pub fn buffer::PixelSliceMut<'a, buffer::Bgrx>::swap_to_rgbx(self) -> buffer::PixelSliceMut<'a, buffer::Rgbx>
 pub fn buffer::PixelSliceMut<'a, buffer::Rgbx>::swap_to_bgrx(self) -> buffer::PixelSliceMut<'a, buffer::Bgrx>
 pub fn buffer::PixelSliceMut<'a>::new(&'a mut [u8], u32, u32, usize, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
+pub fn buffer::PixelSliceMut<'a>::new_tight(&'a mut [u8], u32, u32, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 pub buffer::Rgbx::b: u8
 pub buffer::Rgbx::g: u8
 pub buffer::Rgbx::r: u8
@@ -164,6 +166,7 @@ pub const cicp::Cicp::DISPLAY_P3: Self
 pub const cicp::Cicp::SRGB: Self
 pub fn cicp::Cicp::color_primaries_enum(&self) -> descriptor::ColorPrimaries
 pub fn cicp::Cicp::color_primaries_name(u8) -> &'static str
+pub const fn cicp::Cicp::from_bytes([u8; 4]) -> Self [also: (root)]
 pub fn cicp::Cicp::from_descriptor(&descriptor::PixelDescriptor) -> core::option::Option<Self>
 pub fn cicp::Cicp::matrix_coefficients_name(u8) -> &'static str
 pub const fn cicp::Cicp::new(u8, u8, u8, bool) -> Self [also: (root)]
@@ -379,6 +382,7 @@ pub const fn descriptor::PixelDescriptor::simd_aligned_stride(self, u32, usize) 
 pub const fn descriptor::PixelDescriptor::transfer(&self) -> descriptor::TransferFunction [also: (root)]
 pub const fn descriptor::PixelDescriptor::with_alpha(self, core::option::Option<descriptor::AlphaMode>) -> Self [also: (root)]
 pub const fn descriptor::PixelDescriptor::with_alpha_mode(self, core::option::Option<descriptor::AlphaMode>) -> Self [also: (root)]
+pub const fn descriptor::PixelDescriptor::with_color_from_cicp(self, cicp::Cicp) -> Self [also: (root)]
 pub const fn descriptor::PixelDescriptor::with_primaries(self, descriptor::ColorPrimaries) -> Self [also: (root)]
 pub const fn descriptor::PixelDescriptor::with_signal_range(self, descriptor::SignalRange) -> Self [also: (root)]
 pub const fn descriptor::PixelDescriptor::with_transfer(self, descriptor::TransferFunction) -> Self [also: (root)]
@@ -786,6 +790,7 @@ pub fn buffer::PixelSlice<'a, P>::with_primaries(self, descriptor::ColorPrimarie
 pub fn buffer::PixelSlice<'a, P>::with_signal_range(self, descriptor::SignalRange) -> Self
 pub fn buffer::PixelSlice<'a, P>::with_transfer(self, descriptor::TransferFunction) -> Self
 pub fn buffer::PixelSlice<'a>::new(&'a [u8], u32, u32, usize, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
+pub fn buffer::PixelSlice<'a>::new_tight(&'a [u8], u32, u32, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 #[non_exhaustive] pub struct PixelSliceMut<'a, P> [also: buffer]
 pub fn buffer::PixelSliceMut<'a, P>::new_typed(&'a mut [u8], u32, u32, u32) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 pub fn buffer::PixelSliceMut<'a, P>::as_pixel_slice(&self) -> buffer::PixelSlice<'_, P>
@@ -814,6 +819,7 @@ pub fn buffer::PixelSliceMut<'a, P>::with_transfer(self, descriptor::TransferFun
 pub fn buffer::PixelSliceMut<'a, buffer::Bgrx>::swap_to_rgbx(self) -> buffer::PixelSliceMut<'a, buffer::Rgbx>
 pub fn buffer::PixelSliceMut<'a, buffer::Rgbx>::swap_to_bgrx(self) -> buffer::PixelSliceMut<'a, buffer::Bgrx>
 pub fn buffer::PixelSliceMut<'a>::new(&'a mut [u8], u32, u32, usize, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
+pub fn buffer::PixelSliceMut<'a>::new_tight(&'a mut [u8], u32, u32, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 #[repr(C)] pub struct Rgbx [also: buffer]
 pub Rgbx::b: u8
 pub Rgbx::g: u8

--- a/docs/public-api/zenpixels.txt
+++ b/docs/public-api/zenpixels.txt
@@ -121,7 +121,7 @@ pub fn buffer::PixelSlice<'a, P>::with_primaries(self, descriptor::ColorPrimarie
 pub fn buffer::PixelSlice<'a, P>::with_signal_range(self, descriptor::SignalRange) -> Self
 pub fn buffer::PixelSlice<'a, P>::with_transfer(self, descriptor::TransferFunction) -> Self
 pub fn buffer::PixelSlice<'a>::new(&'a [u8], u32, u32, usize, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
-pub fn buffer::PixelSlice<'a>::new_tight(&'a [u8], u32, u32, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
+pub fn buffer::PixelSlice<'a>::new_contiguous(&'a [u8], u32, u32, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 pub fn buffer::PixelSliceMut<'a, P>::new_typed(&'a mut [u8], u32, u32, u32) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 pub fn buffer::PixelSliceMut<'a, P>::as_pixel_slice(&self) -> buffer::PixelSlice<'_, P>
 pub fn buffer::PixelSliceMut<'a, P>::as_strided_bytes(&self) -> &[u8]
@@ -149,7 +149,7 @@ pub fn buffer::PixelSliceMut<'a, P>::with_transfer(self, descriptor::TransferFun
 pub fn buffer::PixelSliceMut<'a, buffer::Bgrx>::swap_to_rgbx(self) -> buffer::PixelSliceMut<'a, buffer::Rgbx>
 pub fn buffer::PixelSliceMut<'a, buffer::Rgbx>::swap_to_bgrx(self) -> buffer::PixelSliceMut<'a, buffer::Bgrx>
 pub fn buffer::PixelSliceMut<'a>::new(&'a mut [u8], u32, u32, usize, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
-pub fn buffer::PixelSliceMut<'a>::new_tight(&'a mut [u8], u32, u32, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
+pub fn buffer::PixelSliceMut<'a>::new_contiguous(&'a mut [u8], u32, u32, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 pub buffer::Rgbx::b: u8
 pub buffer::Rgbx::g: u8
 pub buffer::Rgbx::r: u8
@@ -790,7 +790,7 @@ pub fn buffer::PixelSlice<'a, P>::with_primaries(self, descriptor::ColorPrimarie
 pub fn buffer::PixelSlice<'a, P>::with_signal_range(self, descriptor::SignalRange) -> Self
 pub fn buffer::PixelSlice<'a, P>::with_transfer(self, descriptor::TransferFunction) -> Self
 pub fn buffer::PixelSlice<'a>::new(&'a [u8], u32, u32, usize, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
-pub fn buffer::PixelSlice<'a>::new_tight(&'a [u8], u32, u32, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
+pub fn buffer::PixelSlice<'a>::new_contiguous(&'a [u8], u32, u32, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 #[non_exhaustive] pub struct PixelSliceMut<'a, P> [also: buffer]
 pub fn buffer::PixelSliceMut<'a, P>::new_typed(&'a mut [u8], u32, u32, u32) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 pub fn buffer::PixelSliceMut<'a, P>::as_pixel_slice(&self) -> buffer::PixelSlice<'_, P>
@@ -819,7 +819,7 @@ pub fn buffer::PixelSliceMut<'a, P>::with_transfer(self, descriptor::TransferFun
 pub fn buffer::PixelSliceMut<'a, buffer::Bgrx>::swap_to_rgbx(self) -> buffer::PixelSliceMut<'a, buffer::Rgbx>
 pub fn buffer::PixelSliceMut<'a, buffer::Rgbx>::swap_to_bgrx(self) -> buffer::PixelSliceMut<'a, buffer::Bgrx>
 pub fn buffer::PixelSliceMut<'a>::new(&'a mut [u8], u32, u32, usize, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
-pub fn buffer::PixelSliceMut<'a>::new_tight(&'a mut [u8], u32, u32, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
+pub fn buffer::PixelSliceMut<'a>::new_contiguous(&'a mut [u8], u32, u32, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 #[repr(C)] pub struct Rgbx [also: buffer]
 pub Rgbx::b: u8
 pub Rgbx::g: u8

--- a/docs/public-api/zenpixels.txt
+++ b/docs/public-api/zenpixels.txt
@@ -12,7 +12,7 @@
 #   pub types (struct/enum/trait/alias)        76
 #   pub consts/statics                        280
 #   free functions                              4
-#   inherent methods                          236
+#   inherent methods                          240
 #   struct fields                             107
 #   enum variants                             208
 #   re-exports                                  4
@@ -22,7 +22,7 @@
 #
 # per-module pub lines:
 #   (root)                          397
-#   buffer                          216
+#   buffer                          220
 #   cicp                             27
 #   color                            64
 #   descriptor                      148
@@ -32,7 +32,7 @@
 #   pixel_types                       9
 #   policy                           25
 
-## items (793 lines)
+## items (797 lines)
 
 pub mod zenpixels
 pub use At
@@ -122,6 +122,7 @@ pub fn buffer::PixelSlice<'a, P>::with_signal_range(self, descriptor::SignalRang
 pub fn buffer::PixelSlice<'a, P>::with_transfer(self, descriptor::TransferFunction) -> Self
 pub fn buffer::PixelSlice<'a>::new(&'a [u8], u32, u32, usize, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 pub fn buffer::PixelSlice<'a>::new_contiguous(&'a [u8], u32, u32, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
+pub fn buffer::PixelSlice<'a>::new_packed(&'a [u8], u32, u32, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 pub fn buffer::PixelSliceMut<'a, P>::new_typed(&'a mut [u8], u32, u32, u32) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 pub fn buffer::PixelSliceMut<'a, P>::as_pixel_slice(&self) -> buffer::PixelSlice<'_, P>
 pub fn buffer::PixelSliceMut<'a, P>::as_strided_bytes(&self) -> &[u8]
@@ -150,6 +151,7 @@ pub fn buffer::PixelSliceMut<'a, buffer::Bgrx>::swap_to_rgbx(self) -> buffer::Pi
 pub fn buffer::PixelSliceMut<'a, buffer::Rgbx>::swap_to_bgrx(self) -> buffer::PixelSliceMut<'a, buffer::Bgrx>
 pub fn buffer::PixelSliceMut<'a>::new(&'a mut [u8], u32, u32, usize, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 pub fn buffer::PixelSliceMut<'a>::new_contiguous(&'a mut [u8], u32, u32, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
+pub fn buffer::PixelSliceMut<'a>::new_packed(&'a mut [u8], u32, u32, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 pub buffer::Rgbx::b: u8
 pub buffer::Rgbx::g: u8
 pub buffer::Rgbx::r: u8
@@ -791,6 +793,7 @@ pub fn buffer::PixelSlice<'a, P>::with_signal_range(self, descriptor::SignalRang
 pub fn buffer::PixelSlice<'a, P>::with_transfer(self, descriptor::TransferFunction) -> Self
 pub fn buffer::PixelSlice<'a>::new(&'a [u8], u32, u32, usize, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 pub fn buffer::PixelSlice<'a>::new_contiguous(&'a [u8], u32, u32, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
+pub fn buffer::PixelSlice<'a>::new_packed(&'a [u8], u32, u32, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 #[non_exhaustive] pub struct PixelSliceMut<'a, P> [also: buffer]
 pub fn buffer::PixelSliceMut<'a, P>::new_typed(&'a mut [u8], u32, u32, u32) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 pub fn buffer::PixelSliceMut<'a, P>::as_pixel_slice(&self) -> buffer::PixelSlice<'_, P>
@@ -820,6 +823,7 @@ pub fn buffer::PixelSliceMut<'a, buffer::Bgrx>::swap_to_rgbx(self) -> buffer::Pi
 pub fn buffer::PixelSliceMut<'a, buffer::Rgbx>::swap_to_bgrx(self) -> buffer::PixelSliceMut<'a, buffer::Bgrx>
 pub fn buffer::PixelSliceMut<'a>::new(&'a mut [u8], u32, u32, usize, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 pub fn buffer::PixelSliceMut<'a>::new_contiguous(&'a mut [u8], u32, u32, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
+pub fn buffer::PixelSliceMut<'a>::new_packed(&'a mut [u8], u32, u32, descriptor::PixelDescriptor) -> core::result::Result<Self, whereat::at::At<buffer::BufferError>>
 #[repr(C)] pub struct Rgbx [also: buffer]
 pub Rgbx::b: u8
 pub Rgbx::g: u8

--- a/zenpixels-convert/Cargo.toml
+++ b/zenpixels-convert/Cargo.toml
@@ -22,6 +22,7 @@ include = [
 [package.metadata.docs.rs]
 features = [
     "hdr-experimental",
+    "estimation-experimental",
     "pipeline",
     "cms-moxcms",
     "rgb",
@@ -72,6 +73,20 @@ pipeline = []
 # `features = ["hdr-experimental"]` to access measurement until the API
 # locks at 0.3.0.
 hdr-experimental = []
+# Resource estimation for a `ConvertPlan` (the `estimate` module —
+# `ResourceEstimate` / `ComputeEnvironment` / `ImageCharacteristics` /
+# `SimdTier`, plus `ConvertPlan::estimate(_in)`). Answers "will this op fit a
+# memory budget / SLA before it runs", and is deliberately shape-compatible
+# with `zencodec::estimate::*` so a `decode → convert → encode` caller can
+# estimate a job end-to-end.
+#
+# Experimental because it has not been adopted yet: the numbers come from the
+# 2026-04-23 bench suite (±30 % contract) but no scheduler consumes them, so
+# neither the API shape nor the accuracy has been validated against a real
+# caller. Gated rather than shipped so the surface stays revisable — expect
+# both to change as the first consumer lands. Default-off; opt in with
+# `features = ["estimation-experimental"]`. See `docs/ESTIMATE.md`.
+estimation-experimental = []
 cms-moxcms = ["std", "dep:moxcms"]
 # Soft-removed in 0.2.15. The `serde` feature previously forwarded to
 # `zenpixels/serde` and added a `Serialize`/`Deserialize` derive on
@@ -254,3 +269,11 @@ required-features = ["__bench_orient"]
 name = "measure_histogram_throughput"
 path = "examples/measure_histogram_throughput.rs"
 required-features = ["hdr-experimental"]
+
+# The heaptrack/marginal-WS harness that validates `ConvertPlan::estimate`
+# against measured peak RSS — i.e. the apparatus behind the estimate's ±30 %
+# accuracy contract. Follows the surface it measures behind the gate.
+[[example]]
+name = "mem_probe_convert"
+path = "examples/mem_probe_convert.rs"
+required-features = ["estimation-experimental"]

--- a/zenpixels-convert/examples/convert_pipeline.rs
+++ b/zenpixels-convert/examples/convert_pipeline.rs
@@ -193,13 +193,18 @@ fn convert_a_strip_with_a_plan() -> Fallible {
     Ok(())
 }
 
-/// Turn a processed buffer + its provenance into encoder-ready pixels+metadata.
+/// Atomically turn a processed buffer + its provenance into encoder-ready
+/// pixels AND matching color metadata — the crate's recommended encode step.
 ///
-/// NOTE: `finalize_for_output*` / `EncodeReady` / `OutputProfile` are the
-/// documented "encode" step, but the downstream-usage audit found *zero*
-/// real call sites — codecs use `adapt_for_encode` + zencodec's color
-/// resolution instead. Flagged in the ergonomics report as an unadopted
-/// surface (a 0.3.0 demotion candidate), shown here only for completeness.
+/// This is the *color-correct* encode path: `finalize_for_output_with`
+/// converts the pixels to the target profile and produces the exact ICC/CICP
+/// to embed **together**, so they can never diverge (the classic "pixels are
+/// Display P3 but the file says sRGB" bug). [`EncodeReady`] is the only way to
+/// obtain both, and its `pixels()` come off a `PixelBuffer` — so, unlike
+/// `Adapted::as_pixel_slice` above, they are always SIMD-aligned and never
+/// fallible on alignment. Contrast with `adapt_for_encode`, which negotiates
+/// pixel *format* only and leaves the color metadata to the caller (faster /
+/// zero-copy when you are not changing color and manage the metadata yourself).
 fn finalize_metadata_for_the_encoder() -> Fallible {
     let buffer = PixelBuffer::new(4, 4, PixelDescriptor::RGBA8_SRGB);
     let origin = ColorOrigin::from_cicp(Cicp::SRGB); // how the source declared color

--- a/zenpixels-convert/examples/convert_pipeline.rs
+++ b/zenpixels-convert/examples/convert_pipeline.rs
@@ -42,6 +42,7 @@ fn main() {
     apply_a_transfer_function_to_one_value();
     reorient_pixels();
     synthesize_then_read_back_an_icc();
+    #[cfg(feature = "estimation-experimental")]
     estimate_conversion_resources().unwrap();
     carry_hdr_metadata();
     println!("all zenpixels-convert examples passed");
@@ -259,6 +260,11 @@ fn synthesize_then_read_back_an_icc() {
 }
 
 /// Estimate memory + wall-time for a conversion before committing to it.
+///
+/// Requires `--features estimation-experimental` — the estimate surface is
+/// experimental and off by default until a real scheduler consumer validates
+/// its shape and its ±30 % accuracy contract.
+#[cfg(feature = "estimation-experimental")]
 fn estimate_conversion_resources() -> Fallible {
     let plan = ConvertPlan::new(PixelDescriptor::RGB8_SRGB, PixelDescriptor::RGBAF32_LINEAR)?;
     let est = plan.estimate(1920, 1080);

--- a/zenpixels-convert/examples/convert_pipeline.rs
+++ b/zenpixels-convert/examples/convert_pipeline.rs
@@ -137,18 +137,14 @@ fn adapt_pixels_before_encoding() -> Fallible {
     assert!(matches!(adapted.data, std::borrow::Cow::Borrowed(_)));
     assert_eq!(adapted.descriptor, PixelDescriptor::RGB8_SRGB);
 
-    // Every downstream encoder then re-wraps the adapted bytes as a `PixelSlice`,
-    // recomputing the tight stride by hand (this exact block is duplicated 5×
-    // across zenpipe/zencodecs). See the ergonomics report, findings A + B.
-    let adapted_stride = adapted.width as usize * adapted.descriptor.bytes_per_pixel();
-    let slice = zenpixels::buffer::PixelSlice::new(
-        &adapted.data,
-        adapted.width,
-        adapted.rows,
-        adapted_stride,
-        adapted.descriptor,
-    )?;
-    assert_eq!(slice.width(), 4);
+    // `Adapted::as_pixel_slice()` wraps the adapted bytes in one call — ready
+    // to hand to `encoder.encode(slice)`. Before this helper every encoder
+    // repeated a recompute-stride + `PixelSlice::new` block (duplicated 5×
+    // across zenpipe/zencodecs — ergonomics report findings 1 + 2), i.e.:
+    //     let stride = adapted.width as usize * adapted.descriptor.bytes_per_pixel();
+    //     let slice = PixelSlice::new(&adapted.data, adapted.width, adapted.rows, stride, adapted.descriptor)?;
+    let slice = adapted.as_pixel_slice()?;
+    assert_eq!((slice.width(), slice.rows()), (4, 4));
     Ok(())
 }
 
@@ -184,6 +180,16 @@ fn convert_a_strip_with_a_plan() -> Fallible {
     }
     // RGB8 -> RGBA8 fills an opaque alpha byte after each triple.
     assert_eq!(&dst[0..4], &[9, 9, 9, 255]);
+
+    // The same conversion, bundled: wrap the (possibly strided) source as a
+    // `PixelSlice` and let `RowConverter::convert_slice` size the output and
+    // drive the row loop — no manual `alloc w*h*bpp` + `convert_row` scaffolding.
+    let mut conv = RowConverter::new(PixelDescriptor::RGB8_SRGB, PixelDescriptor::RGBA8_SRGB)?;
+    let src_slice =
+        zenpixels::buffer::PixelSlice::new_tight(&src, w, h, PixelDescriptor::RGB8_SRGB)?;
+    let out = conv.convert_slice(src_slice)?;
+    assert_eq!(out.descriptor(), PixelDescriptor::RGBA8_SRGB);
+    assert_eq!(&out.as_slice().row(0)[0..4], &[9, 9, 9, 255]);
     Ok(())
 }
 

--- a/zenpixels-convert/examples/convert_pipeline.rs
+++ b/zenpixels-convert/examples/convert_pipeline.rs
@@ -12,7 +12,7 @@
 //! Run the whole gallery:   `cargo run -p zenpixels-convert --example convert_pipeline`
 //! Run it as tests:         `cargo test -p zenpixels-convert --examples`
 
-use zenpixels::buffer::PixelBuffer;
+use zenpixels::buffer::{PixelBuffer, PixelSlice, PixelSliceMut};
 use zenpixels::cicp::Cicp;
 use zenpixels::color::ColorOrigin;
 use zenpixels::descriptor::{PixelDescriptor, PixelFormat, TransferFunction};
@@ -149,7 +149,7 @@ fn adapt_pixels_before_encoding() -> Fallible {
     Ok(())
 }
 
-/// Streaming: build the plan once, convert row-strips many times.
+/// Streaming: build the plan once, convert into a destination you own.
 fn stream_rows_through_a_converter() -> Fallible {
     // RGBA8 -> BGRA8 is a pure R<->B swizzle.
     let mut conv = RowConverter::new(PixelDescriptor::RGBA8_SRGB, PixelDescriptor::BGRA8_SRGB)?;
@@ -157,7 +157,15 @@ fn stream_rows_through_a_converter() -> Fallible {
 
     let src = [10u8, 20, 30, 40, 50, 60, 70, 80]; // two RGBA pixels
     let mut dst = [0u8; 8];
-    conv.convert_rows(&src, 8, &mut dst, 8, 2, 1)?;
+
+    // `convert_slice_into` is the no-alloc primitive: each slice carries its own
+    // stride, so neither is passed separately, and the descriptors are checked
+    // against the plan. It supersedes `convert_rows(src, src_stride, dst,
+    // dst_stride, width, rows)`, whose six positional args nothing type-checks.
+    let src_slice = PixelSlice::new_contiguous(&src, 2, 1, PixelDescriptor::RGBA8_SRGB)?;
+    let dst_slice = PixelSliceMut::new_contiguous(&mut dst, 2, 1, PixelDescriptor::BGRA8_SRGB)?;
+    conv.convert_slice_into(src_slice, dst_slice)?;
+
     assert_eq!(dst, [30, 20, 10, 40, 70, 60, 50, 80]); // R and B swapped
     Ok(())
 }

--- a/zenpixels-convert/examples/convert_pipeline.rs
+++ b/zenpixels-convert/examples/convert_pipeline.rs
@@ -1,0 +1,279 @@
+//! Common `zenpixels-convert` usages, each self-checking.
+//!
+//! This is the "caller also has `zenpixels-convert`" story: on top of the
+//! `zenpixels` description layer you now get transfer-function-aware
+//! conversion, format negotiation, orientation, ICC synthesis, and encode
+//! finalization. It walks the pixel lifecycle the crate is built around:
+//!
+//! ```text
+//! Decode ──> Negotiate ──> Convert ──> Encode
+//! ```
+//!
+//! Run the whole gallery:   `cargo run -p zenpixels-convert --example convert_pipeline`
+//! Run it as tests:         `cargo test -p zenpixels-convert --examples`
+
+use zenpixels::buffer::PixelBuffer;
+use zenpixels::cicp::Cicp;
+use zenpixels::color::ColorOrigin;
+use zenpixels::descriptor::{PixelDescriptor, PixelFormat, TransferFunction};
+use zenpixels::hdr::ContentLightLevel;
+use zenpixels::orientation::Orientation;
+
+use zenpixels_convert::adapt::{adapt_for_encode, convert_buffer};
+use zenpixels_convert::converter::RowConverter;
+use zenpixels_convert::ext::{PixelBufferConvertExt, TransferFunctionExt};
+use zenpixels_convert::icc_profiles::{SynthesizedIcc, synthesize_icc_for_cicp};
+use zenpixels_convert::orient::apply_orientation;
+use zenpixels_convert::output::OutputProfile;
+use zenpixels_convert::{ConvertIntent, ConvertPlan, best_match, finalize_for_output_with};
+
+type Fallible = Result<(), Box<dyn std::error::Error>>;
+
+fn main() {
+    convert_a_whole_buffer_one_shot().unwrap();
+    convert_a_buffer_ergonomically().unwrap();
+    linearize_for_gamma_correct_work().unwrap();
+    widen_depth_and_add_alpha().unwrap();
+    negotiate_an_encoder_format();
+    adapt_pixels_before_encoding().unwrap();
+    stream_rows_through_a_converter().unwrap();
+    convert_a_strip_with_a_plan().unwrap();
+    finalize_metadata_for_the_encoder().unwrap();
+    apply_a_transfer_function_to_one_value();
+    reorient_pixels();
+    synthesize_then_read_back_an_icc();
+    estimate_conversion_resources().unwrap();
+    carry_hdr_metadata();
+    println!("all zenpixels-convert examples passed");
+}
+
+/// The lowest-friction one-shot: raw bytes in, converted bytes out.
+fn convert_a_whole_buffer_one_shot() -> Fallible {
+    // 2x1 opaque RGB8 (red, green), tightly packed.
+    let rgb = [255u8, 0, 0, 0, 255, 0];
+    let bgr = convert_buffer(
+        &rgb,
+        2,
+        1,
+        PixelDescriptor::RGB8_SRGB,
+        PixelDescriptor::BGRA8_SRGB,
+    )?;
+    // R and B are swapped and an opaque alpha byte is appended.
+    assert_eq!(bgr, vec![0, 0, 255, 255, 0, 255, 0, 255]);
+    // NOTE: `convert_buffer` returns a bare `Vec<u8>` — the caller has to keep
+    // width/height/descriptor on the side. Prefer the buffer path below when
+    // you already hold a `PixelBuffer`.
+    Ok(())
+}
+
+/// The ergonomic path when you hold a `PixelBuffer`: one call, metadata kept.
+fn convert_a_buffer_ergonomically() -> Fallible {
+    let src = PixelBuffer::new(4, 4, PixelDescriptor::RGBA8_SRGB);
+
+    // `PixelBufferConvertExt::convert_to` preserves dims, stride, and color
+    // context — and reads the source descriptor off the buffer for you.
+    let f32_linear = src.convert_to(PixelDescriptor::RGBAF32_LINEAR)?;
+    assert_eq!(f32_linear.descriptor().transfer(), TransferFunction::Linear);
+    assert_eq!((f32_linear.width(), f32_linear.height()), (4, 4));
+    Ok(())
+}
+
+/// Move to linear light for gamma-correct resize/blur, then back.
+fn linearize_for_gamma_correct_work() -> Fallible {
+    let srgb = PixelBuffer::new(8, 8, PixelDescriptor::RGB8_SRGB);
+
+    // `linearize` picks the matching linear float descriptor automatically.
+    let linear = srgb.linearize()?;
+    assert!(linear.descriptor().is_linear());
+
+    // ... resize / blur here ... then re-encode the transfer curve.
+    let back = linear.delinearize(TransferFunction::Srgb)?;
+    assert_eq!(back.descriptor().transfer(), TransferFunction::Srgb);
+    Ok(())
+}
+
+/// Depth and alpha adjustments read as verbs on the buffer.
+fn widen_depth_and_add_alpha() -> Fallible {
+    let u8_rgb = PixelBuffer::new(2, 2, PixelDescriptor::RGB8_SRGB);
+
+    let u16_rgb = u8_rgb.try_widen_to_u16()?;
+    assert_eq!(u16_rgb.descriptor().bytes_per_pixel(), 6); // 3 channels * u16
+
+    let rgba = u8_rgb.try_add_alpha()?; // appends an opaque alpha channel
+    assert!(rgba.has_alpha());
+    Ok(())
+}
+
+/// Pick the encoder-supported format that costs the least to reach.
+fn negotiate_an_encoder_format() {
+    // What a hypothetical encoder accepts.
+    let encoder_supports = [PixelDescriptor::RGB8_SRGB, PixelDescriptor::GRAY8_SRGB];
+
+    // Encoding => `Fastest`: get to a supported format with minimal work.
+    let target = best_match(
+        PixelDescriptor::RGBA8_SRGB,
+        &encoder_supports,
+        ConvertIntent::Fastest,
+    );
+    // Dropping an (opaque) alpha to RGB8 is cheaper than going to gray.
+    assert_eq!(target, Some(PixelDescriptor::RGB8_SRGB));
+}
+
+/// Convert *only if needed* right before encoding — zero-copy on the fast path.
+fn adapt_pixels_before_encoding() -> Fallible {
+    let pixels = vec![0u8; 4 * 4 * 3];
+    let stride = 4 * 3; // tightly packed
+    let encoder_supports = [PixelDescriptor::RGB8_SRGB];
+
+    let adapted = adapt_for_encode(
+        &pixels,
+        PixelDescriptor::RGB8_SRGB, // source already matches a supported format
+        4,
+        4,
+        stride,
+        &encoder_supports,
+    )?;
+    // No conversion was necessary, so the data is borrowed, not copied.
+    assert!(matches!(adapted.data, std::borrow::Cow::Borrowed(_)));
+    assert_eq!(adapted.descriptor, PixelDescriptor::RGB8_SRGB);
+
+    // Every downstream encoder then re-wraps the adapted bytes as a `PixelSlice`,
+    // recomputing the tight stride by hand (this exact block is duplicated 5×
+    // across zenpipe/zencodecs). See the ergonomics report, findings A + B.
+    let adapted_stride = adapted.width as usize * adapted.descriptor.bytes_per_pixel();
+    let slice = zenpixels::buffer::PixelSlice::new(
+        &adapted.data,
+        adapted.width,
+        adapted.rows,
+        adapted_stride,
+        adapted.descriptor,
+    )?;
+    assert_eq!(slice.width(), 4);
+    Ok(())
+}
+
+/// Streaming: build the plan once, convert row-strips many times.
+fn stream_rows_through_a_converter() -> Fallible {
+    // RGBA8 -> BGRA8 is a pure R<->B swizzle.
+    let mut conv = RowConverter::new(PixelDescriptor::RGBA8_SRGB, PixelDescriptor::BGRA8_SRGB)?;
+    assert!(!conv.is_identity());
+
+    let src = [10u8, 20, 30, 40, 50, 60, 70, 80]; // two RGBA pixels
+    let mut dst = [0u8; 8];
+    conv.convert_rows(&src, 8, &mut dst, 8, 2, 1)?;
+    assert_eq!(dst, [30, 20, 10, 40, 70, 60, 50, 80]); // R and B swapped
+    Ok(())
+}
+
+/// Streaming with the free-function plan API: build the plan once, then convert
+/// row strips into a reused scratch buffer. This "alloc `w*h*bpp`, loop
+/// `convert_row`" block is hand-rolled in ~5 downstream crates (see report).
+fn convert_a_strip_with_a_plan() -> Fallible {
+    use zenpixels_convert::convert_row;
+
+    let plan = ConvertPlan::new(PixelDescriptor::RGB8_SRGB, PixelDescriptor::RGBA8_SRGB)?;
+    let (w, h) = (2u32, 2u32);
+    let src = vec![9u8; (w * h) as usize * 3];
+    let dst_bpp = PixelDescriptor::RGBA8_SRGB.bytes_per_pixel();
+    let mut dst = vec![0u8; (w * h) as usize * dst_bpp];
+
+    for y in 0..h as usize {
+        let s = &src[y * w as usize * 3..][..w as usize * 3];
+        let d = &mut dst[y * w as usize * dst_bpp..][..w as usize * dst_bpp];
+        convert_row(&plan, s, d, w);
+    }
+    // RGB8 -> RGBA8 fills an opaque alpha byte after each triple.
+    assert_eq!(&dst[0..4], &[9, 9, 9, 255]);
+    Ok(())
+}
+
+/// Turn a processed buffer + its provenance into encoder-ready pixels+metadata.
+///
+/// NOTE: `finalize_for_output*` / `EncodeReady` / `OutputProfile` are the
+/// documented "encode" step, but the downstream-usage audit found *zero*
+/// real call sites — codecs use `adapt_for_encode` + zencodec's color
+/// resolution instead. Flagged in the ergonomics report as an unadopted
+/// surface (a 0.3.0 demotion candidate), shown here only for completeness.
+fn finalize_metadata_for_the_encoder() -> Fallible {
+    let buffer = PixelBuffer::new(4, 4, PixelDescriptor::RGBA8_SRGB);
+    let origin = ColorOrigin::from_cicp(Cicp::SRGB); // how the source declared color
+
+    // `_with(..., None)` = no external CMS needed (sRGB in, sRGB out).
+    let ready = finalize_for_output_with(
+        &buffer,
+        &origin,
+        OutputProfile::SameAsOrigin,
+        PixelFormat::Rgb8, // encoder wants RGB8
+        None,
+    )?;
+    assert_eq!(
+        ready.pixels().descriptor().pixel_format(),
+        PixelFormat::Rgb8
+    );
+    assert_eq!(ready.metadata().cicp, Some(Cicp::SRGB));
+    Ok(())
+}
+
+/// Apply a transfer curve to a single scalar (e.g. a lookup or unit test).
+fn apply_a_transfer_function_to_one_value() {
+    // sRGB midpoint 0.5 delinearizes to ~0.735 encoded.
+    let encoded = TransferFunction::Srgb.delinearize(0.5);
+    assert!((encoded - 0.735).abs() < 0.01);
+    // ... and round-trips back.
+    let linear = TransferFunction::Srgb.linearize(encoded);
+    assert!((linear - 0.5).abs() < 1e-4);
+}
+
+/// Rotate pixels to match an EXIF orientation.
+fn reorient_pixels() {
+    let img = PixelBuffer::new(4, 2, PixelDescriptor::RGBA8_SRGB);
+    let rotated = apply_orientation(img.as_slice(), Orientation::Rotate90);
+    // 90-degree rotation swaps the axes.
+    assert_eq!((rotated.width(), rotated.height()), (2, 4));
+}
+
+/// Synthesize an ICC profile for a CICP signal, then read the signal back out.
+fn synthesize_then_read_back_an_icc() {
+    match synthesize_icc_for_cicp(Cicp::DISPLAY_P3) {
+        SynthesizedIcc::Profile(bytes) => {
+            // Recover the signal the way codecs do (cf. zencodec's color path):
+            // a literal `cICP` tag if the profile embeds one, else fall back to
+            // hash/matrix identification of a well-known profile.
+            let recovered = zenpixels::icc::extract_cicp(&bytes)
+                .or_else(|| zenpixels::icc::identify_common(&bytes).and_then(|id| id.to_cicp()));
+            assert_eq!(recovered, Some(Cicp::DISPLAY_P3));
+        }
+        other => panic!("expected a bundled profile, got {other:?}"),
+    }
+}
+
+/// Estimate memory + wall-time for a conversion before committing to it.
+fn estimate_conversion_resources() -> Fallible {
+    let plan = ConvertPlan::new(PixelDescriptor::RGB8_SRGB, PixelDescriptor::RGBAF32_LINEAR)?;
+    let est = plan.estimate(1920, 1080);
+    // A real conversion (not identity) reports a non-zero peak-memory estimate.
+    assert!(est.peak_memory_bytes_est().unwrap_or(0) > 0);
+    Ok(())
+}
+
+/// Build HDR signaling to hand to an encoder.
+fn carry_hdr_metadata() {
+    // HDR10 = PQ transfer + content light levels (MaxCLL / MaxFALL). Carry the
+    // light-level and mastering-display structs directly; the transfer lives on
+    // the descriptor. (`HdrMetadata` exists but is deprecated — see the report.)
+    let cll = ContentLightLevel::new(1000, 400);
+    assert_eq!(cll.max_content_light_level, 1000);
+
+    let mastering = zenpixels::hdr::MasteringDisplay::HDR10_REFERENCE;
+    assert!(mastering.max_luminance > 0.0);
+
+    assert_eq!(
+        PixelDescriptor::RGB16_BT2100_PQ.transfer(),
+        TransferFunction::Pq
+    );
+}
+
+#[test]
+fn examples_run() {
+    main();
+}

--- a/zenpixels-convert/examples/convert_pipeline.rs
+++ b/zenpixels-convert/examples/convert_pipeline.rs
@@ -186,7 +186,7 @@ fn convert_a_strip_with_a_plan() -> Fallible {
     // drive the row loop — no manual `alloc w*h*bpp` + `convert_row` scaffolding.
     let mut conv = RowConverter::new(PixelDescriptor::RGB8_SRGB, PixelDescriptor::RGBA8_SRGB)?;
     let src_slice =
-        zenpixels::buffer::PixelSlice::new_tight(&src, w, h, PixelDescriptor::RGB8_SRGB)?;
+        zenpixels::buffer::PixelSlice::new_contiguous(&src, w, h, PixelDescriptor::RGB8_SRGB)?;
     let out = conv.convert_slice(src_slice)?;
     assert_eq!(out.descriptor(), PixelDescriptor::RGBA8_SRGB);
     assert_eq!(&out.as_slice().row(0)[0..4], &[9, 9, 9, 255]);

--- a/zenpixels-convert/examples/convert_pipeline.rs
+++ b/zenpixels-convert/examples/convert_pipeline.rs
@@ -19,7 +19,7 @@ use zenpixels::descriptor::{PixelDescriptor, PixelFormat, TransferFunction};
 use zenpixels::hdr::ContentLightLevel;
 use zenpixels::orientation::Orientation;
 
-use zenpixels_convert::adapt::{adapt_for_encode, convert_buffer};
+use zenpixels_convert::adapt::adapt_for_encode;
 use zenpixels_convert::converter::RowConverter;
 use zenpixels_convert::ext::{PixelBufferConvertExt, TransferFunctionExt};
 use zenpixels_convert::icc_profiles::{SynthesizedIcc, synthesize_icc_for_cicp};
@@ -48,22 +48,20 @@ fn main() {
     println!("all zenpixels-convert examples passed");
 }
 
-/// The lowest-friction one-shot: raw bytes in, converted bytes out.
+/// The lowest-friction one-shot: hold a `PixelBuffer`, convert it.
 fn convert_a_whole_buffer_one_shot() -> Fallible {
-    // 2x1 opaque RGB8 (red, green), tightly packed.
-    let rgb = [255u8, 0, 0, 0, 255, 0];
-    let bgr = convert_buffer(
-        &rgb,
-        2,
-        1,
-        PixelDescriptor::RGB8_SRGB,
-        PixelDescriptor::BGRA8_SRGB,
-    )?;
+    // 2x1 opaque RGB8 (red, green).
+    let rgb = PixelBuffer::from_vec(vec![255, 0, 0, 0, 255, 0], 2, 1, PixelDescriptor::RGB8_SRGB)?;
+
+    // `convert_to` keeps width/height/descriptor together on the result — no
+    // separate bookkeeping. (The old `convert_buffer` free function returned a
+    // bare `Vec<u8>` and dropped that geometry; it is deprecated.)
+    let bgra = rgb.convert_to(PixelDescriptor::BGRA8_SRGB)?;
     // R and B are swapped and an opaque alpha byte is appended.
-    assert_eq!(bgr, vec![0, 0, 255, 255, 0, 255, 0, 255]);
-    // NOTE: `convert_buffer` returns a bare `Vec<u8>` — the caller has to keep
-    // width/height/descriptor on the side. Prefer the buffer path below when
-    // you already hold a `PixelBuffer`.
+    assert_eq!(
+        &bgra.as_slice().row(0)[..8],
+        &[0, 0, 255, 255, 0, 255, 0, 255]
+    );
     Ok(())
 }
 

--- a/zenpixels-convert/src/adapt.rs
+++ b/zenpixels-convert/src/adapt.rs
@@ -182,7 +182,7 @@ impl<'a> Adapted<'a> {
     /// ```
     #[track_caller]
     pub fn as_pixel_slice(&self) -> Result<PixelSlice<'_>, At<ConvertError>> {
-        PixelSlice::new_tight(&self.data, self.width, self.rows, self.descriptor)
+        PixelSlice::new_contiguous(&self.data, self.width, self.rows, self.descriptor)
             .map_err_at(ConvertError::from)
     }
 }

--- a/zenpixels-convert/src/adapt.rs
+++ b/zenpixels-convert/src/adapt.rs
@@ -191,6 +191,11 @@ impl<'a> Adapted<'a> {
 ///
 /// Uses [`ConvertIntent::Fastest`] — minimizes conversion cost.
 ///
+/// Note the zero-copy claim below is conditional: [`Adapted`] has no stride
+/// field, so a source that is **strided** — even when it already matches a
+/// supported format — is repacked into an owned buffer rather than borrowed.
+/// See the "Strided buffers" section and imazen/zenpixels#68.
+///
 /// If the input already matches one of the `supported` formats, returns
 /// `Cow::Borrowed` (zero-copy). Otherwise, converts to the best match.
 ///

--- a/zenpixels-convert/src/adapt.rs
+++ b/zenpixels-convert/src/adapt.rs
@@ -68,7 +68,7 @@ use crate::negotiate::{ConvertIntent, best_match};
 use crate::policy::{AlphaPolicy, ConvertOptions};
 use crate::{
     AlphaMode, ChannelLayout, ChannelType, ColorModel, ConvertError, PixelBuffer, PixelDescriptor,
-    PixelSliceMut,
+    PixelSlice, PixelSliceMut,
 };
 use whereat::{At, ResultAtExt};
 
@@ -149,6 +149,42 @@ pub struct Adapted<'a> {
     pub width: u32,
     /// Number of rows.
     pub rows: u32,
+}
+
+impl<'a> Adapted<'a> {
+    /// Borrow the adapted pixels as a tightly-packed [`PixelSlice`], ready to
+    /// hand to an encoder — without restating the `width * bytes_per_pixel`
+    /// stride by hand.
+    ///
+    /// Every `adapt_for_encode*` result is contiguous (the zero-copy path only
+    /// borrows already-packed source; the conversion path writes a packed
+    /// buffer), so the stride is exactly `width * descriptor.bytes_per_pixel()`.
+    /// This folds the recompute-stride-then-[`PixelSlice::new`] block that
+    /// encoders otherwise repeat verbatim after [`adapt_for_encode`].
+    ///
+    /// # Errors
+    ///
+    /// Errors only when the *borrowed* source bytes are misaligned for a
+    /// multi-byte channel type ([`PixelSlice`] requires native-aligned U16 /
+    /// F16 / F32 samples). The freshly-converted (owned) path is always
+    /// aligned, so it never errors.
+    ///
+    /// ```
+    /// use zenpixels::PixelDescriptor;
+    /// use zenpixels_convert::adapt::adapt_for_encode;
+    ///
+    /// let rgb = [1u8, 2, 3, 4, 5, 6]; // 2x1 RGB8
+    /// let supported = [PixelDescriptor::RGB8_SRGB];
+    /// let adapted = adapt_for_encode(&rgb, PixelDescriptor::RGB8_SRGB, 2, 1, 6, &supported)?;
+    /// let slice = adapted.as_pixel_slice()?; // ready for encoder.encode(slice)
+    /// assert_eq!((slice.width(), slice.rows(), slice.stride()), (2, 1, 6));
+    /// # Ok::<(), whereat::At<zenpixels_convert::ConvertError>>(())
+    /// ```
+    #[track_caller]
+    pub fn as_pixel_slice(&self) -> Result<PixelSlice<'_>, At<ConvertError>> {
+        PixelSlice::new_tight(&self.data, self.width, self.rows, self.descriptor)
+            .map_err_at(ConvertError::from)
+    }
 }
 
 /// Negotiate format and convert pixel data for encoding.

--- a/zenpixels-convert/src/adapt.rs
+++ b/zenpixels-convert/src/adapt.rs
@@ -139,7 +139,14 @@ fn checked_byte_alloc(rows: u32, stride: usize) -> Result<usize, At<ConvertError
 }
 
 /// Result of format adaptation: the converted data and its descriptor.
+///
+/// `#[non_exhaustive]`: construct it only via [`adapt_for_encode`] and read it
+/// via the accessors / [`as_pixel_slice`](Self::as_pixel_slice). The fields are
+/// still `pub` for now, but a future `stride` field (imazen/zenpixels#68) will
+/// land additively behind this attribute — code that reads through the
+/// accessors won't need to change.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct Adapted<'a> {
     /// Pixel data — borrowed if no conversion was needed, owned otherwise.
     pub data: Cow<'a, [u8]>,
@@ -152,6 +159,35 @@ pub struct Adapted<'a> {
 }
 
 impl<'a> Adapted<'a> {
+    /// The adapted pixel bytes — borrowed on the zero-copy path, owned when a
+    /// conversion ran. Tightly packed (`width * bytes_per_pixel`).
+    #[inline]
+    #[must_use]
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// The pixel format of [`data`](Self::data).
+    #[inline]
+    #[must_use]
+    pub fn descriptor(&self) -> PixelDescriptor {
+        self.descriptor
+    }
+
+    /// Width in pixels.
+    #[inline]
+    #[must_use]
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// Row count.
+    #[inline]
+    #[must_use]
+    pub fn rows(&self) -> u32 {
+        self.rows
+    }
+
     /// Borrow the adapted pixels as a tightly-packed [`PixelSlice`], ready to
     /// hand to an encoder — without restating the `width * bytes_per_pixel`
     /// stride by hand.
@@ -324,7 +360,30 @@ pub fn adapt_for_encode_with_intent<'a>(
 /// Convert a raw byte buffer from one format to another.
 ///
 /// Assumes packed (stride = width * bpp) layout.
+///
+/// # Deprecated
+///
+/// Two footguns: it **assumes packed input** (a strided buffer is read with its
+/// padding interpreted as pixels — the length check cannot catch it), and it
+/// returns a bare `Vec<u8>` that drops the dimensions and descriptor the caller
+/// then has to carry separately. Build a [`PixelBuffer`] and use
+/// [`PixelBufferConvertExt`](crate::PixelBufferConvertExt)'s `convert_to` /
+/// `convert_into` / `convert_in_place`, which carry the geometry and honour
+/// stride:
+///
+/// ```
+/// use zenpixels::{PixelBuffer, PixelDescriptor};
+/// use zenpixels_convert::PixelBufferConvertExt;
+///
+/// let src = PixelBuffer::from_vec(vec![255, 0, 0, 0, 255, 0], 2, 1, PixelDescriptor::RGB8_SRGB)?;
+/// let dst = src.convert_to(PixelDescriptor::BGRA8_SRGB)?;
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
 #[track_caller]
+#[deprecated(
+    since = "0.2.15",
+    note = "assumes packed input and drops geometry into a bare Vec; build a PixelBuffer and use PixelBufferConvertExt::convert_to / convert_into / convert_in_place"
+)]
 pub fn convert_buffer(
     src: &[u8],
     width: u32,
@@ -1088,6 +1147,7 @@ mod anchor_tests {
 }
 
 #[cfg(test)]
+#[allow(deprecated)] // several tests exercise the deprecated convert_buffer; it must keep working
 mod tests {
     use super::*;
     use zenpixels::descriptor::{ColorPrimaries, SignalRange};

--- a/zenpixels-convert/src/convert.rs
+++ b/zenpixels-convert/src/convert.rs
@@ -1364,7 +1364,8 @@ impl ConvertPlan {
 
     /// Crate-internal view of the planned step list — exposed for the
     /// estimate-API code under `crate::estimate`. NOT public:
-    /// `ConvertStep` itself is `pub(crate)`.
+    /// `ConvertStep` itself is `pub(crate)`. Gated with its only caller.
+    #[cfg(feature = "estimation-experimental")]
     pub(crate) fn steps(&self) -> &[ConvertStep] {
         &self.steps
     }
@@ -1438,6 +1439,7 @@ impl ConvertPlan {
     /// assert!(est.wall_ms().is_some());
     /// ```
     #[must_use]
+    #[cfg(feature = "estimation-experimental")]
     pub fn estimate_in(
         &self,
         image: &crate::estimate::ImageCharacteristics,
@@ -1470,6 +1472,7 @@ impl ConvertPlan {
     /// assert!(est.wall_ms().is_some());
     /// ```
     #[must_use]
+    #[cfg(feature = "estimation-experimental")]
     pub fn estimate(&self, width: u32, height: u32) -> crate::estimate::ResourceEstimate {
         let image = crate::estimate::ImageCharacteristics::new(width, height, self.from());
         let compute = crate::estimate::ComputeEnvironment::new();
@@ -1478,7 +1481,9 @@ impl ConvertPlan {
 }
 
 /// Bridge for the [`crate::estimate`] module: mirror of
-/// [`intermediate_desc`] without making that function public.
+/// [`intermediate_desc`] without making that function public. Gated with
+/// its only caller.
+#[cfg(feature = "estimation-experimental")]
 pub(crate) fn intermediate_desc_for_estimate(
     current: PixelDescriptor,
     step: &ConvertStep,

--- a/zenpixels-convert/src/convert.rs
+++ b/zenpixels-convert/src/convert.rs
@@ -423,7 +423,7 @@ impl ConvertStep {
 ///
 /// Anything outside this set is a device-dependent / CMS-only path —
 /// CMYK today, Lab / XYZ / spot inks if/when those land as
-/// [`crate::ColorModel`] variants. See [`requires_cms`].
+/// [`crate::ColorModel`] variants. See `requires_cms` (crate-internal; the public signal is `ConvertError::NeedsCms`).
 #[inline]
 fn native_color_model(m: crate::ColorModel) -> bool {
     // `Gray`, `Rgb` and `Oklab` are the colorimetric spaces the built-in
@@ -455,7 +455,12 @@ fn native_color_model(m: crate::ColorModel) -> bool {
 /// attach a CMS plugin (e.g. `&MoxCms`) for that batch.
 ///
 /// [`color_model`]: zenpixels::PixelDescriptor::color_model
-pub fn requires_cms(from: &PixelDescriptor, to: &PixelDescriptor) -> bool {
+///
+/// `pub(crate)`: the **public** "needs a CMS" signal is the
+/// [`ConvertError::NeedsCms`] variant returned by the no-CMS entry points
+/// (`convert_to`, `to_rgba8`, …). This predicate had no external consumer, so
+/// it is not part of the public surface; catch `NeedsCms` instead of probing.
+pub(crate) fn requires_cms(from: &PixelDescriptor, to: &PixelDescriptor) -> bool {
     !native_color_model(from.color_model()) || !native_color_model(to.color_model())
 }
 
@@ -1706,7 +1711,7 @@ fn f32_tf_pair_steps(from: TransferFunction, to: TransferFunction) -> Vec<Conver
 
 /// Depth conversion step into F32 for any non-F32 channel type (U8, U16, F16).
 /// Panics for F32 (caller must check); CMYK is rejected upstream by
-/// [`requires_cms`] before any plan steps are picked.
+/// `requires_cms` before any plan steps are picked (the public signal is `ConvertError::NeedsCms`).
 fn to_f32_step(ct: ChannelType) -> ConvertStep {
     match ct {
         ChannelType::U8 => ConvertStep::NaiveU8ToF32,

--- a/zenpixels-convert/src/converter.rs
+++ b/zenpixels-convert/src/converter.rs
@@ -6,7 +6,7 @@
 use alloc::boxed::Box;
 
 use crate::convert::{ConvertPlan, ConvertScratch, convert_row_buffered};
-use crate::{ChannelLayout, ConvertError, PixelDescriptor};
+use crate::{ChannelLayout, ConvertError, PixelBuffer, PixelDescriptor, PixelSlice};
 use whereat::{At, ResultAtExt};
 
 /// Pre-computed pixel format converter with pre-allocated scratch buffers.
@@ -339,6 +339,63 @@ impl RowConverter {
             );
         }
         Ok(())
+    }
+
+    /// Convert an entire [`PixelSlice`] into a freshly-allocated
+    /// [`PixelBuffer`] of this converter's target format.
+    ///
+    /// Bundles the common "allocate `rows * stride`, loop
+    /// [`convert_row`](Self::convert_row)" block behind the [`PixelSlice`]
+    /// stride contract: the source may be strided (a crop, a decoder
+    /// row-guard, an [`Adapted`](crate::adapt::Adapted) view) and the owned output is
+    /// SIMD-aligned. The source's color context, if any, is carried over.
+    ///
+    /// Prefer [`PixelBufferConvertExt::convert_to`] when you already hold an
+    /// owned [`PixelBuffer`]; reach for this when you hold a [`PixelSlice`] and
+    /// want owned output without threading the six positional stride arguments
+    /// through [`convert_rows`](Self::convert_rows).
+    ///
+    /// [`PixelBufferConvertExt::convert_to`]: crate::ext::PixelBufferConvertExt::convert_to
+    ///
+    /// # Errors
+    ///
+    /// Errors if the output byte count overflows `usize`
+    /// ([`ConvertError::AllocationFailed`]) or the target descriptor rejects
+    /// the computed buffer.
+    ///
+    /// ```
+    /// use zenpixels::{PixelDescriptor, PixelSlice};
+    /// use zenpixels_convert::RowConverter;
+    ///
+    /// // Two RGB8 pixels -> RGBA8 (an opaque alpha byte is appended per pixel).
+    /// let src = [10u8, 20, 30, 40, 50, 60];
+    /// let slice = PixelSlice::new_tight(&src, 2, 1, PixelDescriptor::RGB8_SRGB)?;
+    /// let mut conv = RowConverter::new(PixelDescriptor::RGB8_SRGB, PixelDescriptor::RGBA8_SRGB)?;
+    /// let out = conv.convert_slice(slice)?;
+    /// assert_eq!((out.width(), out.height()), (2, 1));
+    /// assert_eq!(out.descriptor(), PixelDescriptor::RGBA8_SRGB);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[track_caller]
+    pub fn convert_slice(&mut self, src: PixelSlice<'_>) -> Result<PixelBuffer, At<ConvertError>> {
+        let (width, rows) = (src.width(), src.rows());
+        let target = self.plan.to();
+        let dst_stride = target.aligned_stride(width);
+        let total = dst_stride
+            .checked_mul(rows as usize)
+            .ok_or_else(|| whereat::at!(ConvertError::AllocationFailed))?;
+        let mut out = alloc::vec![0u8; total];
+        for y in 0..rows {
+            let src_row = src.row(y);
+            let dst_start = y as usize * dst_stride;
+            self.convert_row(src_row, &mut out[dst_start..dst_start + dst_stride], width);
+        }
+        let mut buf =
+            PixelBuffer::from_vec(out, width, rows, target).map_err_at(ConvertError::from)?;
+        if let Some(ctx) = src.color_context() {
+            buf = buf.with_color_context(alloc::sync::Arc::clone(ctx));
+        }
+        Ok(buf)
     }
 
     /// True if the conversion is a no-op (formats are identical).

--- a/zenpixels-convert/src/converter.rs
+++ b/zenpixels-convert/src/converter.rs
@@ -369,7 +369,7 @@ impl RowConverter {
     ///
     /// // Two RGB8 pixels -> RGBA8 (an opaque alpha byte is appended per pixel).
     /// let src = [10u8, 20, 30, 40, 50, 60];
-    /// let slice = PixelSlice::new_tight(&src, 2, 1, PixelDescriptor::RGB8_SRGB)?;
+    /// let slice = PixelSlice::new_contiguous(&src, 2, 1, PixelDescriptor::RGB8_SRGB)?;
     /// let mut conv = RowConverter::new(PixelDescriptor::RGB8_SRGB, PixelDescriptor::RGBA8_SRGB)?;
     /// let out = conv.convert_slice(slice)?;
     /// assert_eq!((out.width(), out.height()), (2, 1));

--- a/zenpixels-convert/src/converter.rs
+++ b/zenpixels-convert/src/converter.rs
@@ -348,7 +348,9 @@ impl RowConverter {
     /// [`convert_row`](Self::convert_row)" block behind the [`PixelSlice`]
     /// stride contract: the source may be strided (a crop, a decoder
     /// row-guard, an [`Adapted`](crate::adapt::Adapted) view) and the owned output is
-    /// SIMD-aligned. The source's color context, if any, is carried over.
+    /// tightly packed (`width * bytes_per_pixel`) — every [`PixelBuffer`] this
+    /// crate allocates is, despite the `aligned_stride` name. The source's
+    /// color context, if any, is carried over.
     ///
     /// Prefer [`PixelBufferConvertExt::convert_to`] when you already hold an
     /// owned [`PixelBuffer`]; reach for this when you hold a [`PixelSlice`] and

--- a/zenpixels-convert/src/converter.rs
+++ b/zenpixels-convert/src/converter.rs
@@ -6,7 +6,7 @@
 use alloc::boxed::Box;
 
 use crate::convert::{ConvertPlan, ConvertScratch, convert_row_buffered};
-use crate::{ChannelLayout, ConvertError, PixelBuffer, PixelDescriptor, PixelSlice};
+use crate::{ChannelLayout, ConvertError, PixelBuffer, PixelDescriptor, PixelSlice, PixelSliceMut};
 use whereat::{At, ResultAtExt};
 
 /// Pre-computed pixel format converter with pre-allocated scratch buffers.
@@ -380,22 +380,77 @@ impl RowConverter {
     pub fn convert_slice(&mut self, src: PixelSlice<'_>) -> Result<PixelBuffer, At<ConvertError>> {
         let (width, rows) = (src.width(), src.rows());
         let target = self.plan.to();
-        let dst_stride = target.aligned_stride(width);
-        let total = dst_stride
-            .checked_mul(rows as usize)
-            .ok_or_else(|| whereat::at!(ConvertError::AllocationFailed))?;
-        let mut out = alloc::vec![0u8; total];
-        for y in 0..rows {
-            let src_row = src.row(y);
-            let dst_start = y as usize * dst_stride;
-            self.convert_row(src_row, &mut out[dst_start..dst_start + dst_stride], width);
-        }
-        let mut buf =
-            PixelBuffer::from_vec(out, width, rows, target).map_err_at(ConvertError::from)?;
-        if let Some(ctx) = src.color_context() {
-            buf = buf.with_color_context(alloc::sync::Arc::clone(ctx));
+        // Captured before `src` moves into the no-alloc primitive below.
+        let ctx = src.color_context().cloned();
+        let mut buf = PixelBuffer::try_new(width, rows, target).map_err_at(ConvertError::from)?;
+        self.convert_slice_into(src, buf.as_slice_mut())?;
+        if let Some(ctx) = ctx {
+            buf = buf.with_color_context(ctx);
         }
         Ok(buf)
+    }
+
+    /// Convert an entire [`PixelSlice`] into a caller-provided
+    /// [`PixelSliceMut`] — no allocation.
+    ///
+    /// The no-alloc primitive that [`convert_slice`](Self::convert_slice) is
+    /// sugar over. Both sides may be strided (a crop, a decoder row-guard, a
+    /// reused scratch buffer, a staging buffer with a required pitch), because
+    /// each [`PixelSlice`] carries its own stride — which is why neither is
+    /// passed separately. Use this when you already own the destination or are
+    /// converting many frames through one buffer; use `convert_slice` for the
+    /// one-shot case.
+    ///
+    /// The destination's [`ColorContext`](zenpixels::ColorContext) is left
+    /// alone — the caller owns `dst` and its metadata. (`convert_slice` copies
+    /// the source's context onto the buffer it allocates.)
+    ///
+    /// # Errors
+    ///
+    /// * [`ConvertError::BufferSize`] if `dst`'s dimensions differ from `src`'s.
+    /// * [`ConvertError::NoPath`] if `dst`'s descriptor is not this converter's
+    ///   target — the plan was built for a specific `to`, so writing into a
+    ///   differently-shaped destination would silently produce wrong pixels.
+    ///
+    /// ```
+    /// use zenpixels::{PixelBuffer, PixelDescriptor, PixelSlice};
+    /// use zenpixels_convert::RowConverter;
+    ///
+    /// let src_bytes = [10u8, 20, 30, 40, 50, 60];
+    /// let src = PixelSlice::new_contiguous(&src_bytes, 2, 1, PixelDescriptor::RGB8_SRGB)?;
+    /// // A destination you already own — reused across frames, no alloc here.
+    /// let mut dst = PixelBuffer::new(2, 1, PixelDescriptor::RGBA8_SRGB);
+    ///
+    /// let mut conv = RowConverter::new(PixelDescriptor::RGB8_SRGB, PixelDescriptor::RGBA8_SRGB)?;
+    /// conv.convert_slice_into(src, dst.as_slice_mut())?;
+    /// assert_eq!(&dst.as_slice().row(0)[0..4], &[10, 20, 30, 255]);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[track_caller]
+    pub fn convert_slice_into(
+        &mut self,
+        src: PixelSlice<'_>,
+        mut dst: PixelSliceMut<'_>,
+    ) -> Result<(), At<ConvertError>> {
+        let (width, rows) = (src.width(), src.rows());
+        if dst.width() != width || dst.rows() != rows {
+            return Err(whereat::at!(ConvertError::BufferSize {
+                expected: (width as usize) * (rows as usize),
+                actual: (dst.width() as usize) * (dst.rows() as usize),
+            }));
+        }
+        let target = self.plan.to();
+        if dst.descriptor() != target {
+            return Err(whereat::at!(ConvertError::NoPath {
+                from: dst.descriptor(),
+                to: target,
+            }));
+        }
+        for y in 0..rows {
+            let src_row = src.row(y);
+            self.convert_row(src_row, dst.row_mut(y), width);
+        }
+        Ok(())
     }
 
     /// True if the conversion is a no-op (formats are identical).

--- a/zenpixels-convert/src/converter.rs
+++ b/zenpixels-convert/src/converter.rs
@@ -309,7 +309,24 @@ impl RowConverter {
     /// Convert multiple rows from a strided source buffer to a strided destination.
     ///
     /// The source and destination can have different strides.
+    ///
+    /// # Deprecated
+    ///
+    /// Four of these six arguments are a [`PixelSlice`] / [`PixelSliceMut`]
+    /// taken apart, and `width`/`rows` live on those types too — nothing
+    /// type-checks that `src_stride` belongs to `src`, or that either
+    /// descriptor matches the plan, so transposing a pair of stride arguments
+    /// compiles and silently produces wrong pixels.
+    /// [`convert_slice_into`](Self::convert_slice_into) is the bundled
+    /// equivalent: both sides carry their own stride, a dimension mismatch
+    /// errors with [`ConvertError::BufferSize`], and a destination whose
+    /// descriptor is not this converter's target errors with
+    /// [`ConvertError::NoPath`] instead of being written into.
     #[track_caller]
+    #[deprecated(
+        since = "0.2.15",
+        note = "use convert_slice_into(src: PixelSlice, dst: PixelSliceMut) — it carries the strides, dimensions and descriptors together and validates them"
+    )]
     pub fn convert_rows(
         &mut self,
         src: &[u8],
@@ -1312,6 +1329,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
+    #[allow(deprecated)] // deliberately exercises the deprecated fn; it must keep working
     fn convert_rows_basic() {
         let mut conv =
             RowConverter::new(PixelDescriptor::RGB8_SRGB, PixelDescriptor::RGBA8_SRGB).unwrap();
@@ -1328,6 +1346,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // deliberately exercises the deprecated fn; it must keep working
     fn convert_rows_buffer_too_small() {
         let mut conv =
             RowConverter::new(PixelDescriptor::RGB8_SRGB, PixelDescriptor::RGBA8_SRGB).unwrap();

--- a/zenpixels-convert/src/ext.rs
+++ b/zenpixels-convert/src/ext.rs
@@ -4,7 +4,7 @@
 //! `zenpixels` (no heavy deps), while the conversion math lives here
 //! (depends on `linear-srgb`).
 
-use zenpixels::{ColorPrimaries, TransferFunction};
+use zenpixels::{ColorPrimaries, PixelSliceMut, TransferFunction};
 
 use crate::convert::{hlg_eotf, hlg_oetf, pq_eotf, pq_oetf};
 use crate::gamut::GamutMatrix;
@@ -104,15 +104,64 @@ use zenpixels::PixelDescriptor;
 use zenpixels::buffer::PixelBuffer;
 use zenpixels::descriptor::{AlphaMode, ChannelLayout, ChannelType};
 
+mod sealed {
+    /// Seals the `PixelBuffer*ConvertExt` traits.
+    ///
+    /// These are extension traits over a concrete foreign type — implementing
+    /// them elsewhere was never meaningful (every method returns a
+    /// `PixelBuffer`), and a full audit of `~/work/zen` found zero external
+    /// impls. Sealing makes adding methods a non-breaking change, which is
+    /// what `convert_into` needed; without it every future addition would be
+    /// a major bump for impls that do not exist.
+    pub trait Sealed {}
+    impl Sealed for zenpixels::buffer::PixelBuffer {}
+}
+
 /// Adds format conversion methods to type-erased [`PixelBuffer`].
-pub trait PixelBufferConvertExt {
+///
+/// Sealed — this crate is the only implementor.
+pub trait PixelBufferConvertExt: sealed::Sealed {
     /// Convert pixel data to a different layout and depth.
     ///
     /// Uses [`RowConverter`](crate::RowConverter) for transfer-function-aware
     /// conversion. Color metadata is preserved.
     ///
-    /// **Allocates** a new [`PixelBuffer`].
+    /// **Allocates** a new [`PixelBuffer`]. For a no-allocation conversion into
+    /// storage you already own, use [`convert_into`](Self::convert_into).
     fn convert_to(&self, target: PixelDescriptor) -> Result<PixelBuffer, At<crate::ConvertError>>;
+
+    /// Convert into a caller-provided destination — **no allocation**.
+    ///
+    /// The no-alloc primitive that [`convert_to`](Self::convert_to) is sugar
+    /// over. The target descriptor is read from `dst`, and both sides may be
+    /// strided (a crop, a decoder row-guard, a reused scratch buffer, a
+    /// staging buffer with a required pitch) because each carries its own
+    /// stride. Reach for this when converting many frames through one
+    /// destination, or when you already own the output.
+    ///
+    /// `dst`'s [`ColorContext`](zenpixels::ColorContext) is left alone — the
+    /// caller owns `dst` and its metadata. (`convert_to` copies the source's
+    /// context onto the buffer it allocates.)
+    ///
+    /// # Errors
+    ///
+    /// [`ConvertError::NeedsCms`](crate::ConvertError::NeedsCms) if the pair
+    /// needs a CMS, [`ConvertError::NoPath`](crate::ConvertError::NoPath) if no
+    /// kernel exists, or [`ConvertError::BufferSize`](crate::ConvertError::BufferSize)
+    /// if `dst`'s dimensions differ from this buffer's.
+    ///
+    /// ```
+    /// use zenpixels::{PixelBuffer, PixelDescriptor};
+    /// use zenpixels_convert::PixelBufferConvertExt;
+    ///
+    /// let src = PixelBuffer::new(4, 4, PixelDescriptor::RGB8_SRGB);
+    /// // A destination you already own — reused across frames, no alloc here.
+    /// let mut dst = PixelBuffer::new(4, 4, PixelDescriptor::RGBA8_SRGB);
+    /// src.convert_into(dst.as_slice_mut())?;
+    /// assert_eq!(dst.as_slice().row(0)[3], 255); // opaque alpha filled in
+    /// # Ok::<(), whereat::At<zenpixels_convert::ConvertError>>(())
+    /// ```
+    fn convert_into(&self, dst: PixelSliceMut<'_>) -> Result<(), At<crate::ConvertError>>;
 
     /// Add an alpha channel. **Allocates** a new `PixelBuffer`.
     ///
@@ -194,51 +243,28 @@ fn check_needs_cms(
 impl PixelBufferConvertExt for PixelBuffer {
     #[track_caller]
     fn convert_to(&self, target: PixelDescriptor) -> Result<PixelBuffer, At<crate::ConvertError>> {
-        let src_desc = self.descriptor();
-        check_needs_cms(&src_desc, &target)?;
-        if src_desc == target {
-            // Identity — just copy.
-            let dst_stride = target.aligned_stride(self.width());
-            let total = dst_stride
-                .checked_mul(self.height() as usize)
-                .ok_or_else(|| whereat::at!(crate::ConvertError::AllocationFailed))?;
-            let mut out = alloc::vec![0u8; total];
-            let src_slice = self.as_slice();
-            for y in 0..self.height() {
-                let src_row = src_slice.row(y);
-                let dst_start = y as usize * dst_stride;
-                out[dst_start..dst_start + src_row.len()].copy_from_slice(src_row);
-            }
-            let mut buf = PixelBuffer::from_vec(out, self.width(), self.height(), target)
-                .map_err_at(crate::ConvertError::from)?;
-            if let Some(ctx) = self.color_context() {
-                buf = buf.with_color_context(Arc::clone(ctx));
-            }
-            return Ok(buf);
-        }
-
-        let mut converter = crate::RowConverter::new(src_desc, target).at()?;
-
-        let dst_stride = target.aligned_stride(self.width());
-        let total = dst_stride
-            .checked_mul(self.height() as usize)
-            .ok_or_else(|| whereat::at!(crate::ConvertError::AllocationFailed))?;
-        let mut out = alloc::vec![0u8; total];
-
-        let src_slice = self.as_slice();
-        for y in 0..self.height() {
-            let src_row = src_slice.row(y);
-            let dst_start = y as usize * dst_stride;
-            let dst_end = dst_start + dst_stride;
-            converter.convert_row(src_row, &mut out[dst_start..dst_end], self.width());
-        }
-
-        let mut buf = PixelBuffer::from_vec(out, self.width(), self.height(), target)
+        // Sugar over `convert_into`: allocate the destination, then run the
+        // one row loop that lives in `RowConverter::convert_slice_into`. The
+        // identity case is not special-cased — the plan is identity and the
+        // kernel degrades to a row copy, which is what the old hand-written
+        // identity branch did anyway. (The allocation is inherent: `&self` in,
+        // owned out. Callers who own their destination want `convert_into`.)
+        let mut buf = PixelBuffer::try_new(self.width(), self.height(), target)
             .map_err_at(crate::ConvertError::from)?;
+        self.convert_into(buf.as_slice_mut())?;
         if let Some(ctx) = self.color_context() {
             buf = buf.with_color_context(Arc::clone(ctx));
         }
         Ok(buf)
+    }
+
+    #[track_caller]
+    fn convert_into(&self, dst: PixelSliceMut<'_>) -> Result<(), At<crate::ConvertError>> {
+        let src_desc = self.descriptor();
+        let target = dst.descriptor();
+        check_needs_cms(&src_desc, &target)?;
+        let mut converter = crate::RowConverter::new(src_desc, target).at()?;
+        converter.convert_slice_into(self.as_slice(), dst)
     }
 
     #[track_caller]

--- a/zenpixels-convert/src/ext.rs
+++ b/zenpixels-convert/src/ext.rs
@@ -163,6 +163,49 @@ pub trait PixelBufferConvertExt: sealed::Sealed {
     /// ```
     fn convert_into(&self, dst: PixelSliceMut<'_>) -> Result<(), At<crate::ConvertError>>;
 
+    /// Convert **in place**, reusing this buffer's own allocation.
+    ///
+    /// The move-counterpart to [`convert_into`](Self::convert_into): where
+    /// `convert_into` writes into a destination *you* provide, this rewrites
+    /// the buffer's *own* storage. Whether it allocates depends on the size
+    /// relationship, because the bytes shrink or grow with the format:
+    ///
+    /// | Case | Behavior |
+    /// |---|---|
+    /// | **identity** (`target` == current) | no-op — zero copy, zero alloc |
+    /// | **narrowing** (RGBA→RGB, U16→U8, RGB→Gray) | shuffle-collapses front-to-back in the same allocation; only an O(row) scratch |
+    /// | **same size** (BGRA↔RGBA swizzle) | rewrites in place |
+    /// | **widening** (RGB→RGBA, U8→U16) | reallocates — the result is larger than the current storage |
+    ///
+    /// On success the buffer adopts `target`, a tightly-packed stride, and (for
+    /// the reused-allocation cases) keeps its existing
+    /// [`ColorContext`](zenpixels::ColorContext); a stale descriptor is never
+    /// observable. Prefer this over [`convert_to`](Self::convert_to) whenever
+    /// you are done with the source in its old format — it turns the common
+    /// narrowing and identity cases from a full-image allocation into none.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`convert_to`](Self::convert_to):
+    /// [`NeedsCms`](crate::ConvertError::NeedsCms),
+    /// [`NoPath`](crate::ConvertError::NoPath), or
+    /// [`AllocationFailed`](crate::ConvertError::AllocationFailed) on the
+    /// widening path.
+    ///
+    /// ```
+    /// use zenpixels::{PixelBuffer, PixelDescriptor};
+    /// use zenpixels_convert::PixelBufferConvertExt;
+    ///
+    /// // RGBA8 -> RGB8 is a narrowing: the alpha lane is dropped in place,
+    /// // no new image buffer is allocated.
+    /// let mut buf = PixelBuffer::new(4, 4, PixelDescriptor::RGBA8_SRGB);
+    /// buf.convert_in_place(PixelDescriptor::RGB8_SRGB)?;
+    /// assert_eq!(buf.descriptor(), PixelDescriptor::RGB8_SRGB);
+    /// assert_eq!(buf.stride(), 4 * 3);
+    /// # Ok::<(), whereat::At<zenpixels_convert::ConvertError>>(())
+    /// ```
+    fn convert_in_place(&mut self, target: PixelDescriptor) -> Result<(), At<crate::ConvertError>>;
+
     /// Add an alpha channel. **Allocates** a new `PixelBuffer`.
     ///
     /// - Gray → GrayAlpha (opaque alpha)
@@ -204,16 +247,44 @@ pub trait PixelBufferConvertExt: sealed::Sealed {
 #[cfg(feature = "rgb")]
 pub trait PixelBufferConvertTypedExt: PixelBufferConvertExt {
     /// Convert to RGB8, allocating a new buffer.
+    ///
+    /// **Panics** if the conversion needs a CMS (a CMYK / Lab / XYZ source) or
+    /// has no path. Use [`try_to_rgb8`](Self::try_to_rgb8) for untrusted or
+    /// non-RGB-family input.
     fn to_rgb8(&self) -> PixelBuffer<rgb::Rgb<u8>>;
 
     /// Convert to RGBA8, allocating a new buffer.
+    ///
+    /// **Panics** if the conversion needs a CMS or has no path — see
+    /// [`try_to_rgba8`](Self::try_to_rgba8).
     fn to_rgba8(&self) -> PixelBuffer<rgb::Rgba<u8>>;
 
     /// Convert to Gray8, allocating a new buffer.
+    ///
+    /// **Panics** if the conversion needs a CMS or has no path — see
+    /// [`try_to_gray8`](Self::try_to_gray8).
     fn to_gray8(&self) -> PixelBuffer<rgb::Gray<u8>>;
 
     /// Convert to BGRA8, allocating a new buffer.
+    ///
+    /// **Panics** if the conversion needs a CMS or has no path — see
+    /// [`try_to_bgra8`](Self::try_to_bgra8).
     fn to_bgra8(&self) -> PixelBuffer<rgb::alt::BGRA<u8>>;
+
+    /// Fallible [`to_rgb8`](Self::to_rgb8) — returns
+    /// [`ConvertError::NeedsCms`](crate::ConvertError::NeedsCms) instead of
+    /// panicking on a CMYK / Lab / XYZ source. Prefer this for decode output,
+    /// where the source format is not known in advance.
+    fn try_to_rgb8(&self) -> Result<PixelBuffer<rgb::Rgb<u8>>, At<crate::ConvertError>>;
+
+    /// Fallible [`to_rgba8`](Self::to_rgba8).
+    fn try_to_rgba8(&self) -> Result<PixelBuffer<rgb::Rgba<u8>>, At<crate::ConvertError>>;
+
+    /// Fallible [`to_gray8`](Self::to_gray8).
+    fn try_to_gray8(&self) -> Result<PixelBuffer<rgb::Gray<u8>>, At<crate::ConvertError>>;
+
+    /// Fallible [`to_bgra8`](Self::to_bgra8).
+    fn try_to_bgra8(&self) -> Result<PixelBuffer<rgb::alt::BGRA<u8>>, At<crate::ConvertError>>;
 }
 
 /// Reject conversions that require a CMS plugin from these
@@ -265,6 +336,66 @@ impl PixelBufferConvertExt for PixelBuffer {
         check_needs_cms(&src_desc, &target)?;
         let mut converter = crate::RowConverter::new(src_desc, target).at()?;
         converter.convert_slice_into(self.as_slice(), dst)
+    }
+
+    #[track_caller]
+    fn convert_in_place(&mut self, target: PixelDescriptor) -> Result<(), At<crate::ConvertError>> {
+        let source = self.descriptor();
+        check_needs_cms(&source, &target)?;
+        if source == target {
+            return Ok(()); // identity — no bytes move, no allocation.
+        }
+
+        let src_bpp = source.bytes_per_pixel();
+        let dst_bpp = target.bytes_per_pixel();
+
+        if dst_bpp > src_bpp {
+            // Widening: the result is larger than the current storage, so it
+            // cannot be written in place — allocate and replace.
+            *self = self.convert_to(target)?;
+            return Ok(());
+        }
+
+        // Narrowing or same-size: reuse the allocation. Each source row is
+        // copied to an O(row) scratch before the (smaller-or-equal) destination
+        // row is written over it, so an arbitrary conversion — not just byte
+        // selection — stays overlap-safe front-to-back. The image allocation is
+        // never duplicated.
+        let mut converter = crate::RowConverter::new(source, target).at()?;
+        let width = self.width();
+        let rows = self.height();
+        let out_stride = target.aligned_stride(width);
+        let src_row_bytes = width as usize * src_bpp;
+        let dst_row_bytes = width as usize * dst_bpp;
+        let mut scratch = alloc::vec![0u8; src_row_bytes];
+
+        self.transform_in_place(|px| {
+            let zenpixels::InPlacePixels {
+                bytes,
+                stride: in_stride,
+                color,
+                ..
+            } = px;
+            for y in 0..rows as usize {
+                let s = y * in_stride;
+                scratch.copy_from_slice(&bytes[s..s + src_row_bytes]);
+                let d = y * out_stride;
+                converter.convert_row(&scratch, &mut bytes[d..d + dst_row_bytes], width);
+            }
+            let out = PixelSliceMut::new(
+                &mut bytes[..rows as usize * out_stride],
+                width,
+                rows,
+                out_stride,
+                target,
+            )
+            .expect("in-place conversion geometry is always valid");
+            match color {
+                Some(c) => out.with_color_context(c),
+                None => out,
+            }
+        });
+        Ok(())
     }
 
     #[track_caller]
@@ -493,38 +624,48 @@ impl PixelBufferConvertTypedExt for PixelBuffer {
     fn to_bgra8(&self) -> PixelBuffer<rgb::alt::BGRA<u8>> {
         convert_to_typed(self, PixelDescriptor::BGRA8_SRGB)
     }
+
+    fn try_to_rgb8(&self) -> Result<PixelBuffer<rgb::Rgb<u8>>, At<crate::ConvertError>> {
+        try_convert_to_typed(self, PixelDescriptor::RGB8_SRGB)
+    }
+
+    fn try_to_rgba8(&self) -> Result<PixelBuffer<rgb::Rgba<u8>>, At<crate::ConvertError>> {
+        try_convert_to_typed(self, PixelDescriptor::RGBA8_SRGB)
+    }
+
+    fn try_to_gray8(&self) -> Result<PixelBuffer<rgb::Gray<u8>>, At<crate::ConvertError>> {
+        try_convert_to_typed(self, PixelDescriptor::GRAY8_SRGB)
+    }
+
+    fn try_to_bgra8(&self) -> Result<PixelBuffer<rgb::alt::BGRA<u8>>, At<crate::ConvertError>> {
+        try_convert_to_typed(self, PixelDescriptor::BGRA8_SRGB)
+    }
 }
 
-/// Internal: convert to any target descriptor, returning a typed buffer.
+/// Internal fallible core: convert to any target descriptor, returning a typed
+/// buffer. The `try_to_*` methods surface its errors; the infallible `to_*`
+/// wrappers `.expect()` over it.
+#[cfg(feature = "rgb")]
+fn try_convert_to_typed<Q: Pixel>(
+    buf: &PixelBuffer,
+    target: PixelDescriptor,
+) -> Result<PixelBuffer<Q>, At<crate::ConvertError>> {
+    let erased = buf.convert_to(target)?;
+    erased.try_typed::<Q>().ok_or_else(|| {
+        whereat::at!(crate::ConvertError::NoPath {
+            from: buf.descriptor(),
+            to: target,
+        })
+    })
+}
+
+/// Internal: infallible convert to a typed buffer. **Panics** on the errors
+/// [`try_convert_to_typed`] returns — used by the documented-panic `to_*`
+/// methods only.
 #[cfg(feature = "rgb")]
 fn convert_to_typed<Q: Pixel>(buf: &PixelBuffer, target: PixelDescriptor) -> PixelBuffer<Q> {
-    use alloc::vec;
-    let mut conv = crate::RowConverter::new(buf.descriptor(), target)
-        .expect("RowConverter: no conversion path");
-    let dst_bpp = target.bytes_per_pixel();
-    let dst_stride = target.aligned_stride(buf.width());
-    let total = dst_stride * buf.height() as usize;
-    let mut out = vec![0u8; total];
-    let src_slice = buf.as_slice();
-    for y in 0..buf.height() {
-        let src_row = src_slice.row(y);
-        let dst_start = y as usize * dst_stride;
-        let dst_end = dst_start + buf.width() as usize * dst_bpp;
-        conv.convert_row(src_row, &mut out[dst_start..dst_end], buf.width());
-    }
-    // We need to construct PixelBuffer<Q> from raw parts.
-    // Use from_vec to build the erased form, then reinterpret.
-    let erased = PixelBuffer::from_vec(out, buf.width(), buf.height(), target)
-        .expect("convert_to_typed: buffer construction failed");
-    // Carry over color context
-    let erased = if let Some(ctx) = buf.color_context() {
-        erased.with_color_context(Arc::clone(ctx))
-    } else {
-        erased
-    };
-    erased
-        .try_typed::<Q>()
-        .expect("convert_to_typed: type mismatch after conversion")
+    try_convert_to_typed(buf, target)
+        .expect("convert_to_typed: use try_to_* for fallible conversion")
 }
 
 #[cfg(test)]
@@ -716,6 +857,73 @@ mod tests {
         assert_eq!(row[5], 100);
         assert_eq!(row[6], 150);
         assert_eq!(row[7], 255);
+    }
+
+    // ── convert_in_place ──────────────────────────────────────────────────
+
+    /// Narrowing in place must produce byte-identical pixels to the allocating
+    /// `convert_to` — this is the shuffle-collapse overlap-safety gate.
+    #[test]
+    fn convert_in_place_narrowing_matches_convert_to() {
+        // Non-tight source (RGBA8, width 3) so the front-to-back overlap is real.
+        let data: Vec<u8> = (0..3 * 4 * 5).map(|i| (i * 7 % 251) as u8).collect();
+        let buf = PixelBuffer::from_vec(data, 3, 5, PixelDescriptor::RGBA8_SRGB).unwrap();
+
+        let allocated = buf.convert_to(PixelDescriptor::RGB8_SRGB).unwrap();
+
+        let mut in_place = buf;
+        in_place
+            .convert_in_place(PixelDescriptor::RGB8_SRGB)
+            .unwrap();
+
+        assert_eq!(in_place.descriptor(), PixelDescriptor::RGB8_SRGB);
+        assert_eq!(in_place.stride(), 3 * 3); // packed
+        for y in 0..5 {
+            assert_eq!(
+                in_place.as_slice().row(y),
+                allocated.as_slice().row(y),
+                "row {y} diverged from convert_to"
+            );
+        }
+    }
+
+    /// Identity is a no-op: descriptor and every byte unchanged.
+    #[test]
+    fn convert_in_place_identity_is_noop() {
+        let data = vec![100u8, 150, 200, 50, 100, 150];
+        let mut buf =
+            PixelBuffer::from_vec(data.clone(), 2, 1, PixelDescriptor::RGB8_SRGB).unwrap();
+        buf.convert_in_place(PixelDescriptor::RGB8_SRGB).unwrap();
+        assert_eq!(buf.descriptor(), PixelDescriptor::RGB8_SRGB);
+        assert_eq!(&buf.as_slice().row(0)[..6], &data[..]);
+    }
+
+    /// Widening reallocates and still matches `convert_to`.
+    #[test]
+    fn convert_in_place_widening_matches_convert_to() {
+        let data = vec![100u8, 150, 200, 50, 100, 150];
+        let buf = PixelBuffer::from_vec(data, 2, 1, PixelDescriptor::RGB8_SRGB).unwrap();
+        let allocated = buf.convert_to(PixelDescriptor::RGBA8_SRGB).unwrap();
+        let mut in_place = buf;
+        in_place
+            .convert_in_place(PixelDescriptor::RGBA8_SRGB)
+            .unwrap();
+        assert_eq!(in_place.descriptor(), PixelDescriptor::RGBA8_SRGB);
+        assert_eq!(in_place.as_slice().row(0), allocated.as_slice().row(0));
+    }
+
+    /// Same-size swizzle (RGBA8 -> BGRA8) rewrites in place, matches convert_to.
+    #[test]
+    fn convert_in_place_same_size_swizzle() {
+        let data = vec![10u8, 20, 30, 40, 50, 60, 70, 80];
+        let buf = PixelBuffer::from_vec(data, 2, 1, PixelDescriptor::RGBA8_SRGB).unwrap();
+        let allocated = buf.convert_to(PixelDescriptor::BGRA8_SRGB).unwrap();
+        let mut in_place = buf;
+        in_place
+            .convert_in_place(PixelDescriptor::BGRA8_SRGB)
+            .unwrap();
+        assert_eq!(in_place.descriptor(), PixelDescriptor::BGRA8_SRGB);
+        assert_eq!(in_place.as_slice().row(0), allocated.as_slice().row(0));
     }
 
     #[test]

--- a/zenpixels-convert/src/lib.rs
+++ b/zenpixels-convert/src/lib.rs
@@ -414,6 +414,13 @@ pub mod error;
 /// [`ConvertPlan::estimate`](crate::ConvertPlan::estimate), and
 /// [`ConvertPlan::estimate_in`](crate::ConvertPlan::estimate_in).
 ///
+/// **Experimental** — requires `features = ["estimation-experimental"]`.
+/// The goal is estimating a `decode → convert → encode` job end-to-end, but
+/// no scheduler consumes this yet, so neither the API shape nor the ±30 %
+/// accuracy contract has been validated against a real caller. Expect both
+/// to change; the gate keeps the surface revisable rather than frozen by a
+/// release. See `docs/ESTIMATE.md`.
+///
 /// These estimate types are defined locally here. `zenpixels-convert`
 /// is a foundation crate and does NOT depend on `zencodec` — the layering
 /// rule keeps codec abstractions strictly above pixel math. There is
@@ -422,8 +429,11 @@ pub mod error;
 /// `zencodec`'s `ResourceEstimate` additionally tracks `cpu_ms` and
 /// `peak_memory_bytes_max`, and its `ImageCharacteristics` tracks
 /// `frame_count`, none of which exist here). A `decode → convert → encode`
-/// pipeline bridging the two currently has to map fields by hand.
+/// pipeline bridging the two currently has to map fields by hand — closing
+/// that gap is the main thing the first consumer should force.
+#[cfg(feature = "estimation-experimental")]
 pub mod estimate;
+#[cfg(feature = "estimation-experimental")]
 pub use estimate::{ComputeEnvironment, ImageCharacteristics, ResourceEstimate, SimdTier};
 pub(crate) mod f16_scalar;
 pub(crate) mod negotiate;

--- a/zenpixels-convert/src/lib.rs
+++ b/zenpixels-convert/src/lib.rs
@@ -520,7 +520,7 @@ mod scan;
 pub use adapt::{adapt_for_encode_explicit, try_adapt_in_place};
 #[cfg(feature = "hdr-experimental")]
 pub use convert::HdrConfig;
-pub use convert::{ConvertPlan, convert_row, requires_cms};
+pub use convert::{ConvertPlan, convert_row};
 pub use converter::RowConverter;
 pub use error::ConvertError;
 pub use negotiate::{

--- a/zenpixels-convert/src/lib.rs
+++ b/zenpixels-convert/src/lib.rs
@@ -9,6 +9,13 @@
 //! All interchange types from `zenpixels` are re-exported at the crate root,
 //! so downstream code can depend on `zenpixels-convert` alone.
 //!
+//! # Examples
+//!
+//! A runnable, self-checking walk through the Decode → Negotiate → Convert →
+//! Encode lifecycle lives in
+//! [`examples/convert_pipeline.rs`](https://github.com/imazen/zenpixels/blob/main/zenpixels-convert/examples/convert_pipeline.rs)
+//! (`cargo run -p zenpixels-convert --example convert_pipeline`).
+//!
 //! # Core concepts
 //!
 //! - **Format negotiation**: [`best_match`] picks the cheapest conversion

--- a/zenpixels-convert/src/lib.rs
+++ b/zenpixels-convert/src/lib.rs
@@ -57,7 +57,7 @@
 //!
 //! 4. **Pixels and metadata travel together.** [`ColorContext`] rides on
 //!    [`PixelBuffer`] via `Arc` so ICC/CICP metadata follows pixel data
-//!    through the pipeline. [`finalize_for_output`] couples converted pixels
+//!    through the pipeline. [`finalize_for_output_with`] couples converted pixels
 //!    with matching encoder metadata atomically.
 //!
 //! 5. **Provenance enables lossless round-trips.** The cost model tracks
@@ -253,15 +253,19 @@
 //! The encoder receives pixel data in a format it natively supports and
 //! must embed correct color metadata.
 //!
-//! For the atomic path (recommended), use [`finalize_for_output`]:
+//! For the atomic path (recommended), use [`finalize_for_output_with`]. It does
+//! **color conversion + matching metadata, not format negotiation**: it takes a
+//! *single* target [`PixelFormat`] — the byte layout you already chose, typically
+//! the winner of [`best_match`] / [`adapt::adapt_for_encode`] (via
+//! `descriptor.pixel_format()`). Negotiate first, then finalize:
 //!
 //! ```rust,ignore
-//! let ready = finalize_for_output(
+//! let ready = finalize_for_output_with(
 //!     &buffer,
 //!     &color_origin,
 //!     OutputProfile::SameAsOrigin,
-//!     target_format,
-//!     &cms,
+//!     target_format,      // a single, already-negotiated PixelFormat
+//!     Some(&cms),         // Option<&dyn PluggableCms>; None for Named profiles
 //! )?;
 //!
 //! // Pixels and metadata are guaranteed to match
@@ -283,7 +287,7 @@
 //!   so negotiation will route f32 data directly to the encoder instead of
 //!   doing a redundant f32→u8 conversion first.
 //!
-//! - Use [`finalize_for_output`] to bundle pixels and metadata atomically.
+//! - Use [`finalize_for_output_with`] to bundle pixels and metadata atomically.
 //!   This prevents the most common color management bug: pixel values that
 //!   don't match the embedded ICC/CICP.
 //!
@@ -354,7 +358,7 @@
 //! Codecs that handle ICC profiles must:
 //! 1. Extract ICC bytes on decode and store them on [`ColorContext`].
 //! 2. Record provenance on [`ColorOrigin`].
-//! 3. On encode, let [`finalize_for_output`] handle the ICC transform
+//! 3. On encode, let [`finalize_for_output_with`] handle the ICC transform
 //!    (if the target profile differs from the source) or pass-through
 //!    (if `SameAsOrigin`).
 //!
@@ -385,7 +389,7 @@
 //! - [ ] Decode: record provenance → [`ColorOrigin`]
 //! - [ ] Encode: negotiate via [`best_match`] or [`adapt::adapt_for_encode`]
 //! - [ ] Encode: convert via [`RowConverter`] (not hand-rolled)
-//! - [ ] Encode: embed metadata via [`finalize_for_output`]
+//! - [ ] Encode: embed metadata via [`finalize_for_output_with`]
 //! - [ ] Encode: embed ICC/CICP when the format supports it
 //! - [ ] Handle [`ConvertError`] variants specifically
 //! - [ ] Test round-trip: native format → encode → decode = lossless

--- a/zenpixels-convert/src/load_bearing.rs
+++ b/zenpixels-convert/src/load_bearing.rs
@@ -191,10 +191,13 @@ pub trait PixelSliceLoadBearingExt: sealed::Sealed {
     /// available; `None` if the buffer is already at its load-bearing
     /// minimum, the predicates couldn't run, or allocation failed.
     ///
-    /// The returned [`PixelBuffer`] carries the narrowed descriptor and
-    /// the buffer's standard SIMD-aligned row stride (it is not
-    /// byte-tightly packed; use the buffer's own accessors or
-    /// [`PixelBuffer::as_slice`] downstream).
+    /// The returned [`PixelBuffer`] carries the narrowed descriptor and a
+    /// tightly-packed row stride (`width * bytes_per_pixel`) — it is allocated
+    /// with [`PixelBuffer::try_new`], and `PixelDescriptor::aligned_stride` is
+    /// packed despite its name (`simd_aligned_stride` is the padded one, and
+    /// nothing in these crates allocates with it). Use the buffer's own
+    /// accessors or [`PixelBuffer::as_slice`] downstream rather than assuming
+    /// either stride.
     fn try_reduce_to_load_bearing_format(&self) -> Option<PixelBuffer>;
 }
 

--- a/zenpixels-convert/tests/adapt.rs
+++ b/zenpixels-convert/tests/adapt.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)] // exercises the deprecated convert_buffer; it must keep working
 //! Tests for the adapt module (codec helper functions).
 
 use zenpixels_convert::PixelDescriptor;

--- a/zenpixels-convert/tests/adapt_extended.rs
+++ b/zenpixels-convert/tests/adapt_extended.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)] // exercises the deprecated convert_buffer; it must keep working
 //! Extended tests for adapt module — strided buffers, policy enforcement,
 //! and edge cases not covered by the basic adapt tests.
 

--- a/zenpixels-convert/tests/cmyk_cms_roundtrip.rs
+++ b/zenpixels-convert/tests/cmyk_cms_roundtrip.rs
@@ -10,7 +10,7 @@
 //!    CMYK ICC is supplied via `ColorProfileSource::Icc(...)`.
 //! 2. CMYK without an attached CMS surfaces as
 //!    `ConvertError::NeedsCms { from, to }` (typed error, not panic).
-//! 3. The `requires_cms` predicate is `pub` so schedulers can probe it.
+//! 3. `ConvertError::NeedsCms` is the public "needs a CMS" signal (the internal `requires_cms` predicate backs it).
 //! 4. RGB → RGB with `MoxCms` attached still uses the built-in plan.
 //!
 //! Test 3 (`lab_through_moxcms`) is intentionally omitted: there is no
@@ -39,9 +39,7 @@
 extern crate alloc;
 
 use zenpixels::buffer::PixelBuffer;
-use zenpixels_convert::{
-    ConvertError, ConvertOptions, PixelDescriptor, RowConverter, requires_cms,
-};
+use zenpixels_convert::{ConvertError, ConvertOptions, PixelDescriptor, RowConverter};
 
 #[cfg(feature = "cms-moxcms")]
 use zenpixels_convert::cms_moxcms::MoxCms;
@@ -70,12 +68,8 @@ fn cmyk_no_cms_returns_needs_cms_not_panic() {
 
 #[test]
 fn rgb_to_rgb_does_not_require_cms() {
-    // `requires_cms` is the predicate schedulers probe before deciding
-    // whether to attach a plugin. Native RGB→RGB must be `false`.
-    assert!(!requires_cms(
-        &PixelDescriptor::RGB8_SRGB,
-        &PixelDescriptor::RGB8_SRGB
-    ));
+    // The public "needs a CMS" signal is that a no-CMS entry point does NOT
+    // return `ConvertError::NeedsCms`; native RGB→RGB builds fine without one.
     let res = RowConverter::new(PixelDescriptor::RGB8_SRGB, PixelDescriptor::RGB8_SRGB);
     assert!(res.is_ok(), "RGB→RGB identity must succeed without CMS");
 }

--- a/zenpixels-convert/tests/resource_estimate.rs
+++ b/zenpixels-convert/tests/resource_estimate.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "estimation-experimental")]
+
 //! Tests for the `ResourceEstimate` returned by `ConvertPlan::estimate(_in)`.
 //! The estimate types live locally in `zenpixels_convert::estimate` and are
 //! shape-compatible with the corresponding `zencodec::estimate::*` types

--- a/zenpixels/examples/common_usage.rs
+++ b/zenpixels/examples/common_usage.rs
@@ -115,11 +115,11 @@ fn walk_strided_rows() {
         assert_eq!(slice.row(y).len(), 3 * 4);
     }
 
-    // For the common *packed* case, `new_tight` derives `width * bpp` for you —
+    // For the common *packed* case, `new_contiguous` derives `width * bpp` for you —
     // no hand-computed stride (the single most-repeated line across the ecosystem).
     let packed = vec![0u8; width as usize * rows as usize * 4];
-    let tight =
-        PixelSlice::new_tight(&packed, width, rows, PixelDescriptor::RGBA8).expect("packed buffer");
+    let tight = PixelSlice::new_contiguous(&packed, width, rows, PixelDescriptor::RGBA8)
+        .expect("packed buffer");
     assert_eq!(tight.stride(), width as usize * 4);
     assert!(tight.is_contiguous());
 }

--- a/zenpixels/examples/common_usage.rs
+++ b/zenpixels/examples/common_usage.rs
@@ -122,6 +122,14 @@ fn walk_strided_rows() {
         .expect("packed buffer");
     assert_eq!(tight.stride(), width as usize * 4);
     assert!(tight.is_contiguous());
+
+    // `new_packed` is an alias for `new_contiguous` — same result, and it
+    // upholds the same alignment invariant (every row aligned to the channel
+    // type, since it delegates to `new` rather than skipping validation).
+    let via_alias = PixelSlice::new_packed(&packed, width, rows, PixelDescriptor::RGBA8)
+        .expect("packed buffer");
+    assert_eq!(via_alias.stride(), tight.stride());
+    assert!(via_alias.is_contiguous());
 }
 
 /// BGRX -> RGBX is a pure channel swizzle: do it in place, no allocation.

--- a/zenpixels/examples/common_usage.rs
+++ b/zenpixels/examples/common_usage.rs
@@ -114,6 +114,14 @@ fn walk_strided_rows() {
         // `row` hands back exactly the pixel bytes — the 4 padding bytes are gone.
         assert_eq!(slice.row(y).len(), 3 * 4);
     }
+
+    // For the common *packed* case, `new_tight` derives `width * bpp` for you —
+    // no hand-computed stride (the single most-repeated line across the ecosystem).
+    let packed = vec![0u8; width as usize * rows as usize * 4];
+    let tight =
+        PixelSlice::new_tight(&packed, width, rows, PixelDescriptor::RGBA8).expect("packed buffer");
+    assert_eq!(tight.stride(), width as usize * 4);
+    assert!(tight.is_contiguous());
 }
 
 /// BGRX -> RGBX is a pure channel swizzle: do it in place, no allocation.
@@ -152,6 +160,10 @@ fn describe_color_with_cicp() {
     let srgb = Cicp::SRGB;
     assert_eq!(srgb.transfer_function_enum(), TransferFunction::Srgb);
 
+    // Unpack a 4-byte CICP tuple straight from a container box (primaries,
+    // transfer, matrix, full-range flag) — no `!= 0` papercut on the last byte.
+    assert_eq!(Cicp::from_bytes([1, 13, 0, 1]), Cicp::SRGB);
+
     // A descriptor's color axes round-trip through CICP.
     let desc = Cicp::DISPLAY_P3.to_descriptor(PixelFormat::Rgba8);
     assert_eq!(
@@ -159,6 +171,13 @@ fn describe_color_with_cicp() {
         zenpixels::descriptor::ColorPrimaries::DisplayP3
     );
     assert_eq!(Cicp::from_descriptor(&desc), Some(Cicp::DISPLAY_P3));
+
+    // Retag *only* the color axes of an existing descriptor from a decoded
+    // CICP, keeping the format/type/alpha. Contrast with `to_descriptor`, which
+    // builds a fresh descriptor from a `PixelFormat`.
+    let hdr = PixelDescriptor::RGBA8_SRGB.with_color_from_cicp(Cicp::BT2100_PQ);
+    assert_eq!(hdr.transfer(), TransferFunction::Pq);
+    assert_eq!(hdr.primaries, zenpixels::descriptor::ColorPrimaries::Bt2020);
 
     // Named profiles bridge friendly names and CICP codes.
     assert_eq!(NamedProfile::Srgb.to_cicp(), Some(Cicp::SRGB));

--- a/zenpixels/examples/common_usage.rs
+++ b/zenpixels/examples/common_usage.rs
@@ -1,0 +1,186 @@
+//! Common `zenpixels` usages, each self-checking.
+//!
+//! `zenpixels` is the *description* layer: it says what bytes are
+//! ([`PixelFormat`]), what they mean ([`PixelDescriptor`]), and where they live
+//! ([`PixelBuffer`] / [`PixelSlice`]). No conversion logic lives here — for that
+//! reach for `zenpixels-convert` (see its `common_usage` example).
+//!
+//! Run the whole gallery:      `cargo run -p zenpixels --example common_usage`
+//! Run it as tests:            `cargo test -p zenpixels --examples`
+//!
+//! [`PixelFormat`]: zenpixels::descriptor::PixelFormat
+//! [`PixelDescriptor`]: zenpixels::descriptor::PixelDescriptor
+//! [`PixelBuffer`]: zenpixels::buffer::PixelBuffer
+//! [`PixelSlice`]: zenpixels::buffer::PixelSlice
+
+use zenpixels::buffer::{Bgrx, PixelBuffer, PixelSlice, PixelSliceMut};
+use zenpixels::cicp::Cicp;
+use zenpixels::color::{ColorContext, NamedProfile};
+use zenpixels::descriptor::{PixelDescriptor, PixelFormat, TransferFunction};
+use zenpixels::orientation::Orientation;
+
+fn main() {
+    construct_owned_buffers();
+    read_and_write_pixels();
+    inspect_a_descriptor();
+    crop_a_region();
+    walk_strided_rows();
+    swap_bgrx_to_rgbx_in_place();
+    tag_color_metadata();
+    describe_color_with_cicp();
+    normalize_exif_orientation();
+    println!("all zenpixels examples passed");
+}
+
+/// Build owned, zero-filled, SIMD-aligned pixel storage — three ways.
+fn construct_owned_buffers() {
+    // Use a `*_SRGB` preset so the color metadata (transfer = sRGB,
+    // primaries = BT.709) travels with the pixels for free.
+    let img = PixelBuffer::new(4, 2, PixelDescriptor::RGBA8_SRGB);
+    assert_eq!((img.width(), img.height()), (4, 2));
+    assert_eq!(img.descriptor().bytes_per_pixel(), 4);
+    // stride is at least width * bytes-per-pixel; it may be padded for SIMD.
+    assert!(img.stride() >= 4 * 4);
+
+    // Wrap bytes you already have (e.g. straight from a decoder). The vec must
+    // be tightly packed: `width * height * bytes_per_pixel`.
+    let raw = vec![0u8; 4 * 2 * 3];
+    let img =
+        PixelBuffer::from_vec(raw, 4, 2, PixelDescriptor::RGB8_SRGB).expect("24 bytes == 4x2 RGB8");
+    assert!(!img.has_alpha());
+
+    // Untrusted dimensions? The fallible sibling returns an error instead of
+    // panicking on a huge allocation.
+    assert!(PixelBuffer::try_new(16, 16, PixelDescriptor::RGBA8).is_ok());
+}
+
+/// Read and write pixels through a mutable row view.
+fn read_and_write_pixels() {
+    let mut img = PixelBuffer::new(2, 1, PixelDescriptor::RGBA8_SRGB);
+    {
+        let mut view = img.as_slice_mut();
+        let row = view.row_mut(0);
+        row[0..4].copy_from_slice(&[255, 0, 0, 255]); // opaque red
+        row[4..8].copy_from_slice(&[0, 255, 0, 255]); // opaque green
+    }
+    let view = img.as_slice();
+    assert_eq!(&view.row(0)[0..4], &[255, 0, 0, 255]);
+    assert_eq!(&view.row(0)[4..8], &[0, 255, 0, 255]);
+}
+
+/// Ask a descriptor what the bytes are, without touching the pixels.
+fn inspect_a_descriptor() {
+    let rgba = PixelFormat::Rgba8.descriptor();
+    assert_eq!(rgba.channels(), 4);
+    assert_eq!(rgba.bytes_per_pixel(), 4);
+    assert!(rgba.has_alpha());
+    assert!(!rgba.is_grayscale());
+    assert!(!rgba.is_opaque()); // Rgba8's default alpha is Straight, not Opaque
+
+    // Grayscale, no alpha channel => opaque by construction.
+    assert!(PixelDescriptor::GRAY8.is_grayscale());
+    assert!(PixelDescriptor::GRAY8.is_opaque());
+
+    // Presets are just data — retag one axis with a `with_*` builder.
+    let linear = PixelDescriptor::RGB16_SRGB.with_transfer(TransferFunction::Linear);
+    assert_eq!(linear.transfer(), TransferFunction::Linear);
+    assert!(linear.is_linear());
+}
+
+/// Crop a rectangle — borrowed (no copy) or owned.
+fn crop_a_region() {
+    let img = PixelBuffer::new(8, 8, PixelDescriptor::RGBA8_SRGB);
+
+    // Borrow a sub-region: zero-copy, just an offset + the parent's stride.
+    let view = img.crop_view(2, 2, 4, 4);
+    assert_eq!((view.width(), view.rows()), (4, 4));
+
+    // Take an owned, tightly-packed copy of the same region.
+    let owned = img.crop_copy(2, 2, 4, 4);
+    assert_eq!((owned.width(), owned.height()), (4, 4));
+}
+
+/// Strided rows are first-class: every row API excludes the padding.
+fn walk_strided_rows() {
+    let (width, rows) = (3u32, 2u32);
+    let stride = 16usize; // 3*4 = 12 bytes of pixels + 4 bytes of padding per row
+    let bytes = vec![0u8; stride * rows as usize];
+
+    let slice = PixelSlice::new(&bytes, width, rows, stride, PixelDescriptor::RGBA8)
+        .expect("stride >= width * bpp");
+    assert_eq!(slice.stride(), 16);
+    assert!(!slice.is_contiguous());
+    for y in 0..slice.rows() {
+        // `row` hands back exactly the pixel bytes — the 4 padding bytes are gone.
+        assert_eq!(slice.row(y).len(), 3 * 4);
+    }
+}
+
+/// BGRX -> RGBX is a pure channel swizzle: do it in place, no allocation.
+fn swap_bgrx_to_rgbx_in_place() {
+    // One BGRX pixel: b=10, g=20, r=30, x=40.
+    let mut bytes = [10u8, 20, 30, 40];
+    let slice = PixelSliceMut::new(&mut bytes, 1, 1, 4, PixelDescriptor::BGRX8).unwrap();
+    let typed: PixelSliceMut<Bgrx> = slice.try_typed::<Bgrx>().expect("BGRX8 matches Bgrx");
+    // swap_to_rgbx rewrites the bytes in place, then hands back an RGBX view.
+    drop(typed.swap_to_rgbx());
+    // Now stored as r=30, g=20, b=10, x=40.
+    assert_eq!(bytes, [30, 20, 10, 40]);
+}
+
+/// Attach color metadata to a buffer with chained `with_*` builders.
+fn tag_color_metadata() {
+    // Start from a plain (untagged) RGBA8 buffer, then declare its color.
+    let img = PixelBuffer::new(2, 2, PixelDescriptor::RGBA8)
+        .with_primaries(zenpixels::descriptor::ColorPrimaries::DisplayP3)
+        .with_transfer(TransferFunction::Srgb);
+    assert_eq!(img.descriptor().transfer(), TransferFunction::Srgb);
+    assert_eq!(
+        img.descriptor().primaries,
+        zenpixels::descriptor::ColorPrimaries::DisplayP3
+    );
+
+    // Or carry a full ICC / CICP context, `Arc`-shared so clones are cheap.
+    let ctx = ColorContext::from_cicp(Cicp::DISPLAY_P3);
+    assert!(!ctx.is_srgb());
+    assert_eq!(ctx.transfer_function(), TransferFunction::Srgb);
+}
+
+/// `Cicp` is the compact ITU-T H.273 color signal; convert to/from descriptors.
+fn describe_color_with_cicp() {
+    // Named constants for the common signals.
+    let srgb = Cicp::SRGB;
+    assert_eq!(srgb.transfer_function_enum(), TransferFunction::Srgb);
+
+    // A descriptor's color axes round-trip through CICP.
+    let desc = Cicp::DISPLAY_P3.to_descriptor(PixelFormat::Rgba8);
+    assert_eq!(
+        desc.primaries,
+        zenpixels::descriptor::ColorPrimaries::DisplayP3
+    );
+    assert_eq!(Cicp::from_descriptor(&desc), Some(Cicp::DISPLAY_P3));
+
+    // Named profiles bridge friendly names and CICP codes.
+    assert_eq!(NamedProfile::Srgb.to_cicp(), Some(Cicp::SRGB));
+    assert_eq!(
+        NamedProfile::from_cicp(Cicp::BT2100_PQ),
+        Some(NamedProfile::Bt2020Pq)
+    );
+}
+
+/// Normalize an EXIF orientation tag to upright output dimensions.
+fn normalize_exif_orientation() {
+    // EXIF tag 6 = "rotate 90 CW": a 1920x1080 sensor frame displays as 1080x1920.
+    let orient = Orientation::from_exif(6).expect("valid EXIF orientation");
+    assert!(orient.swaps_axes());
+    assert_eq!(orient.output_dimensions(1920, 1080), (1080, 1920));
+
+    // Composing an orientation with its inverse is the identity.
+    assert_eq!(orient.then(orient.inverse()), Orientation::Identity);
+    assert!(Orientation::Identity.is_identity());
+}
+
+#[test]
+fn examples_run() {
+    main();
+}

--- a/zenpixels/src/buffer.rs
+++ b/zenpixels/src/buffer.rs
@@ -421,6 +421,28 @@ impl<'a> PixelSlice<'a> {
             descriptor,
         )
     }
+
+    /// Alias for [`new_contiguous`](Self::new_contiguous) — identical behavior.
+    ///
+    /// Provided because "packed" is the term many callers reach for;
+    /// `new_contiguous` is the canonical name (it pairs with
+    /// [`is_contiguous`](Self::is_contiguous)). Like `new_contiguous`, this
+    /// delegates to [`new`](Self::new) with **no unchecked fast path**, so the
+    /// [`PixelSlice`] alignment invariant callers rely on is upheld: a
+    /// base pointer misaligned for the channel type is rejected
+    /// ([`BufferError::AlignmentViolation`]), and the tight `width * bpp`
+    /// stride (always a multiple of the channel alignment) keeps every row
+    /// start aligned — so consumers may reinterpret any row as `&[u16]` /
+    /// `&[f32]` safely.
+    #[track_caller]
+    pub fn new_packed(
+        data: &'a [u8],
+        width: u32,
+        rows: u32,
+        descriptor: PixelDescriptor,
+    ) -> Result<Self, At<BufferError>> {
+        Self::new_contiguous(data, width, rows, descriptor)
+    }
 }
 
 impl<'a, P> PixelSlice<'a, P> {
@@ -954,6 +976,24 @@ impl<'a> PixelSliceMut<'a> {
             width as usize * descriptor.bytes_per_pixel(),
             descriptor,
         )
+    }
+
+    /// Alias for [`new_contiguous`](Self::new_contiguous) — identical behavior.
+    ///
+    /// The `&mut` counterpart to [`PixelSlice::new_packed`]. `new_contiguous`
+    /// is the canonical name (it pairs with
+    /// [`PixelSlice::is_contiguous`]); this delegates to
+    /// [`new`](Self::new) with **no unchecked fast path**, upholding the
+    /// alignment invariant — a base misaligned for the channel type is
+    /// rejected, and the tight `width * bpp` stride keeps every row aligned.
+    #[track_caller]
+    pub fn new_packed(
+        data: &'a mut [u8],
+        width: u32,
+        rows: u32,
+        descriptor: PixelDescriptor,
+    ) -> Result<Self, At<BufferError>> {
+        Self::new_contiguous(data, width, rows, descriptor)
     }
 }
 

--- a/zenpixels/src/buffer.rs
+++ b/zenpixels/src/buffer.rs
@@ -380,6 +380,45 @@ impl<'a> PixelSlice<'a> {
             _pixel: PhantomData,
         })
     }
+
+    /// Create a slice over **tightly-packed** rows, where the stride is exactly
+    /// `width * bytes_per_pixel` (no inter-row padding).
+    ///
+    /// A convenience over [`new`](Self::new) for the overwhelmingly common
+    /// packed case, so call sites stop restating `width * bpp` by hand.
+    /// Equivalent to
+    /// `PixelSlice::new(data, width, rows, width as usize * descriptor.bytes_per_pixel(), descriptor)`.
+    /// For strided views (SIMD-aligned padding, sub-region crops), use
+    /// [`new`](Self::new) with the explicit stride.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`new`](Self::new): errors if `data` is smaller than
+    /// `rows * width * bytes_per_pixel`, or is misaligned for the channel type.
+    ///
+    /// ```
+    /// use zenpixels::{PixelDescriptor, PixelSlice};
+    /// // 2x2 RGB8 = 12 tightly-packed bytes.
+    /// let data = [0u8; 12];
+    /// let ps = PixelSlice::new_tight(&data, 2, 2, PixelDescriptor::RGB8_SRGB)?;
+    /// assert_eq!(ps.stride(), 6); // 2 px * 3 bytes/px
+    /// # Ok::<(), zenpixels::At<zenpixels::BufferError>>(())
+    /// ```
+    #[track_caller]
+    pub fn new_tight(
+        data: &'a [u8],
+        width: u32,
+        rows: u32,
+        descriptor: PixelDescriptor,
+    ) -> Result<Self, At<BufferError>> {
+        Self::new(
+            data,
+            width,
+            rows,
+            width as usize * descriptor.bytes_per_pixel(),
+            descriptor,
+        )
+    }
 }
 
 impl<'a, P> PixelSlice<'a, P> {
@@ -878,6 +917,41 @@ impl<'a> PixelSliceMut<'a> {
             color: None,
             _pixel: PhantomData,
         })
+    }
+
+    /// Create a mutable slice over **tightly-packed** rows, where the stride is
+    /// exactly `width * bytes_per_pixel` (no inter-row padding).
+    ///
+    /// The `&mut` counterpart to [`PixelSlice::new_tight`]; a convenience over
+    /// [`new`](Self::new) for the packed case so call sites stop restating
+    /// `width * bpp`. For strided views, use [`new`](Self::new).
+    ///
+    /// # Errors
+    ///
+    /// Same as [`new`](Self::new): errors if `data` is smaller than
+    /// `rows * width * bytes_per_pixel`, or is misaligned for the channel type.
+    ///
+    /// ```
+    /// use zenpixels::{PixelDescriptor, PixelSliceMut};
+    /// let mut data = [0u8; 12]; // 2x2 RGB8, tightly packed
+    /// let ps = PixelSliceMut::new_tight(&mut data, 2, 2, PixelDescriptor::RGB8_SRGB)?;
+    /// assert_eq!(ps.stride(), 6);
+    /// # Ok::<(), zenpixels::At<zenpixels::BufferError>>(())
+    /// ```
+    #[track_caller]
+    pub fn new_tight(
+        data: &'a mut [u8],
+        width: u32,
+        rows: u32,
+        descriptor: PixelDescriptor,
+    ) -> Result<Self, At<BufferError>> {
+        Self::new(
+            data,
+            width,
+            rows,
+            width as usize * descriptor.bytes_per_pixel(),
+            descriptor,
+        )
     }
 }
 

--- a/zenpixels/src/buffer.rs
+++ b/zenpixels/src/buffer.rs
@@ -2009,10 +2009,18 @@ impl PixelBuffer {
 
     /// Consume the buffer and return the pixels as a typed `Vec<P>`.
     ///
+    /// **Allocation:** zero-copy **only** when `P` has alignment 1 (u8-component
+    /// types — `Rgb<u8>`, `Rgba<u8>`, `Gray<u8>`, `BGRA<u8>`) *and* the buffer
+    /// is tightly packed with no offset. For **any multi-byte `P`**
+    /// (`Rgb<u16>`, `Rgba<f32>`, …) this **copies the whole image** — the
+    /// backing `Vec<u8>` has alignment 1 and cannot be reinterpreted as a
+    /// `Vec` of a wider element, so the move-implied-by-`into_` does not hold
+    /// there. If you only need to read the pixels, prefer
+    /// [`as_contiguous_pixels`](Self::as_contiguous_pixels) (borrows, never
+    /// copies, `None` when it cannot).
+    ///
     /// Returns `None` if the descriptor is not layout-compatible with `P`.
-    /// Strips stride padding if present. Zero-copy when the buffer is
-    /// tightly packed and `P` has alignment 1 (u8-component types like
-    /// `Rgb<u8>`, `Rgba<u8>`); copies otherwise.
+    /// Strips stride padding if present.
     pub fn into_contiguous_pixels<P: Pixel>(self) -> Option<Vec<P>> {
         if !self.descriptor.layout_compatible(P::DESCRIPTOR) {
             return None;

--- a/zenpixels/src/buffer.rs
+++ b/zenpixels/src/buffer.rs
@@ -389,7 +389,8 @@ impl<'a> PixelSlice<'a> {
     /// Equivalent to
     /// `PixelSlice::new(data, width, rows, width as usize * descriptor.bytes_per_pixel(), descriptor)`.
     /// For strided views (SIMD-aligned padding, sub-region crops), use
-    /// [`new`](Self::new) with the explicit stride.
+    /// [`new`](Self::new) with the explicit stride. The resulting slice
+    /// satisfies [`is_contiguous`](Self::is_contiguous).
     ///
     /// # Errors
     ///
@@ -400,12 +401,13 @@ impl<'a> PixelSlice<'a> {
     /// use zenpixels::{PixelDescriptor, PixelSlice};
     /// // 2x2 RGB8 = 12 tightly-packed bytes.
     /// let data = [0u8; 12];
-    /// let ps = PixelSlice::new_tight(&data, 2, 2, PixelDescriptor::RGB8_SRGB)?;
+    /// let ps = PixelSlice::new_contiguous(&data, 2, 2, PixelDescriptor::RGB8_SRGB)?;
     /// assert_eq!(ps.stride(), 6); // 2 px * 3 bytes/px
+    /// assert!(ps.is_contiguous());
     /// # Ok::<(), zenpixels::At<zenpixels::BufferError>>(())
     /// ```
     #[track_caller]
-    pub fn new_tight(
+    pub fn new_contiguous(
         data: &'a [u8],
         width: u32,
         rows: u32,
@@ -922,7 +924,7 @@ impl<'a> PixelSliceMut<'a> {
     /// Create a mutable slice over **tightly-packed** rows, where the stride is
     /// exactly `width * bytes_per_pixel` (no inter-row padding).
     ///
-    /// The `&mut` counterpart to [`PixelSlice::new_tight`]; a convenience over
+    /// The `&mut` counterpart to [`PixelSlice::new_contiguous`]; a convenience over
     /// [`new`](Self::new) for the packed case so call sites stop restating
     /// `width * bpp`. For strided views, use [`new`](Self::new).
     ///
@@ -934,12 +936,12 @@ impl<'a> PixelSliceMut<'a> {
     /// ```
     /// use zenpixels::{PixelDescriptor, PixelSliceMut};
     /// let mut data = [0u8; 12]; // 2x2 RGB8, tightly packed
-    /// let ps = PixelSliceMut::new_tight(&mut data, 2, 2, PixelDescriptor::RGB8_SRGB)?;
+    /// let ps = PixelSliceMut::new_contiguous(&mut data, 2, 2, PixelDescriptor::RGB8_SRGB)?;
     /// assert_eq!(ps.stride(), 6);
     /// # Ok::<(), zenpixels::At<zenpixels::BufferError>>(())
     /// ```
     #[track_caller]
-    pub fn new_tight(
+    pub fn new_contiguous(
         data: &'a mut [u8],
         width: u32,
         rows: u32,

--- a/zenpixels/src/cicp.rs
+++ b/zenpixels/src/cicp.rs
@@ -52,6 +52,25 @@ impl Cicp {
         }
     }
 
+    /// Create a CICP description from a 4-byte code-point tuple, in ISO/IEC
+    /// 23091-2 / cICP-box order: `[color_primaries, transfer_characteristics,
+    /// matrix_coefficients, video_full_range_flag]`.
+    ///
+    /// The final byte is the full-range flag: `0` = narrow (studio) range,
+    /// non-zero = full range. This removes the `!= 0` papercut when unpacking
+    /// a parsed CICP tuple straight from a container box.
+    ///
+    /// ```
+    /// use zenpixels::Cicp;
+    /// // BT.709 primaries, sRGB transfer, Identity matrix, full range.
+    /// assert_eq!(Cicp::from_bytes([1, 13, 0, 1]), Cicp::SRGB);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn from_bytes(bytes: [u8; 4]) -> Self {
+        Self::new(bytes[0], bytes[1], bytes[2], bytes[3] != 0)
+    }
+
     /// sRGB color space: BT.709 primaries, sRGB transfer, Identity (RGB) matrix, full range.
     pub const SRGB: Self = Self {
         color_primaries: 1,

--- a/zenpixels/src/descriptor.rs
+++ b/zenpixels/src/descriptor.rs
@@ -1165,6 +1165,48 @@ impl PixelDescriptor {
         Self { primaries, ..self }
     }
 
+    /// Return a copy of this descriptor with its **transfer function and
+    /// color primaries** taken from a decoded [`Cicp`](crate::Cicp), leaving the pixel
+    /// format, channel type, alpha mode, and signal range unchanged.
+    ///
+    /// The "I decoded a CICP tag and want to retag my buffer descriptor's
+    /// color axes" path — folds the recurring
+    /// [`from_cicp`](TransferFunction::from_cicp)-then-[`with_transfer`](Self::with_transfer)
+    /// (+ the primaries pair) chain into one call. Only codes that map to a
+    /// known [`TransferFunction`] / [`ColorPrimaries`] are applied; unmapped
+    /// codes (e.g. `Unspecified` / reserved) leave that axis as-is.
+    ///
+    /// Distinct from [`Cicp::to_descriptor`](crate::Cicp::to_descriptor), which
+    /// *builds a fresh* descriptor from a [`PixelFormat`] rather than retagging
+    /// the color axes of one you already hold. Signal range is deliberately
+    /// left untouched — relabeling narrow↔full without rescaling pixels is a
+    /// footgun; convert instead.
+    ///
+    /// **Metadata-only** — like [`with_transfer`](Self::with_transfer) /
+    /// [`with_primaries`](Self::with_primaries), no pixel bytes change and no
+    /// gamut matrix is applied.
+    ///
+    /// ```
+    /// use zenpixels::{Cicp, ColorPrimaries, PixelDescriptor, TransferFunction};
+    /// // Decoded HDR10 CICP: BT.2020 primaries (9), PQ transfer (16).
+    /// let hdr = Cicp::new(9, 16, 0, true);
+    /// let d = PixelDescriptor::RGBA8_SRGB.with_color_from_cicp(hdr);
+    /// assert_eq!(d.primaries, ColorPrimaries::Bt2020);
+    /// assert_eq!(d.transfer(), TransferFunction::Pq);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn with_color_from_cicp(self, cicp: crate::Cicp) -> Self {
+        let mut d = self;
+        if let Some(tf) = TransferFunction::from_cicp(cicp.transfer_characteristics) {
+            d = d.with_transfer(tf);
+        }
+        if let Some(p) = ColorPrimaries::from_cicp(cicp.color_primaries) {
+            d = d.with_primaries(p);
+        }
+        d
+    }
+
     /// Return a copy of this descriptor **relabeled** with a different
     /// alpha mode. Does not touch any pixel bytes or apply (un)premultiply.
     ///

--- a/zenpixels/src/lib.rs
+++ b/zenpixels/src/lib.rs
@@ -8,6 +8,12 @@
 //! gamut mapping, and codec format negotiation, see
 //! [`zenpixels-convert`](https://docs.rs/zenpixels-convert).
 //!
+//! # Examples
+//!
+//! A runnable, self-checking gallery of the common usages lives in
+//! [`examples/common_usage.rs`](https://github.com/imazen/zenpixels/blob/main/zenpixels/examples/common_usage.rs)
+//! (`cargo run -p zenpixels --example common_usage`).
+//!
 //! # Core types
 //!
 //! - [`PixelFormat`] — flat enum of byte layouts (`Rgb8`, `Rgba16`, `OklabF32`, etc.)

--- a/zenpixels/src/lib.rs
+++ b/zenpixels/src/lib.rs
@@ -18,7 +18,9 @@
 //!
 //! - [`PixelFormat`] — flat enum of byte layouts (`Rgb8`, `Rgba16`, `OklabF32`, etc.)
 //! - [`PixelDescriptor`] — format + transfer function + primaries + alpha mode + signal range
-//! - [`PixelBuffer`] — owned pixel storage with SIMD-aligned allocation
+//! - [`PixelBuffer`] — owned pixel storage, tightly packed
+//!   (`width * bytes_per_pixel`); base aligned to the channel type. Opt into a
+//!   SIMD-padded row stride with [`PixelBuffer::new_simd_aligned`].
 //! - [`PixelSlice`] / [`PixelSliceMut`] — borrowed views with stride support
 //! - [`Pixel`] — trait mapping concrete types to their descriptor
 //! - [`Cicp`] — ITU-T H.273 color signaling codes


### PR DESCRIPTION
Stacked on #65 (base = `hdr-fixes-2026-07-14`) — **review #65 first**. This work was originally appended onto #65's HDR PR, which made that PR noisy; the two workstreams are now separate.

10 commits, in three reviewable groups.

## 1. New public API — the permanent commitments (`2e1a4fb`, `649e5f7`, `fefd0d7`)

Five additive helpers, each with a **verified downstream consumer count** from a `~/work/zen` audit, a doctest, and a gallery scenario. `cargo semver-checks`: **minor, no bump required**.

| Helper | Replaces | Consumers |
|---|---|---|
| `PixelSlice`/`PixelSliceMut::new_contiguous` (+ `new_packed` alias) | `let stride = w * bpp; PixelSlice::new(.., stride, ..)` | **~361 sites** |
| `Adapted::as_pixel_slice() -> Result<PixelSlice>` | recompute-stride + `PixelSlice::new` after `adapt_for_encode` | 5 (zenpipe#78) |
| `RowConverter::convert_slice(PixelSlice) -> PixelBuffer` | `alloc rows*stride; for y { convert_row }` | cvvdp, zenmetrics-gpu-core x2 |
| `PixelDescriptor::with_color_from_cicp(Cicp)` (`const fn`) | `from_cicp` -> `with_transfer` + `with_primaries` chain | zenpng, zenavif x2 |
| `Cicp::from_bytes([u8; 4])` (`const fn`) | `Cicp::new(c[0], c[1], c[2], c[3] != 0)` | ~161 `Cicp::new` sites |

`new_contiguous` is the canonical name (it pairs with the existing `is_contiguous()`); `new_packed` is an alias for callers who reach for "packed". Both delegate to `new`, so `validate_slice`'s base-alignment and `stride % bpp` checks always run — **no unchecked path**. Every row stays aligned to the channel type, so consumers may keep reinterpreting rows as `&[u16]` / `&[f32]`.

`as_pixel_slice` returns `Result`, not the infallible form first sketched: the zero-copy borrow path can hand back wide-channel bytes misaligned for a `PixelSlice`, so the alignment check stays.

## 2. Pre-release API-surface audit (`5e959de`)

Every public item added since the last crates.io release (**0.2.14**) was audited for a real consumer.

**Resource estimation is now behind `estimation-experimental` (default-off).** It had zero consumers, so neither its API shape nor its documented ±30% accuracy contract has been validated against a caller. Gated rather than deleted (the 2026-04-23 bench calibration is worth keeping) and rather than shipped (a release would freeze an unvalidated shape forever). Same pattern as `hdr-experimental`. CI **runs** the gated surface (`--features estimation-experimental --tests --examples`) rather than merely `check`ing it in the feature powerset.

**Result: zenpixels-convert's unshipped default surface drops from 55 to 17 lines** — and those 17 are only 4 real items (the three `ConvertError` variants the code returns, plus `as_pixel_slice` and `convert_slice`).

Kept after audit: the 11 `with_*` colour-tagging builders (cheap tag-only relabels), and `InPlacePixels::new` (the sole constructor for an already-shipped `#[non_exhaustive]` type).

## 3. Tested galleries + docs (`d672211`, `e2463f8`, `7a7614e`, `9df4db6`, `bc14c04`, `b101c4b`)

- Two runnable, self-checking example galleries (9 + 14 scenarios) that double as compile-tested documentation, plus a `cargo test --workspace --examples` CI step — `cargo test --workspace` builds example targets but never runs the `#[test]`s inside them.
- `docs/ergonomics-2026-07-14.md` — the downstream audit behind the helpers.
- **Doc fix:** the crate's own module docs recommended the **deprecated** `finalize_for_output` overload in six places, including the "atomic path (recommended)" example. They now point at `finalize_for_output_with`. This is plausibly why that live API went unadopted — the front door pointed at the deprecated one.

## Follow-ups filed

- imazen/zenpipe#78 — adopt the helpers in zencodecs (-47 lines / 9 sites, verified mechanical). **Blocked on this PR merging.**
- imazen/zenpipe#79 — adopt `try_reduce_to_load_bearing_format` (landed).
- imazen/zencodec#120 / #121 / #122 — quality-calibration authority, FormatSet truncation (landed), upstream candidates.
- imazen/zenpixels#64 — HDR->SDR fails open on default builds.
